### PR TITLE
Buildmodulesseperately

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -629,7 +629,10 @@ function AnalyzeRepo {
             $appJsonFile = Join-Path $folder "app.json"
             $bcptSuiteFile = Join-Path $folder "bcptSuite.json"
             $enumerate = $true
-            if (-not (Test-Path $folder -PathType Container)) {
+
+            # Check if there are any folders matching $folder
+            # Test-Path $folder -PathType Container will return false if any files matches $folder (beside folders)
+            if (-not ((Test-Path $folder) -and (Get-ChildItem $folder -Directory))) {
                 if (!$doNotIssueWarnings) { OutputWarning -message "$descr $folderName, specified in $ALGoSettingsFile, does not exist" }
             }
             elseif (-not (Test-Path $appJsonFile -PathType Leaf)) {


### PR DESCRIPTION
AnalyzeRepo shows a false warning when a folder contains both folders and files.