### PR TITLE
Add sharedfolder when running CreateDevEnv

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1636,11 +1636,17 @@ function CreateDevEnv {
             if ($repo."$_") { $runAlPipelineParams += @{ "$_" = $true } }
         }
 
+        $sharedFolder = ""
+        if ($project) {
+            $sharedFolder = $baseFolder
+        }
+
         Run-AlPipeline @runAlPipelineParams `
             -pipelinename $workflowName `
             -imageName "" `
             -memoryLimit $repo.memoryLimit `
             -baseFolder $projectFolder `
+            -sharedFolder $sharedFolder `
             -licenseFile $licenseFileUrl `
             -installApps $installApps `
             -installTestApps $installTestApps `


### PR DESCRIPTION
Running localdevenv from ALAppExtensions right now is throwing the following error:

```
Error: The appProjectFolder (D:\a\_work\1\s\Modules\DevTools\TestFramework\TestStabilityTools\PreventMetadataUpdates) is not shared with the container.
Stacktrace: at Compile-AppInBcContainer, C:\Users\cloudtest\AppData\Local\Temp\485e71ec-f9de-495d-8bd2-d87b27f5977a\BcContainerHelper\AppHandling\Compile-AppInNavContainer.ps1: line 134
at <ScriptBlock>, D:\a\_work\1\s\Build\Scripts\CompileAppInBcContainer.ps1: line 32
at <ScriptBlock>, D:\a\_work\1\s\Test Stability Tools\.AL-Go\CompileAppInBcContainer.ps1: line 7
at <ScriptBlock>, C:\Users\cloudtest\AppData\Local\Temp\485e71ec-f9de-495d-8bd2-d87b27f5977a\BcContainerHelper\AppHandling\Run-AlPipeline.ps1: line 1753
at <ScriptBlock>, C:\Users\cloudtest\AppData\Local\Temp\485e71ec-f9de-495d-8bd2-d87b27f5977a\BcContainerHelper\AppHandling\Run-AlPipeline.ps1: line 1327
at <ScriptBlock>, C:\Users\cloudtest\AppData\Local\Temp\485e71ec-f9de-495d-8bd2-d87b27f5977a\BcContainerHelper\AppHandling\Run-AlPipeline.ps1: line 1320
at <ScriptBlock>, C:\Users\cloudtest\AppData\Local\Temp\485e71ec-f9de-495d-8bd2-d87b27f5977a\BcContainerHelper\AppHandling\Run-AlPipeline.ps1: line 826
at Run-AlPipeline, C:\Users\cloudtest\AppData\Local\Temp\485e71ec-f9de-495d-8bd2-d87b27f5977a\BcContainerHelper\AppHandling\Run-AlPipeline.ps1: line 788
at CreateDevEnv, C:\Users\cloudtest\AppData\Local\Temp\tmpA816.tmp.ps1: line 1638
at <ScriptBlock>, D:\a\_work\1\s\Test Stability Tools\.AL-Go\localDevEnv.ps1: line 126
at <ScriptBlock>, D:\a\_work\1\s\build.ps1: line 10
at <ScriptBlock>, <No file>: line 1
```

It seems like we share the folder that contains the Al-GO configuration with the container, but in our case we have the AL project in a separate folder. 

 The AL-GO project "Test Stability Tools" is building PreventMetadataUpdates. But in AlAppExtensions that AL project is in a different path:

_AlAppExtensions
 -> Test Stability Tools
      -> .AL-GO
 -> Modules\\DevTools\\TestFramework\\TestStabilityTools\\PreventMetadataUpdates_

As far as I can see, AlAppExtensions is not broken in GitHub because we add the basefolder as a shared folder in [RunPipeline](https://github.com/microsoft/AL-Go/blob/5a63a9cad71ecbaab935ff4cabc8ced8ff6e8a37/Actions/RunPipeline/RunPipeline.ps1#L61)