### PR TITLE
Add updateBranch parameter to CheckForUpdates action

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -11,6 +11,8 @@ Param(
     [string] $templateBranch = "",
     [Parameter(HelpMessage = "Set this input to Y in order to update AL-Go System Files if needed", Mandatory = $false)]
     [bool] $update,
+    [Parameter(HelpMessage = "Set the branch to update", Mandatory = $false)]
+    [string] $updateBranch,
     [Parameter(HelpMessage = "Direct Commit (Y/N)", Mandatory = $false)]
     [bool] $directCommit    
 )
@@ -321,7 +323,7 @@ try {
                     }
                     else {
                         invoke-git push -u $url $branch
-                        invoke-gh pr create --fill --head $branch --repo $env:GITHUB_REPOSITORY --body "$releaseNotes"
+                        invoke-gh pr create --fill --head $branch --base $updateBranch --repo $env:GITHUB_REPOSITORY --body "$releaseNotes"
                     }
                 }
                 else {

--- a/Actions/CheckForUpdates/README.md
+++ b/Actions/CheckForUpdates/README.md
@@ -9,5 +9,7 @@ The GitHub token running the action
 Specifies the parent telemetry scope for the telemetry signal
 ### update (default N)
 Set this input to Y in order to update AL-Go System Files if needed
+### updateBranch (default github.ref_name)
+Set the branch to update. In case `directCommit` parameter is set to 'Y', then the branch the action is run on will be updated. 
 ### directCommit (default N)
 Direct Commit (Y/N)

--- a/Actions/CheckForUpdates/action.yaml
+++ b/Actions/CheckForUpdates/action.yaml
@@ -29,6 +29,10 @@ inputs:
     description: Set this input to Y in order to update AL-Go System Files if needed
     required: false
     default: 'N'
+  updateBranch:
+    description: Set the branch to update
+    required: false
+    default: ${{ github.ref_name }}
   directCommit:
     description: Direct Commit (Y/N)
     required: false
@@ -45,8 +49,9 @@ runs:
         _templateUrl: ${{ inputs.templateUrl }}
         _templateBranch: ${{ inputs.templateBranch }}
         _update: ${{ inputs.update }}
+        _updateBranch: ${{ inputs.updateBranch }}
         _directCommit: ${{ inputs.directCommit }}
-      run: try { ${{ github.action_path }}/CheckForUpdates.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -templateUrl $ENV:_templateUrl -templateBranch $ENV:_templateBranch -update ($ENV:_update -eq 'Y') -directCommit ($ENV:_directCommit -eq 'Y') } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
+      run: try { ${{ github.action_path }}/CheckForUpdates.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -templateUrl $ENV:_templateUrl -templateBranch $ENV:_templateBranch -update ($ENV:_update -eq 'Y') -updateBranch $ENV:_updateBranch -directCommit ($ENV:_directCommit -eq 'Y') } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal
   color: blue


### PR DESCRIPTION
Issue: Running the "Update AL-Go System Files" with `directCommit` set to 'Y' always creates a PR that targets the main branch insted of the branch the action was invoked on.

Solution: Add an `updateBranch` parameter to `CheckForUpdates` action and corresponding script to use as a target branch when creating a PR with the updates. By default, the `updateBranch` should be the branch the action is run on.