### PR TITLE
Fix licenseFileUrl = "none" param in localDevEnv 

### DIFF
--- a/Templates/AppSource App/.AL-Go/localDevEnv.ps1
+++ b/Templates/AppSource App/.AL-Go/localDevEnv.ps1
@@ -117,10 +117,10 @@ if (-not $licenseFileUrl) {
         -default $default `
         -doNotConvertToLower `
         -trimCharacters @('"',"'",' ')
+}
 
-    if ($licenseFileUrl -eq "none") {
-        $licenseFileUrl = ""
-    }
+if ($licenseFileUrl -eq "none") {
+    $licenseFileUrl = ""
 }
 
 CreateDevEnv `

--- a/Templates/Per Tenant Extension/.AL-Go/localDevEnv.ps1
+++ b/Templates/Per Tenant Extension/.AL-Go/localDevEnv.ps1
@@ -117,10 +117,10 @@ if (-not $licenseFileUrl) {
         -default $default `
         -doNotConvertToLower `
         -trimCharacters @('"',"'",' ')
+}
 
-    if ($licenseFileUrl -eq "none") {
-        $licenseFileUrl = ""
-    }
+if ($licenseFileUrl -eq "none") {
+    $licenseFileUrl = ""
 }
 
 CreateDevEnv `


### PR DESCRIPTION
Fix for localDevEnv.ps1, enabling the script execution with parameter licenseFileUrl = "none".