### PR TITLE
Issue #453

### DIFF
--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -47,7 +47,7 @@ try {
         }
     }
     [System.Collections.ArrayList]$secretsCollection = @()
-    $secrets.Split(',') | ForEach-Object {
+    $secrets.Split(',') | Select-Object -Unique | ForEach-Object {
         $secret = $_
         $secretNameProperty = "$($secret)SecretName"
         if ($settings.Keys -contains $secretNameProperty) {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,7 @@ Note that when using the preview version of AL-Go for GitHub, you need to Update
 
 ### Issues
 Issue #446 Wrong NewLine character in Release Notes
+Issue #453 DeliverToStorage - override fails reading secrets
 
 ### New Settings
 New Project Setting: `UseCompilerFolder`. Setting useCompilerFolder to true causes your pipelines to use containerless compiling. Unless you also set `doNotPublishApps` to true, setting useCompilerFolder to true won't give you any performance advantage, since AL-Go for GitHub will still need to create a container in order to publish and test the apps. In the future, publishing and testing will be split from building and there will be other options for getting an instance of Business Central for publishing and testing. 


### PR DESCRIPTION
Fix for Issue #453

When reading secrets, the list of secrets to get might contain duplicates, resolving in an exception.
This fix ensures that each secret is only read once.