### PR TITLE
Allow to override bcContainerHelper version

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -244,11 +244,15 @@ function DownloadAndImportBcContainerHelper {
         }
         if (Test-Path $repoSettingsPath) {
             $repoSettings = Get-Content $repoSettingsPath -Encoding UTF8 | ConvertFrom-Json | ConvertTo-HashTable
-            if ($bcContainerHelperVersion -eq "") {
+            if ($bcContainerHelperVersion -eq "" -or $bcContainerHelperVersion -eq "latest") {
                 if ($repoSettings.Keys -contains "BcContainerHelperVersion") {
                     $bcContainerHelperVersion = $repoSettings.BcContainerHelperVersion
+                    Write-Host "Using BcContainerHelper $bcContainerHelperVersion version"
                     if ($bcContainerHelperVersion -like "https://*") {
                         throw "Setting BcContainerHelperVersion to a URL is not allowed."
+                    }
+                    elseif ($bcContainerHelperVersion -ne "" -and $bcContainerHelperVersion -ne 'latest' -and $bcContainerHelperVersion -ne 'preview') {
+                        Write-Host "::Warning::Using a specific version of BcContainerHelper is not recommended and will lead to build failures in the future. Consider removing the setting."
                     }
                 }
             }


### PR DESCRIPTION
Fix for issue #513

Allow people to add a setting to use a different version of containerhelper.
Give a warning if they decide to use an older version.

Reason for this is that we has one case, where the latest version had a bug, and the partner could temporarily use an old version to get by.

This also allows people to always use preview (even in latest)
Using "4.0.16" looks like:
![image](https://github.com/microsoft/AL-Go/assets/10775043/68d6aab2-8267-4222-b73d-cfa26c937b71)

Using "preview" looks like:
![image](https://github.com/microsoft/AL-Go/assets/10775043/cd56f086-26c3-4682-8808-32631440267f)

No setting looks like:
![image](https://github.com/microsoft/AL-Go/assets/10775043/b8d71d7a-84a4-4770-8d0b-72cc4bf56168)

Latest might still get different versions from the CDN after a release (if we don't purge the CDN) - but that shouldn't matter
