### PR TITLE
PublishToAppsource doesn't work on github hosted runner.

### DIFF
--- a/Actions/Deliver/Deliver.ps1
+++ b/Actions/Deliver/Deliver.ps1
@@ -27,6 +27,11 @@ $bcContainerHelperPath = $null
 
 # IMPORTANT: No code that can fail should be outside the try/catch
 
+# Load the right module if on hosted runner.
+if(Test-Path -Path "C:\Modules\az_7.5.0") {
+    $env:PSModulePath += ';C:\Modules\az_7.5.0'
+}
+
 try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
     $BcContainerHelperPath = DownloadAndImportBcContainerHelper -baseFolder $ENV:GITHUB_WORKSPACE


### PR DESCRIPTION
> Error: Deliver action failed. Error: The term 'New-AzStorageContext' is not recognized as the name of a cmdlet, function, script file, or operable program.

This is the error I got when running "Publish To AppSource" Action. 

I've had the same issue in DevOps a few days ago. 
The issue is, the correct module is not in the path.

This PR adds the path from the following documentation to the PSModulePath. 

https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#azure-powershell-modules