### PR TITLE
Issue #491 - Unable to get dependency releases during CI/CD pipeline

### DIFF
--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -76,7 +76,7 @@ function InvokeWebRequest {
             $response = $_.Exception.Response
             $responseUri = $response.ResponseUri.AbsoluteUri
             if ($response.StatusCode -eq 404 -and $responseUri -ne $uri) {
-                Write-Host "::Warning::Repository was moved, using this URL instead: $responseUri"
+                Write-Host "::Warning::Repository ($uri) was renamed or moved, please update your references with the new name. Trying $responseUri, as suggested by GitHub."
                 $result = Invoke-WebRequest @params -Uri $responseUri
             }
             else {

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -79,7 +79,7 @@ try {
                     }
                     $json.Keys | ForEach-Object {
                         if (@("Scopes","TenantId","BlobName","ContainerName","StorageAccountName") -notcontains $_) {
-                            # Mask individual values (but not Scopes and TenantId)
+                            # Mask individual values (but not Scopes, TenantId, BlobName, ContainerName and StorageAccountName)
                             MaskValue -key "$($secret).$($_)" -value $json."$_"
                         }
                     }

--- a/Actions/ReadSecrets/ReadSecretsHelper.psm1
+++ b/Actions/ReadSecrets/ReadSecretsHelper.psm1
@@ -58,9 +58,6 @@ function GetGithubSecret {
 }
 	
 function Get-KeyVaultCredentials {
-    Param(
-        [switch] $dontmask
-    )
     if ($script:isKeyvaultSet) {
         $jsonStr = $script:gitHuBSecrets.AZURE_CREDENTIALS
         if ($jsonStr -contains "`n" -or $jsonStr -contains "`r") {
@@ -70,6 +67,7 @@ function Get-KeyVaultCredentials {
             $creds = $jsonStr | ConvertFrom-Json
             # Mask ClientSecret
             MaskValue -key 'clientSecret' -value $creds.ClientSecret
+            # Check thet $creds contains the needed properties
             $creds.ClientId | Out-Null
             $creds.subscriptionId | Out-Null
             $creds.TenantId | Out-Null


### PR DESCRIPTION
This is a fix for issue #491

The reason for this is really that the target repository was renamed, but GitHub handles that in all other cases by redirecting you.
This fix will locate the artifacts needed in the new repository and issue a warning that the repository was renamed or moved.
This PR also relaxes the fields that get masked from StorageContext, as these strings might be reused elsewhere.
