### PR TITLE
Pass the artifacts folders from all build modes to the custom deliver script

### DIFF
--- a/Actions/Deliver/Deliver.ps1
+++ b/Actions/Deliver/Deliver.ps1
@@ -151,9 +151,14 @@ try {
             Write-Host "- $($_.Name)"
         }
 
-        $customScript = Join-Path $ENV:GITHUB_WORKSPACE ".github\DeliverTo$deliveryTarget.ps1" 
+        # Check if there is a custom script to run for the delivery target
+        $customScript = Join-Path $ENV:GITHUB_WORKSPACE ".github\DeliverTo$deliveryTarget.ps1"
+
         if (Test-Path $customScript -PathType Leaf) {
+            Write-Host "Found custom script $customScript for delivery target $deliveryTarget"
+            
             $projectSettings = Get-Content -Path (Join-Path $ENV:GITHUB_WORKSPACE "$thisProject\.AL-Go\settings.json") | ConvertFrom-Json | ConvertTo-HashTable -Recurse
+            
             $parameters = @{
                 "Project" = $thisProject
                 "ProjectName" = $projectName
@@ -163,37 +168,42 @@ try {
                 "ProjectSettings" = $projectSettings
             }
 
-            $appsfolder = @(Get-ChildItem -Path (Join-Path $baseFolder "*-$refname-Apps-*.*.*.*") -Directory)
-            if ($appsFolder.Count -eq 0) {
-                throw "Internal error - unable to locate apps folder"
+            $projectToFilter = $project.Replace('\','_') # this is the project name as it appears in the artifact folder name
+            
+            #Calculate the folders per artifact type
+            'Apps', 'TestApps', 'Dependencies' | ForEach-Object {
+                $artifactType = $_
+                $singleArtifactFilter = "$projectToFilter-$refname-$artifactType-*.*.*.*";
+
+                # Get the folder hoding the artifacts from the standard build
+                $artifactFolder =  @(Get-ChildItem -Path (Join-Path $baseFolder $singleArtifactFilter) -Directory)
+
+                # Verify that there is an apps folder
+                if ($artifactFolder.Count -eq 0 -and $artifactType -eq "Apps") {
+                    throw "Internal error - unable to locate apps folder"
+                }
+
+                # Verify that there is only at most one artifact folder for the standard build
+                if ($artifactFolder.Count -gt 1) {
+                    $artifactFolder | Out-Host
+                    throw "Internal error - multiple $artifactType folders located"
+                }
+
+                # Add the artifact folder to the parameters
+                if ($artifactFolder.Count -ne 0) {
+                    $parameters[$artifactType.ToLower() + "Folder"] = $artifactFolder[0].FullName
+                }
+
+                # Get the folders holding the artifacts from all build modes
+                # Build modes are identified as a prefix to the artifact folder name
+                $artifactsFolders = @(Get-ChildItem -Path (Join-Path $baseFolder $("*" + $singleArtifactFilter)) -Directory)
+
+                if ($artifactsFolders.Count -gt 0) {
+                    $parameters[$artifactType.ToLower() + "Folders"] = $artifactsFolders.FullName
+                }
             }
-            if ($appsFolder.Count -gt 1) {
-                $appsFolder | Out-Host
-                throw "Internal error - multiple apps folders located"
-            }
-            $parameters.appsfolder = $appsfolder[0].FullName
-            $testAppsFolder = @(Get-ChildItem -Path (Join-Path $baseFolder "*-$refname-TestApps-*.*.*.*") -Directory)
-            if ($testAppsFolder.Count -gt 1) {
-                $testAppsFolder | Out-Host
-                throw "Internal error - multiple testApps folders located"
-            }
-            elseif ($testAppsFolder.Count -eq 1) {
-                $parameters.testAppsFolder = $testAppsFolder[0]
-            }
-            else {
-                $parameters.testAppsFolder = ""
-            }
-            $dependenciesFolder = @(Get-ChildItem -Path (Join-Path $baseFolder "*-$refname-Dependencies-*.*.*.*") -Directory)
-            if ($dependenciesFolder.Count -gt 1) {
-                $dependenciesFolder | Out-Host
-                throw "Internal error - multiple dependencies folders located"
-            }
-            elseif ($dependenciesFolder.Count -eq 1) {
-                $parameters.dependenciesFolder = $dependenciesFolder[0]
-            }
-            else {
-                $parameters.dependenciesFolder = ""
-            }
+            
+            Write-Host "Calling custom script: $customScript with parameters: $($parameters | ConvertTo-Json -Depth 1)"
             . $customScript -parameters $parameters
         }
         elseif ($deliveryTarget -eq "GitHubPackages") {


### PR DESCRIPTION
Pass the artifacts folders from all build modes to the custom deliver script.

`appFolder` — the folder that contains the apps from the "standard" build mode (a.k.a _Translated_). The folder name is in the format "<projectName>-<branch>-Apps-<version>"

`appFolders` — the folders that contains the apps from the the corresponding build mode (e.g. _CLEAN_). The folder names are in the format "<buildmode>-<projectName>-<branch>-Apps-<version>" for all build modes, but _Translated_
For _Translated_ the folder is the same as `appFolder`


The same logic applies for _TestApps_ and _Dependencies_.

This PR depends on:
https://github.com/microsoft/AL-Go/pull/321
