### PR TITLE
Issue #385 Ensure case insensitivity

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1501,8 +1501,7 @@ function CreateDevEnv {
                 }
                 elseif ($kind -eq "cloud") {
                     $adminCenterApiCredentialsSecret = Get-AzKeyVaultSecret -VaultName $settings.keyVaultName -Name $settings.adminCenterApiCredentialsSecretName
-                    if ($adminCenterApiCredentialsSecret) { $adminCenterApiCredentials = $adminCenterApiCredentialsSecret.SecretValue | Get-PlainText | ConvertFrom-Json | 
-                    }
+                    if ($adminCenterApiCredentialsSecret) { $adminCenterApiCredentials = $adminCenterApiCredentialsSecret.SecretValue | Get-PlainText | ConvertFrom-Json | ConvertTo-HashTable }
                     $legalParameters = @("RefreshToken","CliendId","ClientSecret","deviceCode","tenantId")
                     $adminCenterApiCredentials.Keys | ForEach-Object {
                         if (-not ($legalParameters -contains $_)) {

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -612,6 +612,8 @@ function AnalyzeRepo {
         [string] $repository = $ENV:GITHUB_REPOSITORY
     )
 
+    $settings = $settings | ConvertTo-Json -Depth 99 | ConvertFrom-Json | ConvertTo-HashTable -recurse
+    
     if (!$runningLocal) {
         Write-Host "::group::Analyzing repository"
     }
@@ -1483,7 +1485,8 @@ function CreateDevEnv {
                 }
                 elseif ($kind -eq "cloud") {
                     $adminCenterApiCredentialsSecret = Get-AzKeyVaultSecret -VaultName $settings.keyVaultName -Name $settings.adminCenterApiCredentialsSecretName
-                    if ($adminCenterApiCredentialsSecret) { $adminCenterApiCredentials = $adminCenterApiCredentialsSecret.SecretValue | Get-PlainText | ConvertFrom-Json | ConvertTo-HashTable }
+                    if ($adminCenterApiCredentialsSecret) { $adminCenterApiCredentials = $adminCenterApiCredentialsSecret.SecretValue | Get-PlainText | ConvertFrom-Json | 
+                    }
                     $legalParameters = @("RefreshToken","CliendId","ClientSecret","deviceCode","tenantId")
                     $adminCenterApiCredentials.Keys | ForEach-Object {
                         if (-not ($legalParameters -contains $_)) {

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -66,6 +66,22 @@ else {
     $IsMacOS = $false
 }
 
+# Copy a HashTable to ensure non case sensitivity (Issue #385)
+function Copy-HashTable() {
+    [CmdletBinding()]
+    Param(
+        [parameter(ValueFromPipeline)]
+        [hashtable] $object
+    )
+    $ht = @{}
+    if ($object) {
+        $object.Keys | ForEach-Object { 
+            $ht[$_] = $object[$_]
+        }
+    }
+    $ht
+}
+
 function ConvertTo-HashTable() {
     [CmdletBinding()]
     Param(
@@ -612,7 +628,7 @@ function AnalyzeRepo {
         [string] $repository = $ENV:GITHUB_REPOSITORY
     )
 
-    $settings = $settings | ConvertTo-Json -Depth 99 | ConvertFrom-Json | ConvertTo-HashTable -recurse
+    $settings = $settings | Copy-HashTable
     
     if (!$runningLocal) {
         Write-Host "::group::Analyzing repository"


### PR DESCRIPTION
Due to what I see as an error in PowerShell, ordered dictionaries cast into a HashTable will become a case sensitive HashTable. This PR will copy the potentially wrong HashTable to ensure we have a case insensitive HashTable.
