### PR TITLE
Update CheckForUpdates.ps1

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -375,7 +375,7 @@ try {
                 # If $directCommit, then changes are made directly to the default branch
                 if (!$directcommit) {
                     # If not direct commit, create a new branch with name, relevant to the current date and base branch, and switch to it
-                    $branch = "$updateBranch/update-al-go-system-files/$((Get-Date).ToUniversalTime().ToString(`"yyMMddHHmmss`"))" # e.g. main/update-al-go-system-files/210101120000
+                    $branch = "$updateBranch-update-al-go-system-files-$((Get-Date).ToUniversalTime().ToString(`"yyMMddHHmmss`"))" # e.g. main-update-al-go-system-files-210101120000
                     invoke-git checkout -b $branch
                 }
 


### PR DESCRIPTION
Current implementation of branch name for update system files always fails:
![image](https://github.com/microsoft/AL-Go/assets/10775043/853ad6a7-cffd-4a2d-b9dc-41e83ef1002c)

Other combinations with / might do the same, so I suggest changing to -

![image](https://github.com/microsoft/AL-Go/assets/10775043/c140d956-a0d9-4398-8bbd-6825e58a64c0)
