### PR TITLE
fixes

### DIFF
--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -385,9 +385,16 @@ function GetArtifacts {
         [string] $mask = "*-Apps-*"
     )
 
+    $result = @()
+
+    $page = 1
     Write-Host "Analyzing artifacts"
-    $artifacts = Invoke-WebRequest -UseBasicParsing -Headers (GetHeader -token $token) -Uri "$api_url/repos/$repository/actions/artifacts" | ConvertFrom-Json
-    $artifacts.artifacts | Where-Object { $_.name -like $mask }
+    do {
+        $artifacts = Invoke-WebRequest -UseBasicParsing -Headers (GetHeader -token $token) -Uri "$api_url/repos/$repository/actions/artifacts?page=$page" | ConvertFrom-Json
+        $page++
+        $result += @($artifacts.artifacts | Where-Object { $_.name -like $mask })
+    } while ($artifacts.artifacts)
+    $result
 }
 
 function DownloadArtifact {

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -14,13 +14,25 @@ $telemetryScope = $null
 $bcContainerHelperPath = $null
 
 # IMPORTANT: No code that can fail should be outside the try/catch
-
+$buildMutexName = "AL-Go-ReadSecrets"
+$buildMutex = New-Object System.Threading.Mutex($false, $buildMutexName)
 try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
     $BcContainerHelperPath = DownloadAndImportBcContainerHelper -baseFolder $ENV:GITHUB_WORKSPACE
 
     import-module (Join-Path -path $PSScriptRoot -ChildPath "..\TelemetryHelper.psm1" -Resolve)
     $telemetryScope = CreateScope -eventId 'DO0078' -parentTelemetryScopeJson $parentTelemetryScopeJson
+
+    try {
+        if (!$buildMutex.WaitOne(1000)) {
+            Write-Host "Waiting for other process executing ReadSecrets"
+            $buildMutex.WaitOne() | Out-Null
+            Write-Host "Other process completed ReadSecrets"
+        }
+    }
+    catch [System.Threading.AbandonedMutexException] {
+       Write-Host "Other process terminated abnormally"
+    }
 
     Import-Module (Join-Path $PSScriptRoot ".\ReadSecretsHelper.psm1")
 
@@ -100,4 +112,5 @@ catch {
 }
 finally {
     CleanupAfterBcContainerHelper -bcContainerHelperPath $bcContainerHelperPath
+    $buildMutex.ReleaseMutex()
 }

--- a/Actions/ReadSecrets/ReadSecretsHelper.psm1
+++ b/Actions/ReadSecrets/ReadSecretsHelper.psm1
@@ -76,7 +76,7 @@ function InstallKeyVaultModuleIfNeeded {
     $AzKeyVaultModule = Get-InstalledModule -Name 'Az.KeyVault' -erroraction 'silentlycontinue'
     if ($AzKeyVaultModule) {
         Write-Host "Using Az.KeyVault version $($AzKeyVaultModule.Version)"
-        Import-Module  'Az.KeyVault' -DisableNameChecking -WarningAction SilentlyContinue | Out-Null
+        Import-Module  'Az.KeyVault' -DisableNameChecking -WarningAction SilentlyContinue
     }
     else {
         $azureRmKeyVaultModule = Get-Module -name 'AzureRm.KeyVault' -ListAvailable | Select-Object -First 1

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,10 +10,17 @@
 ### Update AL-Go System Files Workflow
 - workflow now displays the currently used template URL when selecting the Run Workflow action
 
-### CI/CD and Publish To New Environment
-- base functionality for selecting a specific GitHub runner for an environment
+### CI/CD workflow
 - Better detection of changed projects
 - appDependencyProbingPaths did not support multiple projects in the same repository for latestBuild dependencies
+- appDependencyProbingPaths with release=latestBuild only considered the last 30 artifacts
+- Use mutex around ReadSecrets to ensure that multiple agents on the same host doesn't clash
+
+### CI/CD and Publish To New Environment
+- base functionality for selecting a specific GitHub runner for an environment
+
+### localDevEnv.ps1 and cloudDevEnv.ps1
+- Display clear error message if something goes wrong
 
 ## v1.5
 

--- a/Templates/AppSource App/.AL-Go/cloudDevEnv.ps1
+++ b/Templates/AppSource App/.AL-Go/cloudDevEnv.ps1
@@ -90,6 +90,9 @@ CreateDevEnv `
     -reuseExistingEnvironment:$reuseExistingEnvironment `
     -baseFolder $baseFolder
 }
+catch {
+    Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"
+}
 finally {
     if ($fromVSCode) {
         Read-Host "Press ENTER to close this window"

--- a/Templates/AppSource App/.AL-Go/localDevEnv.ps1
+++ b/Templates/AppSource App/.AL-Go/localDevEnv.ps1
@@ -39,12 +39,19 @@ if ($pshost.Name -eq "Visual Studio Code Host") {
 }
 
 try {
-$ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient = New-Object System.Net.WebClient
 $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
 $webClient.Encoding = [System.Text.Encoding]::UTF8
+Write-Host "Downloading GitHub Helper module"
+$GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
+$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/main/Github-Helper.psm1', $GitHubHelperPath)
 Write-Host "Downloading AL-Go Helper script"
+$ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
+
+$GitHubHelperPath = "C:\src\github\freddydk\AL-Go-Actions\Github-Helper.psm1"
+$ALGoHelperPath = "C:\src\github\freddydk\AL-Go-Actions\AL-Go-Helper.ps1"
+Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local
 
 $baseFolder = Join-Path $PSScriptRoot ".." -Resolve
@@ -146,6 +153,9 @@ CreateDevEnv `
     -credential $credential `
     -LicenseFileUrl $licenseFileUrl `
     -InsiderSasToken $insiderSasToken
+}
+catch {
+    Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"
 }
 finally {
     if ($fromVSCode) {

--- a/Templates/Per Tenant Extension/.AL-Go/cloudDevEnv.ps1
+++ b/Templates/Per Tenant Extension/.AL-Go/cloudDevEnv.ps1
@@ -90,6 +90,9 @@ CreateDevEnv `
     -reuseExistingEnvironment:$reuseExistingEnvironment `
     -baseFolder $baseFolder
 }
+catch {
+    Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"
+}
 finally {
     if ($fromVSCode) {
         Read-Host "Press ENTER to close this window"

--- a/Templates/Per Tenant Extension/.AL-Go/localDevEnv.ps1
+++ b/Templates/Per Tenant Extension/.AL-Go/localDevEnv.ps1
@@ -39,12 +39,19 @@ if ($pshost.Name -eq "Visual Studio Code Host") {
 }
 
 try {
-$ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient = New-Object System.Net.WebClient
 $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
 $webClient.Encoding = [System.Text.Encoding]::UTF8
+Write-Host "Downloading GitHub Helper module"
+$GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
+$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/main/Github-Helper.psm1', $GitHubHelperPath)
 Write-Host "Downloading AL-Go Helper script"
+$ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
+
+$GitHubHelperPath = "C:\src\github\freddydk\AL-Go-Actions\Github-Helper.psm1"
+$ALGoHelperPath = "C:\src\github\freddydk\AL-Go-Actions\AL-Go-Helper.ps1"
+Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local
 
 $baseFolder = Join-Path $PSScriptRoot ".." -Resolve
@@ -146,6 +153,9 @@ CreateDevEnv `
     -credential $credential `
     -LicenseFileUrl $licenseFileUrl `
     -InsiderSasToken $insiderSasToken
+}
+catch {
+    Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"
 }
 finally {
     if ($fromVSCode) {


### PR DESCRIPTION
- appDependencyProbingPaths with release=latestBuild only considered the last 30 artifacts
- Use mutex around ReadSecrets to ensure that multiple agents on the same host doesn't clash
- Display clear error message if something goes wrong in localDevEnv.ps1 and cloudDevEnv.ps1
