### PR TITLE
Verify origin of AL-GO actions in PR 

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,3 +20,13 @@ jobs:
       - name: Run Tests
         run: |
           . (Join-Path "." "Tests/runtests.ps1")
+  
+  TestALGOActionOrigins:
+    name: Test ALGO Action Origins
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Test AL-GO Action Origins
+        run: |
+          . (Join-Path "." "Tests/ActionOrigin.Test.ps1")

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,13 +20,8 @@ jobs:
       - name: Run Tests
         run: |
           . (Join-Path "." "Tests/runtests.ps1")
-  
-  TestALGOActionOrigins:
-    name: Test ALGO Action Origins
-    runs-on: [ ubuntu-latest ]
-    steps:
-      - uses: actions/checkout@v3
 
       - name: Test AL-GO Action Origins
+        if: github.repository_owner == 'microsoft'
         run: |
-          . (Join-Path "." "Tests/ActionOrigin.Test.ps1")
+          . (Join-Path "." "Tests/ActionOriginTest/ActionOrigin.Test.ps1")

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,7 +21,8 @@ jobs:
         run: |
           . (Join-Path "." "Tests/runtests.ps1")
   
-  Test AL-GO Action Origins:
+  TestALGOActionOrigins:
+    name: Test ALGO Action Origins
     runs-on: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,13 +20,3 @@ jobs:
       - name: Run Tests
         run: |
           . (Join-Path "." "Tests/runtests.ps1")
-  
-  TestALGOActionOrigins:
-    name: Test ALGO Action Origins
-    runs-on: [ ubuntu-latest ]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Test AL-GO Action Origins
-        run: |
-          . (Join-Path "." "Tests/ActionOrigin.Test.ps1")

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,6 +20,11 @@ jobs:
       - name: Run Tests
         run: |
           . (Join-Path "." "Tests/runtests.ps1")
+  
+  Test AL-GO Action Origins:
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v3
 
       - name: Test AL-GO Action Origins
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,3 +20,7 @@ jobs:
       - name: Run Tests
         run: |
           . (Join-Path "." "Tests/runtests.ps1")
+
+      - name: Test AL-GO Action Origins
+        run: |
+          . (Join-Path "." "Tests/ActionOrigin.Test.ps1")

--- a/Tests/ActionOrigin.Test.ps1
+++ b/Tests/ActionOrigin.Test.ps1
@@ -1,32 +1,6 @@
+Get-Module TestActionsHelper | Remove-Module -Force
+Import-Module (Join-Path $PSScriptRoot 'TestActionsHelper.psm1')
 
