### PR TITLE
Run PR Build based on merge commit 

### DIFF
--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.number }}/merge
 
       - uses: microsoft/AL-Go-Actions/VerifyPRChanges@main
         with:
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.number }}/merge
 
       - name: Initialize the workflow
         id: init
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.number }}/merge
     
       - name: Download thisbuild artifacts
         if: env.workflowDepth > 1
@@ -230,7 +230,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.number }}/merge
 
       - name: Finalize the workflow
         id: PostProcess

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -33,6 +33,9 @@ jobs:
         with:
           lfs: true
           ref: ${{ github.event.pull_request.head.sha }}
+      
+      - run: |
+          git pull --no-edit --no-rebase --no-ff origin ${{ github.event.pull_request.base.ref }}
 
       - uses: microsoft/AL-Go-Actions/VerifyPRChanges@main
         with:
@@ -58,6 +61,9 @@ jobs:
         with:
           lfs: true
           ref: ${{ github.event.pull_request.head.sha }}
+      
+      - run: |
+          git pull --no-edit --no-rebase --no-ff origin ${{ github.event.pull_request.base.sha }}
 
       - name: Initialize the workflow
         id: init
@@ -105,6 +111,9 @@ jobs:
         with:
           lfs: true
           ref: ${{ github.event.pull_request.head.sha }}
+      
+      - run: |
+          git pull --no-edit --no-rebase --no-ff origin ${{ github.event.pull_request.base.sha }}
     
       - name: Download thisbuild artifacts
         if: env.workflowDepth > 1
@@ -226,12 +235,6 @@ jobs:
     needs: [ Initialization, Build ]
     if: (!cancelled())
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Finalize the workflow
         id: PostProcess
         uses: microsoft/AL-Go-Actions/WorkflowPostProcess@main

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -32,10 +32,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
-      
-      - run: |
-          git pull --no-edit --no-rebase --no-ff origin ${{ github.event.pull_request.base.ref }}
+          ref: refs/pull/${{ github.event.number }}/merge
 
       - uses: microsoft/AL-Go-Actions/VerifyPRChanges@main
         with:
@@ -60,10 +57,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
-      
-      - run: |
-          git pull --no-edit --no-rebase --no-ff origin ${{ github.event.pull_request.base.sha }}
+          ref: refs/pull/${{ github.event.number }}/merge
 
       - name: Initialize the workflow
         id: init
@@ -110,10 +104,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha }}
-      
-      - run: |
-          git pull --no-edit --no-rebase --no-ff origin ${{ github.event.pull_request.base.sha }}
+          ref: refs/pull/${{ github.event.number }}/merge
     
       - name: Download thisbuild artifacts
         if: env.workflowDepth > 1
@@ -235,6 +226,12 @@ jobs:
     needs: [ Initialization, Build ]
     if: (!cancelled())
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          ref: refs/pull/${{ github.event.number }}/merge
+
       - name: Finalize the workflow
         id: PostProcess
         uses: microsoft/AL-Go-Actions/WorkflowPostProcess@main


### PR DESCRIPTION
Sometimes it can be an issue that the PR Build is not running with the latest changes from the base branch. This build https://github.com/microsoft/ALAppExtensions/actions/runs/4500507606 is complaining about breaking changes even though, the PR doesn't touch the SignedXml codeunit. The issue here is that the head branch doesn't contain all the latest changes from the base branch. 

A fix for this could be to use the merge branch created by GitHub since it contains the changes from both head and base branch. 