### PR TITLE
Support override of InstallMissingDependencies

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -33,6 +33,7 @@ $runAlPipelineOverrides = @(
     "RunTestsInBcContainer"
     "GetBcContainerAppRuntimePackage"
     "RemoveBcContainer"
+    "InstallMissingDependencies"
 )
 
 # Well known AppIds

--- a/Scenarios/settings.md
+++ b/Scenarios/settings.md
@@ -181,6 +181,7 @@ This functionality is also available in AL-Go for GitHub, by adding a file to th
 | RunTestsInBcContainer.ps1 | Run the tests specified by the $parameters hashtable |
 | GetBcContainerAppRuntimePackage.ps1 | Get the runtime package specified by the $parameters hashtable |
 | RemoveBcContainer.ps1 | Cleanup based on the $parameters hashtable |
+| InstallMissingDependencies | Install missing dependencies |
 
 ## BcContainerHelper settings
 


### PR DESCRIPTION
This parameter was forgotten when creating the dependency resolution feature, and I have a partner who needs to override this