### PR TITLE
wrong error message

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -689,7 +689,7 @@ function AnalyzeRepo {
         }
     }
     else {
-        throw "The type, specified in $RepoSettingsFile, must be either 'Per Tenant Extension' or 'AppSource App'. It is '$($settings.type)'."
+        throw "The type, specified in $RepoSettingsFile, must be either 'PTE' or 'AppSource App'. It is '$($settings.type)'."
     }
 
     if (-not (@($settings.appFolders)+@($settings.testFolders)+@($settings.bcptTestFolders))) {


### PR DESCRIPTION
Checks for PTE or AppSource App - and gives a wrong error message if the value wasn't one of these