### PR TITLE
Enable concurrency groups in Pull Request Handler

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -270,7 +270,7 @@ try {
                                     # Example (depth 1):
                                     #    needs: [ Initialization ]
                                     #    if: needs.Initialization.outputs.projects1Count > 0
-                                    $if = "if: (!failure()) && needs.Initialization.outputs.projects$($_)Count > 0"
+                                    $if = "(!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0"
                                 }
                                 else {
                                     # Subsequent build jobs needs to have a dependency on all previous build jobs

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -208,7 +208,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: needs.Initialization.outputs.projectCount > 0
+    if: (!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -9,8 +9,6 @@ on:
       - '!.github/workflows/CICD.yaml'
     branches: [ 'main', 'release/*', 'feature/*' ]
 
-run-name: 'CI/CD: ${{github.event.head_commit.message}}'
-
 defaults:
   run:
     shell: powershell

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -9,6 +9,8 @@ on:
       - '!.github/workflows/CICD.yaml'
     branches: [ 'main', 'release/*', 'feature/*' ]
 
+run-name: 'CI/CD: ${{github.event.head_commit.message}}'
+
 defaults:
   run:
     shell: powershell

--- a/Templates/AppSource App/.github/workflows/Current.yaml
+++ b/Templates/AppSource App/.github/workflows/Current.yaml
@@ -88,7 +88,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
+    if: (!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/AppSource App/.github/workflows/NextMajor.yaml
+++ b/Templates/AppSource App/.github/workflows/NextMajor.yaml
@@ -88,7 +88,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
+    if: (!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/AppSource App/.github/workflows/NextMinor.yaml
+++ b/Templates/AppSource App/.github/workflows/NextMinor.yaml
@@ -88,7 +88,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
+    if: (!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -6,6 +6,10 @@ on:
       - '**.md'
     branches: [ 'main' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: powershell
@@ -38,7 +42,7 @@ jobs:
 
   Initialization:
     needs: [ PregateCheck ]
-    if: (!failure())
+    if: (!failure() && !cancelled())
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -114,7 +118,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: (!failure()) && needs.Initialization.outputs.projectCount > 0
+    if: (!cancelled() && !failure() && needs.Initialization.outputs.projectCount > 0)
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ 'main' ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 defaults:
@@ -118,7 +118,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: (!cancelled() && !failure() && needs.Initialization.outputs.projectCount > 0)
+    if: (!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -208,7 +208,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: needs.Initialization.outputs.projectCount > 0
+    if: (!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -9,8 +9,6 @@ on:
       - '!.github/workflows/CICD.yaml'
     branches: [ 'main', 'release/*', 'feature/*' ]
 
-run-name: 'CI/CD: ${{github.event.head_commit.message}}'
-
 defaults:
   run:
     shell: powershell

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -9,6 +9,8 @@ on:
       - '!.github/workflows/CICD.yaml'
     branches: [ 'main', 'release/*', 'feature/*' ]
 
+run-name: 'CI/CD: ${{github.event.head_commit.message}}'
+
 defaults:
   run:
     shell: powershell

--- a/Templates/Per Tenant Extension/.github/workflows/Current.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/Current.yaml
@@ -88,7 +88,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
+    if: (!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/Per Tenant Extension/.github/workflows/NextMajor.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/NextMajor.yaml
@@ -88,7 +88,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
+    if: (!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/Per Tenant Extension/.github/workflows/NextMinor.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/NextMinor.yaml
@@ -88,7 +88,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.projectCount > 0 }}
+    if: (!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -6,6 +6,10 @@ on:
       - '**.md'
     branches: [ 'main' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: powershell
@@ -38,7 +42,7 @@ jobs:
 
   Initialization:
     needs: [ PregateCheck ]
-    if: (!failure())
+    if: (!failure() && !cancelled())
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -114,7 +118,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: (!failure()) && needs.Initialization.outputs.projectCount > 0
+    if: (!cancelled() && !failure() && needs.Initialization.outputs.projectCount > 0)
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ 'main' ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 defaults:
@@ -118,7 +118,7 @@ jobs:
 
   Build:
     needs: [ Initialization ]
-    if: (!cancelled() && !failure() && needs.Initialization.outputs.projectCount > 0)
+    if: (!failure()) && (!cancelled()) && needs.Initialization.outputs.projectCount > 0
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:


### PR DESCRIPTION
Enable concurrency groups in Pull Request Handler. This way there's only one PR Build running at a time per PR, and if there's a new push to the PR while a PR Build is running, that PR build will be cancelled.