### PR TITLE
Improve branch name when updating AL-Go system files

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -375,7 +375,7 @@ try {
                 # If $directCommit, then changes are made directly to the default branch
                 if (!$directcommit) {
                     # If not direct commit, create a new branch with name, relevant to the current date and base branch, and switch to it
-                    $branch = "$updateBranch/update-algo-system-files/$((Get-Date).ToUniversalTime().ToString(`"yyMMddHHmmss`"))" # e.g. main/update-algo-system-files/210101120000
+                    $branch = "$updateBranch/update-al-go-system-files/$((Get-Date).ToUniversalTime().ToString(`"yyMMddHHmmss`"))" # e.g. main/update-al-go-system-files/210101120000
                     invoke-git checkout -b $branch
                 }
 

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -374,7 +374,7 @@ try {
                 
                 # If $directCommit, then changes are made directly to the default branch
                 if (!$directcommit) {
-                    # If not direct commit, create a new branch with and switch to it
+                    # If not direct commit, create a new branch with name, relevant to the current date, and switch to it
                     $branch = "update-algo-system-files/$((Get-Date).ToUniversalTime().ToString(`"yyMMddHHmm`"))" # e.g. update-al-go-system-files/2101011200
                     invoke-git checkout -b $branch
                 }

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -374,8 +374,8 @@ try {
                 
                 # If $directCommit, then changes are made directly to the default branch
                 if (!$directcommit) {
-                    # If not direct commit, create a new branch with name, relevant to the current date, and switch to it
-                    $branch = "update-algo-system-files/$((Get-Date).ToUniversalTime().ToString(`"yyMMddHHmm`"))" # e.g. update-al-go-system-files/2101011200
+                    # If not direct commit, create a new branch with name, relevant to the current date and base branch, and switch to it
+                    $branch = "$updateBranch/update-algo-system-files/$((Get-Date).ToUniversalTime().ToString(`"yyMMddHHmm`"))" # e.g. main/update-al-go-system-files/2101011200
                     invoke-git checkout -b $branch
                 }
 

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -374,8 +374,8 @@ try {
                 
                 # If $directCommit, then changes are made directly to the default branch
                 if (!$directcommit) {
-                    # If not direct commit, create a new branch with a random name, and switch to it
-                    $branch = [System.IO.Path]::GetRandomFileName()
+                    # If not direct commit, create a new branch with and switch to it
+                    $branch = "update-algo-system-files/$((Get-Date).ToUniversalTime().ToString(`"yyMMddHHmm`"))" # e.g. update-al-go-system-files/2101011200
                     invoke-git checkout -b $branch
                 }
 

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -375,7 +375,7 @@ try {
                 # If $directCommit, then changes are made directly to the default branch
                 if (!$directcommit) {
                     # If not direct commit, create a new branch with name, relevant to the current date and base branch, and switch to it
-                    $branch = "$updateBranch/update-algo-system-files/$((Get-Date).ToUniversalTime().ToString(`"yyMMddHHmmss`"))" # e.g. main/update-algo-system-files/2101011200
+                    $branch = "$updateBranch/update-algo-system-files/$((Get-Date).ToUniversalTime().ToString(`"yyMMddHHmmss`"))" # e.g. main/update-algo-system-files/210101120000
                     invoke-git checkout -b $branch
                 }
 


### PR DESCRIPTION
Branch name is too random and creates a mess of branches (in the cases when they are not automatically deleted, when the corresponding PR is merged).

New branch name: `$updateBranch/update-al-go-system-files/$((Get-Date).ToUniversalTime().ToString("yyMMddHHmmss"))`
E.g.
`main/update-al-go-system-files/210101120000`
`releases/1.0/update-al-go-system-files/230508152112`
`my-feature-branch/update-al-go-system-files/220101131201`