### PR TITLE
Use default run name for CICD workflows

### DIFF
--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -9,8 +9,6 @@ on:
       - '!.github/workflows/CICD.yaml'
     branches: [ 'main', 'release/*', 'feature/*' ]
 
-run-name: 'CI/CD: ${{github.event.head_commit.message}}'
-
 defaults:
   run:
     shell: powershell

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -9,8 +9,6 @@ on:
       - '!.github/workflows/CICD.yaml'
     branches: [ 'main', 'release/*', 'feature/*' ]
 
-run-name: 'CI/CD: ${{github.event.head_commit.message}}'
-
 defaults:
   run:
     shell: powershell


### PR DESCRIPTION
Use default run name for CICD workflows as Github already sets the run-name to the commit message if the action is triggered on push (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name) 