### PR TITLE
Apps without subfolders return false warnings

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -733,7 +733,7 @@ function AnalyzeRepo {
 
             # Check if there are any folders matching $folder
             # Test-Path $folder -PathType Container will return false if any files matches $folder (beside folders)
-            if (-not ((Test-Path $folder) -and (Get-ChildItem $folder -Directory))) {
+            if (-not ((Test-Path $folder) -and (Get-ChildItem $folder))) {
                 if (!$doNotIssueWarnings) { OutputWarning -message "$descr $folderName, specified in $ALGoSettingsFile, does not exist" }
             }
             elseif (-not (Test-Path $appJsonFile -PathType Leaf)) {


### PR DESCRIPTION
When an app folder doesn't have subfolder, we return a warning