### PR TITLE
Check pr

### DIFF
--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -482,7 +482,7 @@ jobs:
             $eventStr = Get-Content $ENV:GITHUB_EVENT_PATH -Encoding UTF8
             $eventStr | Out-Host
             $event = $eventStr | ConvertFrom-Json
-            $ref = "PR$($event.workflow_run.pull_requests[0].number)"
+            $ref = "PR$($event.workflow_run.id)"
           }
           else {
             $ref = "$ENV:GITHUB_REF_NAME".Replace('/','_')

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -480,7 +480,6 @@ jobs:
           $buildMode = '${{ matrix.buildMode }}'
           if ("$ENV:GITHUB_EVENT_NAME" -eq 'workflow_run') {
             $eventStr = Get-Content $ENV:GITHUB_EVENT_PATH -Encoding UTF8
-            $eventStr | Out-Host
             $event = $eventStr | ConvertFrom-Json
             $ref = "PR$($event.workflow_run.id)"
           }

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -482,7 +482,7 @@ jobs:
             $eventStr = Get-Content $ENV:GITHUB_EVENT_PATH -Encoding UTF8
             $eventStr | Out-Host
             $event = $eventStr | ConvertFrom-Json
-            $ref = "PR$($event.workflow_run.pull_requests[0].number)"
+            $ref = "PR$($event.workflow_run.id)"
           }
           else {
             $ref = "$ENV:GITHUB_REF_NAME".Replace('/','_')

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -480,7 +480,6 @@ jobs:
           $buildMode = '${{ matrix.buildMode }}'
           if ("$ENV:GITHUB_EVENT_NAME" -eq 'workflow_run') {
             $eventStr = Get-Content $ENV:GITHUB_EVENT_PATH -Encoding UTF8
-            $eventStr | Out-Host
             $event = $eventStr | ConvertFrom-Json
             $ref = "PR$($event.workflow_run.id)"
           }


### PR DESCRIPTION
CI/CD calculate artifact names fails if the Pull Request has been removed.
Use workflow_run.id instead as the only purpose of this is to have a repo-wide unique name for artifacts from a PR run.