### PR TITLE
#446: Wrong new line in Create Release

### DIFF
--- a/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
+++ b/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
@@ -24,7 +24,7 @@ try {
 
     import-module (Join-Path -path $PSScriptRoot -ChildPath "..\TelemetryHelper.psm1" -Resolve)
     $telemetryScope = CreateScope -eventId 'DO0074' -parentTelemetryScopeJson $parentTelemetryScopeJson
-    
+
     Import-Module (Join-Path $PSScriptRoot '..\Github-Helper.psm1' -Resolve)
 
     # Check that tag is SemVer
@@ -53,9 +53,9 @@ try {
         if ($latestRelease -and ([bool]($latestRelease.PSobject.Properties.name -match "tag_name"))){
             $latestReleaseTag = $latestRelease.tag_name
         }
-    
+
         $releaseNotes = GetReleaseNotes -token $token -api_url $ENV:GITHUB_API_URL -repository $ENV:GITHUB_REPOSITORY  -tag_name $tag_name -previous_tag_name $latestReleaseTag | ConvertFrom-Json
-        $releaseNotes = $releaseNotes.body -replace '%','%25' -replace '\n','%0A' -replace '\r','%0D' # supports a multiline text
+        $releaseNotes = $releaseNotes.body -replace '%','%25' # supports a multiline text
     }
     catch {
         OutputWarning -message "Couldn't create release notes.$([environment]::Newline)Error: $($_.Exception.Message)$([environment]::Newline)Stacktrace: $($_.scriptStackTrace)"


### PR DESCRIPTION
Updated creating release notes with wrong new line characters. From what I can see that /n and /r should not be replaced as they work to create line breaks via API.

When entering the release notes manually using markdown, two space characters will create the line break, but that seems to be limited to only the actual markdown editor and not the API or "creating from files".