### PR TITLE
Issue #463

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1940,7 +1940,8 @@ function GetProject {
         [string] $projectALGoFolder
     )
 
-    $projectFolder = Join-Path $projectALGoFolder ".." -Resolve
+    $projectFolder = Join-Path $projectALGoFolder '..' -Resolve
+    $baseFolder = Join-Path $baseFolder '.' -Resolve
     if ($projectFolder -eq $baseFolder) {
         $project = '.'
     }


### PR DESCRIPTION
fix for issue #463

Reason for this bug is that $basefolder sometimes is with / instead of \ - i.e. the comparison returns false.
Using Join-Path to resolve the $basefolder path to the same format as the projectFolder.