### PR TITLE
Give warning when appFolders doesn't exist

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1766,8 +1766,18 @@ Function AnalyzeProjectDependencies {
         $projectSettings = ReadSettings -baseFolder $baseFolder -project $project
 
         # Filter out app folders that doesn't contain an app.json file
-        $folders = @($projectSettings.appFolders) + @($projectSettings.testFolders) + @($projectSettings.bcptTestFolders) | ForEach-Object { Resolve-Path (Join-Path $project $_) -Relative } | Where-Object { Test-Path (Join-Path $_ app.json)}
-
+        $folders = @($projectSettings.appFolders) + @($projectSettings.testFolders) + @($projectSettings.bcptTestFolders) | ForEach-Object { 
+            $projectFolder = Join-Path $project $_
+            if (!(Test-Path $projectFolder -PathType Container)) {
+                Write-Host "::Warning::Folder $_ doesn't exist, skipping."
+            }
+            elseif (!(Test-Path (Join-Path $projectFolder 'app.json'))) {
+                Write-Host "::Warning::Folder $_ doesn't contain an app.json file, skipping."
+            }
+            else {
+                Resolve-Path $projectFolder -Relative
+            }
+        }
         # Default to scanning the project folder if no app folders are specified
         if (-not $folders) {
             Write-Host "No apps or tests folders found for project $project. Scanning for apps in the project folder."

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -191,10 +191,7 @@ try {
     }
 
     $previousApps = @()
-    if ($repo.skipUpgrade) {
-        OutputWarning -message "Skipping upgrade tests"
-    }
-    else {
+    if (!$repo.skipUpgrade) {
         Write-Host "::group::Locating previous release"
         try {
             $latestRelease = GetLatestRelease -token $token -api_url $ENV:GITHUB_API_URL -repository $ENV:GITHUB_REPOSITORY -ref $ENV:GITHUB_REF_NAME


### PR DESCRIPTION
Non-existing appFolders or appFolders, which didn't contain an app.json should just be ignored, but display a warning.

Before this PR, appFolders which doesn't exist would give:
![image](https://user-images.githubusercontent.com/10775043/235285189-0a39a14e-5fc1-45fa-9225-57376c1bf105.png)

After this PR, appFolders which doesn't exists will be ignored and give:
![image](https://user-images.githubusercontent.com/10775043/235285228-e71a7151-f260-4d1a-a0e4-71d08c4e5c42.png)

Additionally, this warning has been removed:
![image](https://user-images.githubusercontent.com/10775043/235290229-7c616c94-3225-4d34-a21b-f860f12d7692.png)

No reason to warn about things people have decided.