### PR TITLE
UpdateSystemFiles fails in preview

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -88,13 +88,24 @@ function ConvertTo-HashTable() {
     [CmdletBinding()]
     Param(
         [parameter(ValueFromPipeline)]
-        [PSCustomObject] $object,
+        $object,
         [switch] $recurse
     )
+
     $ht = @{}
-    if ($object) {
-        $object.PSObject.Properties | ForEach-Object { 
-            if ($recurse -and ($_.Value -is [PSCustomObject])) {
+    if ($object -is [System.Collections.Specialized.OrderedDictionary] -or $object -is [hashtable]) {
+        $object.Keys | ForEach-Object {
+            if ($recurse -and ($object."$_" -is [System.Collections.Specialized.OrderedDictionary] -or $object."$_" -is [hashtable] -or $object."$_" -is [PSCustomObject])) {
+                $ht[$_] = ConvertTo-HashTable $object."$_"
+            }
+            else {
+                $ht[$_] = $object."$_"
+            }
+        }
+    }
+    elseif ($object -is [PSCustomObject]) {
+        $object.PSObject.Properties | ForEach-Object {
+            if ($recurse -and ($object."$_" -is [System.Collections.Specialized.OrderedDictionary] -or $object."$_" -is [hashtable] -or $_.Value -is [PSCustomObject])) {
                 $ht[$_.Name] = ConvertTo-HashTable $_.Value
             }
             else {

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -96,7 +96,7 @@ function ConvertTo-HashTable() {
     if ($object -is [System.Collections.Specialized.OrderedDictionary] -or $object -is [hashtable]) {
         $object.Keys | ForEach-Object {
             if ($recurse -and ($object."$_" -is [System.Collections.Specialized.OrderedDictionary] -or $object."$_" -is [hashtable] -or $object."$_" -is [PSCustomObject])) {
-                $ht[$_] = ConvertTo-HashTable $object."$_"
+                $ht[$_] = ConvertTo-HashTable $object."$_" -recurse
             }
             else {
                 $ht[$_] = $object."$_"

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -64,7 +64,7 @@ try {
     # if $update is set to false, CheckForUpdates will only check for updates and output a warning if there are updates available
 
     # Get Repo settings as a hashtable
-    $repoSettings = [hashtable](ReadSettings -project '' -workflowName '' -userName '' -branchName '')
+    $repoSettings = ReadSettings -project '' -workflowName '' -userName '' -branchName '' | ConvertTo-HashTable
     $unusedALGoSystemFiles = $repoSettings.unusedALGoSystemFiles
 
     # if UpdateSettings is true, we need to update the settings file with the new template url (i.e. there are changes to your AL-Go System files)


### PR DESCRIPTION
Fix for issue #497

After the latest change in Update AL-Go System Files to use ReadSettings instead of just reading the config file, the repoSettings now became a OrderedDictionary, which is case sensitive.

This PR changes the ConvertTo-HashTable to also be able to recursively convert a HashTable or an OrderedDictrionary to a new HashTable - and then use that in AL-Go System Files.

I will add a todo to see if we can make a test to test for case sensitivity in settings files.

This change shouldn't have any side effects, but running End-2-End tests now to ensure that I am right.