-
-function Test-ALGOActionsAreComingFromMicrosoft {
-    param(
-        [Parameter(Mandatory)]
-        [string]$YamlPath
-    )
-
-    $yaml = Get-Content -Path $YamlPath -Raw
-    $pattern = '\w*/AL-Go-Actions/'
-    $actions = [regex]::matches($yaml, $pattern)
-
-    $actions | ForEach-Object {
-        $action = $_.Value
-        $action | Should -BeLike "microsoft/AL-Go-Actions/"
-    }
-}
-
-function Test-AllWorkflowsInPath {
-    param(
-        [Parameter(Mandatory)]
-        [string]$Path
-    )
-
-    $workflows = Get-ChildItem -Path $Path -Filter "*.yaml" -Recurse
-    $workflows | ForEach-Object {
-        Test-ALGOActionsAreComingFromMicrosoft -YamlPath $_.FullName
-    }
-}
 
 Describe "All AL-GO Actions should be coming from the microsoft/AL-Go-Actions repository" {
 

--- a/Tests/ActionOrigin.Test.ps1
+++ b/Tests/ActionOrigin.Test.ps1
@@ -1,0 +1,42 @@
+
+
+function Test-ALGOActionsAreComingFromMicrosoft {
+    param(
+        [Parameter(Mandatory)]
+        [string]$YamlPath
+    )
+
+    $yaml = Get-Content -Path $YamlPath -Raw
+    $pattern = '\w*/AL-Go-Actions/'
+    $actions = [regex]::matches($yaml, $pattern)
+
+    $actions | ForEach-Object {
+        $action = $_.Value
+        $action | Should -BeLike "microsoft/AL-Go-Actions/"
+    }
+}
+
+function Test-AllWorkflowsInPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $workflows = Get-ChildItem -Path $Path -Filter "*.yaml" -Recurse
+    $workflows | ForEach-Object {
+        Test-ALGOActionsAreComingFromMicrosoft -YamlPath $_.FullName
+    }
+}
+
+Describe "All AL-GO Actions should be coming from the microsoft/AL-Go-Actions repository" {
+
+    It 'All PTE workflows are referencing the microsoft/AL-Go-Actions' {
+        $workflowsFolder = (Join-Path $PSScriptRoot "..\Templates\Per Tenant Extension\.github\workflows\" -Resolve)
+        Test-AllWorkflowsInPath -Path $workflowsFolder
+    }
+
+    It 'All AppSource workflows are referencing the microsoft/AL-Go-Actions' {
+        $workflowsFolder = (Join-Path $PSScriptRoot "..\Templates\AppSource App\.github\workflows\" -Resolve)
+        Test-AllWorkflowsInPath -Path $workflowsFolder
+    }
+}

--- a/Tests/ActionOrigin.Test.ps1
+++ b/Tests/ActionOrigin.Test.ps1
@@ -6,11 +6,11 @@ Describe "All AL-GO Actions should be coming from the microsoft/AL-Go-Actions re
 
     It 'All PTE workflows are referencing the microsoft/AL-Go-Actions' {
         $workflowsFolder = (Join-Path $PSScriptRoot "..\Templates\Per Tenant Extension\.github\workflows\" -Resolve)
-        Test-AllWorkflowsInPath -Path $workflowsFolder
+        TestAllWorkflowsInPath -Path $workflowsFolder
     }
 
     It 'All AppSource workflows are referencing the microsoft/AL-Go-Actions' {
         $workflowsFolder = (Join-Path $PSScriptRoot "..\Templates\AppSource App\.github\workflows\" -Resolve)
-        Test-AllWorkflowsInPath -Path $workflowsFolder
+        TestAllWorkflowsInPath -Path $workflowsFolder
     }
 }

--- a/Tests/ActionOriginTest/ActionOrigin.Test.ps1
+++ b/Tests/ActionOriginTest/ActionOrigin.Test.ps1
@@ -1,16 +1,16 @@
 Get-Module TestActionsHelper | Remove-Module -Force
-Import-Module (Join-Path $PSScriptRoot 'TestActionsHelper.psm1')
+Import-Module (Join-Path $PSScriptRoot '../TestActionsHelper.psm1')
 
 
 Describe "All AL-GO Actions should be coming from the microsoft/AL-Go-Actions repository" {
 
     It 'All PTE workflows are referencing the microsoft/AL-Go-Actions' {
-        $workflowsFolder = (Join-Path $PSScriptRoot "..\Templates\Per Tenant Extension\.github\workflows\" -Resolve)
+        $workflowsFolder = (Join-Path $PSScriptRoot "..\..\Templates\Per Tenant Extension\.github\workflows\" -Resolve)
         TestAllWorkflowsInPath -Path $workflowsFolder
     }
 
     It 'All AppSource workflows are referencing the microsoft/AL-Go-Actions' {
-        $workflowsFolder = (Join-Path $PSScriptRoot "..\Templates\AppSource App\.github\workflows\" -Resolve)
+        $workflowsFolder = (Join-Path $PSScriptRoot "..\..\Templates\AppSource App\.github\workflows\" -Resolve)
         TestAllWorkflowsInPath -Path $workflowsFolder
     }
 }

--- a/Tests/TestActionsHelper.psm1
+++ b/Tests/TestActionsHelper.psm1
@@ -147,12 +147,15 @@ function TestALGOActionsAreComingFromMicrosoft {
     )
 
     $yaml = Get-Content -Path $YamlPath -Raw
-    $pattern = '\w*/AL-Go-Actions/'
+    $pattern = '\w*/AL-Go-Actions/\w*@\w*'
     $actions = [regex]::matches($yaml, $pattern)
+
+    $mainAction = "microsoft/AL-Go-Actions/\w*@main"
+    $previewAction = "microsoft/AL-Go-Actions/\w*@preview"
 
     $actions | ForEach-Object {
         $action = $_.Value
-        $action | Should -BeLike "microsoft/AL-Go-Actions/"
+        $action | Should -Match "$mainAction|$previewAction"
     }
 }
 

--- a/Tests/TestActionsHelper.psm1
+++ b/Tests/TestActionsHelper.psm1
@@ -140,15 +140,19 @@ function YamlTest {
     $yamlLines.Count | Should -be $actualYaml.Count
 }
 
-function TestALGOActionsAreComingFromMicrosoft {
+function TestActionsAreComingFromALGoActions {
     param(
         [Parameter(Mandatory)]
         [string]$YamlPath
     )
 
     $yaml = Get-Content -Path $YamlPath -Raw
-    $pattern = '\w*/AL-Go-Actions/\w*@\w*'
-    $actions = [regex]::matches($yaml, $pattern)
+
+    # Test all AL-GO Actions are coming from microsoft/AL-Go-Actions@<main|preview>
+    $alGoActionsFromForksPattern = '\w*/AL-Go-Actions/\w*@\w*'
+    $alGoActionsFromALGORepo = '\w*/AL-Go/Actions/\w*@\w*'
+
+    $actions = [regex]::matches($yaml, "($alGoActionsFromForksPattern)|($alGoActionsFromALGORepo)")
 
     $mainAction = "microsoft/AL-Go-Actions/\w*@main"
     $previewAction = "microsoft/AL-Go-Actions/\w*@preview"
@@ -165,9 +169,9 @@ function TestAllWorkflowsInPath {
         [string]$Path
     )
 
-    $workflows = Get-ChildItem -Path $Path -Filter "*.yaml" -Recurse
+    $workflows = Get-ChildItem -Path $Path -File -Recurse -Include ('*.yaml', '*.yml')
     $workflows | ForEach-Object {
-        TestALGOActionsAreComingFromMicrosoft -YamlPath $_.FullName
+        TestActionsAreComingFromMicrosoftALGOActions -YamlPath $_.FullName
     }
 }
 

--- a/Tests/TestActionsHelper.psm1
+++ b/Tests/TestActionsHelper.psm1
@@ -140,5 +140,34 @@ function YamlTest {
     $yamlLines.Count | Should -be $actualYaml.Count
 }
 
+function TestALGOActionsAreComingFromMicrosoft {
+    param(
+        [Parameter(Mandatory)]
+        [string]$YamlPath
+    )
+
+    $yaml = Get-Content -Path $YamlPath -Raw
+    $pattern = '\w*/AL-Go-Actions/'
+    $actions = [regex]::matches($yaml, $pattern)
+
+    $actions | ForEach-Object {
+        $action = $_.Value
+        $action | Should -BeLike "microsoft/AL-Go-Actions/"
+    }
+}
+
+function TestAllWorkflowsInPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $workflows = Get-ChildItem -Path $Path -Filter "*.yaml" -Recurse
+    $workflows | ForEach-Object {
+        TestALGOActionsAreComingFromMicrosoft -YamlPath $_.FullName
+    }
+}
+
 Export-ModuleMember -Function GetActionScript
 Export-ModuleMember -Function YamlTest
+Export-ModuleMember -Function TestAllWorkflowsInPath


### PR DESCRIPTION
To make sure we don't accidently add references to forks of AL-GO-Actions, we should have a gate that checks for references to AL-GO-Actions. In this gate we should check if all workflows that are using AL-GO-Actions, are using them from microsoft/AL-GO-Actions