### PR TITLE
Use appFolders and testFolders to determine project dependencies

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -683,7 +683,7 @@ function AnalyzeRepo {
         }
     }
 
-    Write-Host "Checking appFolders and testFolders"
+    Write-Host "Checking appFolders, testFolders and bcptTestFolders"
     $dependencies = [ordered]@{}
     $appIdFolders = [ordered]@{}
     1..3 | ForEach-Object {
@@ -940,8 +940,6 @@ function AnalyzeRepo {
     }
 
     Write-Host "Checking project dependencies"
-
-
 
     Write-Host "Checking appDependencyProbingPaths"
     if ($settings.appDependencyProbingPaths) {
@@ -1787,9 +1785,12 @@ Function AnalyzeProjectDependencies {
         Write-Host "- $project"
 
         # Read project settings
-        $projectSettings = ReadSettings -baseFolder $baseFolder -project $project 
+        $projectSettings = ReadSettings -baseFolder $baseFolder -project $project
+
+        # Filter out app folders that doesn't contain an app.json file
         $folders = @($projectSettings.appFolders) + @($projectSettings.testFolders) + @($projectSettings.bcptTestFolders)| ForEach-Object { Resolve-Path (Join-Path $project $_) -Relative } | Where-Object { Test-Path (Join-Path $_ app.json)}
 
+        # Default to scanning the project folder if no app folders are specified
         if ($folders.Count -eq 0) {
             Write-Host "No apps or tests folders found for project $project. Scanning for apps in the project folder."
             $folders = @(Get-ChildItem -Path (Join-Path $baseFolder $project) -Recurse | Where-Object { $_.PSIsContainer -and (Test-Path (Join-Path $_.FullName 'app.json')) } | ForEach-Object { $_.FullName.Substring($baseFolder.Length+1) } )

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1788,10 +1788,10 @@ Function AnalyzeProjectDependencies {
         $projectSettings = ReadSettings -baseFolder $baseFolder -project $project
 
         # Filter out app folders that doesn't contain an app.json file
-        $folders = @($projectSettings.appFolders) + @($projectSettings.testFolders) + @($projectSettings.bcptTestFolders)| ForEach-Object { Resolve-Path (Join-Path $project $_) -Relative } | Where-Object { Test-Path (Join-Path $_ app.json)}
+        $folders = @($projectSettings.appFolders) + @($projectSettings.testFolders) + @($projectSettings.bcptTestFolders) | ForEach-Object { Resolve-Path (Join-Path $project $_) -Relative } | Where-Object { Test-Path (Join-Path $_ app.json)}
 
         # Default to scanning the project folder if no app folders are specified
-        if ($folders.Count -eq 0) {
+        if (-not $folders) {
             Write-Host "No apps or tests folders found for project $project. Scanning for apps in the project folder."
             $folders = @(Get-ChildItem -Path (Join-Path $baseFolder $project) -Recurse | Where-Object { $_.PSIsContainer -and (Test-Path (Join-Path $_.FullName 'app.json')) } | ForEach-Object { $_.FullName.Substring($baseFolder.Length+1) } )
         }

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1788,8 +1788,8 @@ Function AnalyzeProjectDependencies {
 
         # Read project settings
         $projectSettings = ReadSettings -baseFolder $baseFolder -project $project 
-        $folders = @($projectSettings.appFolders) + @($projectSettings.testFolders) | ForEach-Object { Resolve-Path (Join-Path $project $_) -Relative } | Where-Object { Test-Path (Join-Path $_ app.json)}
-        
+        $folders = @($projectSettings.appFolders) + @($projectSettings.testFolders) + @($projectSettings.bcptTestFolders)| ForEach-Object { Resolve-Path (Join-Path $project $_) -Relative } | Where-Object { Test-Path (Join-Path $_ app.json)}
+
         if ($folders.Count -eq 0) {
             Write-Host "No apps or tests folders found for project $project. Scanning for apps in the project folder."
             $folders = @(Get-ChildItem -Path (Join-Path $baseFolder $project) -Recurse | Where-Object { $_.PSIsContainer -and (Test-Path (Join-Path $_.FullName 'app.json')) } | ForEach-Object { $_.FullName.Substring($baseFolder.Length+1) } )

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1799,7 +1799,7 @@ Function AnalyzeProjectDependencies {
 
         $unknownDependencies = @()
         $apps = @()
-        Sort-AppFoldersByDependencies -appFolders $folders -baseFolder $baseFolder -WarningAction SilentlyContinue -unknownDependencies ([ref]$unknownDependencies) -knownApps ([ref]$apps)
+        Sort-AppFoldersByDependencies -appFolders $folders -baseFolder $baseFolder -WarningAction SilentlyContinue -unknownDependencies ([ref]$unknownDependencies) -knownApps ([ref]$apps) | Out-Null
         $appDependencies."$project" = @{
             "apps" = $apps
             "dependencies" = @($unknownDependencies | ForEach-Object { $_.Split(':')[0] })


### PR DESCRIPTION
When scanning for apps in an AL-Go project, the process should look into `appFolders` and `testFolders` (if defined).