### PR TITLE
Add AssignPremiumPlan when using LocalDevEnv

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1583,6 +1583,7 @@ function CreateDevEnv {
             }
         }
         
+        "assignPremiumPlan",
         "installTestRunner",
         "installTestFramework",
         "installTestLibraries",


### PR DESCRIPTION
The addition of AssignPremiumPlan was not affecting LocalDevEnv, but only the build pipelines