### PR TITLE
Issue #508

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -105,7 +105,7 @@ function ConvertTo-HashTable() {
     }
     elseif ($object -is [PSCustomObject]) {
         $object.PSObject.Properties | ForEach-Object {
-            if ($recurse -and ($object."$_" -is [System.Collections.Specialized.OrderedDictionary] -or $object."$_" -is [hashtable] -or $_.Value -is [PSCustomObject])) {
+            if ($recurse -and ($_.Value -is [System.Collections.Specialized.OrderedDictionary] -or $_.Value -is [hashtable] -or $_.Value -is [PSCustomObject])) {
                 $ht[$_.Name] = ConvertTo-HashTable $_.Value -recurse
             }
             else {


### PR DESCRIPTION
Issue #508 is an error in ConvertTo-HashTable in BcContainerHelper, but the same function exists in AL-Go-Helper.ps1

$_ is an object containing various properties and not the name of the property - we should check for the type of $_.value