### PR TITLE
Only ask for authentication if the environment doesn't exist.

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -477,7 +477,7 @@ function ReadSettings {
         "installOnlyReferencedApps"              = $true
         "generateDependencyArtifact"             = $false
         "skipUpgrade"                            = $false
-        "applicationDependency"                  = "20.0.0.0"
+        "applicationDependency"                  = "18.0.0.0"
         "updateDependencies"                     = $false
         "installTestRunner"                      = $false
         "installTestFramework"                   = $false

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -477,7 +477,7 @@ function ReadSettings {
         "installOnlyReferencedApps"              = $true
         "generateDependencyArtifact"             = $false
         "skipUpgrade"                            = $false
-        "applicationDependency"                  = "18.0.0.0"
+        "applicationDependency"                  = "20.0.0.0"
         "updateDependencies"                     = $false
         "installTestRunner"                      = $false
         "installTestFramework"                   = $false

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -138,6 +138,9 @@ try {
     try {
         $authContextParams = $authContext | ConvertFrom-Json | ConvertTo-HashTable
         $bcAuthContext = New-BcAuthContext @authContextParams
+        if ($null -eq $bcAuthContext) {
+            throw "Authentication failed"
+        }
     } catch {
         throw "Authentication failed. $([environment]::Newline) $($_.exception.message)"
     }

--- a/Actions/ReadSettings/action.yaml
+++ b/Actions/ReadSettings/action.yaml
@@ -53,6 +53,9 @@ outputs:
   EnvironmentCount:
     description: Number of environments in array
     value: ${{ steps.readsettings.outputs.EnvironmentCount }}
+  UnknownEnvironment:
+    description: Determines whether we are publishing to an unknown environment
+    value: ${{ steps.readsettings.outputs.UnknownEnvironment }}
 runs:
   using: composite
   steps:

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -31,6 +31,7 @@ jobs:
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
       environments: ${{ steps.ReadSettings.outputs.EnvironmentsJson }}
       environmentCount: ${{ steps.ReadSettings.outputs.EnvironmentCount }}
+      unknownEnvironment: ${{ steps.ReadSettings.outputs.UnknownEnvironment }}
       deviceCode: ${{ steps.Authenticate.outputs.deviceCode }}
     steps:
       - name: Checkout
@@ -54,7 +55,7 @@ jobs:
 
       - name: EnvName
         id: envName
-        if: steps.ReadSettings.outputs.EnvironmentCount == 1
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
         run: |
           $ErrorActionPreference = "STOP"
           Set-StrictMode -version 2.0
@@ -63,7 +64,7 @@ jobs:
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: steps.ReadSettings.outputs.EnvironmentCount == 1
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -74,7 +75,7 @@ jobs:
 
       - name: Authenticate
         id: Authenticate
-        if: steps.ReadSettings.outputs.EnvironmentCount == 1
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
         run: |
           $envName = '${{ steps.envName.outputs.envName }}'
           $secretName = ''

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -31,6 +31,7 @@ jobs:
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
       environments: ${{ steps.ReadSettings.outputs.EnvironmentsJson }}
       environmentCount: ${{ steps.ReadSettings.outputs.EnvironmentCount }}
+      unknownEnvironment: ${{ steps.ReadSettings.outputs.UnknownEnvironment }}
       deviceCode: ${{ steps.Authenticate.outputs.deviceCode }}
     steps:
       - name: Checkout
@@ -54,7 +55,7 @@ jobs:
 
       - name: EnvName
         id: envName
-        if: steps.ReadSettings.outputs.EnvironmentCount == 1
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
         run: |
           $ErrorActionPreference = "STOP"
           Set-StrictMode -version 2.0
@@ -63,7 +64,7 @@ jobs:
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: steps.ReadSettings.outputs.EnvironmentCount == 1
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -74,7 +75,7 @@ jobs:
 
       - name: Authenticate
         id: Authenticate
-        if: steps.ReadSettings.outputs.EnvironmentCount == 1
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
         run: |
           $envName = '${{ steps.envName.outputs.envName }}'
           $secretName = ''

--- a/Tests/ReadSettings.Action.Test.ps1
+++ b/Tests/ReadSettings.Action.Test.ps1
@@ -23,6 +23,7 @@ Describe "ReadSettings Action Tests" {
             "GitHubRunnerShell" = "Shell for GitHubRunner jobs"
             "EnvironmentsJson" = "Environments in compressed Json format"
             "EnvironmentCount" = "Number of environments in array"
+            "UnknownEnvironment" = "Determines whether we are publishing to an unknown environment"
         }
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
     }


### PR DESCRIPTION
In the current preview bits, Publish to Environment will ask for authentication after the initialize step if you are requesting to deploy to a single environment, which is created in GitHub Environments and the AUTHCONTEXT secret is created under the environment as an environment secret.

The reason for this is, that this secret is NOT available during initialize and as such, we think we need to authenticate.

This fix causes us to only ask for authentication to unknown environments (which kind of was the entire idea)