### PR TITLE
ApplicationDependency is not calculated

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -648,8 +648,8 @@ function AnalyzeRepo {
     Param(
         [hashTable] $settings,
         $token,
-        [string] $baseFolder,
-        [string] $project,
+        [string] $baseFolder = $ENV:GITHUB_WORKSPACE,
+        [string] $project = '.',
         [string] $insiderSasToken,
         [switch] $doNotCheckArtifactSetting,
         [switch] $doNotIssueWarnings,

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
@@ -1,10 +1,12 @@
 Param(
+    [Parameter(HelpMessage = "Specifies the parent telemetry scope for the telemetry signal", Mandatory = $false)]
+    [string] $parentTelemetryScopeJson = '7b7d',
+    [Parameter(HelpMessage = "Project folder", Mandatory = $false)]
+    [string] $project = ".",
     [Parameter(HelpMessage = "Settings from repository in compressed Json format", Mandatory = $false)]
     [string] $settingsJson = '{"artifact":""}',
     [Parameter(HelpMessage = "Secrets from repository in compressed Json format", Mandatory = $false)]
-    [string] $secretsJson = '{"insiderSasToken":""}',
-    [Parameter(HelpMessage = "Specifies the parent telemetry scope for the telemetry signal", Mandatory = $false)]
-    [string] $parentTelemetryScopeJson = '7b7d'
+    [string] $secretsJson = '{"insiderSasToken":""}'
 )
 
 $ErrorActionPreference = "Stop"
@@ -26,6 +28,7 @@ try {
     $secrets = $secretsJson | ConvertFrom-Json | ConvertTo-HashTable
     $insiderSasToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.insiderSasToken))
     $projectSettings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
+    $projectSettings = AnalyzeRepo -settings $projectSettings -project $project -doNotCheckArtifactSetting -doNotIssueWarnings
     $artifactUrl = Determine-ArtifactUrl -projectSettings $projectSettings -insiderSasToken $insiderSasToken
     $projectSettings.artifact = $artifactUrl
     #endregion

--- a/Actions/DetermineArtifactUrl/action.yaml
+++ b/Actions/DetermineArtifactUrl/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: Specifies the parent telemetry scope for the telemetry signal
     required: false
     default: '7b7d'
+  project:
+    description: Project folder
+    required: false
+    default: '.'
   settingsJson:
     description: Settings from repository in compressed Json format
     required: false
@@ -29,10 +33,11 @@ runs:
       id: determineArtifactUrl
       env:
         _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+        _project: ${{ inputs.project }}
         _settingsJson: ${{ inputs.settingsJson }}
         _secretsJson: ${{ inputs.secretsJson }}
       run: try { 
-          ${{ github.action_path }}/DetermineArtifactUrl.Action.ps1 -parentTelemetryScopeJson $env:_parentTelemetryScopeJson -settingsJson $ENV:_settingsJson -secretsJson $ENV:_secretsJson
+          ${{ github.action_path }}/DetermineArtifactUrl.Action.ps1 -parentTelemetryScopeJson $env:_parentTelemetryScopeJson  -project $ENV:_project -settingsJson $ENV:_settingsJson -secretsJson $ENV:_secretsJson
         } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -221,6 +221,7 @@ jobs:
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
 

--- a/Templates/AppSource App/.github/workflows/Current.yaml
+++ b/Templates/AppSource App/.github/workflows/Current.yaml
@@ -104,6 +104,7 @@ jobs:
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
 

--- a/Templates/AppSource App/.github/workflows/NextMajor.yaml
+++ b/Templates/AppSource App/.github/workflows/NextMajor.yaml
@@ -104,6 +104,7 @@ jobs:
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
 

--- a/Templates/AppSource App/.github/workflows/NextMinor.yaml
+++ b/Templates/AppSource App/.github/workflows/NextMinor.yaml
@@ -104,6 +104,7 @@ jobs:
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
 

--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -135,6 +135,7 @@ jobs:
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
 

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -221,6 +221,7 @@ jobs:
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
 

--- a/Templates/Per Tenant Extension/.github/workflows/Current.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/Current.yaml
@@ -104,6 +104,7 @@ jobs:
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
 

--- a/Templates/Per Tenant Extension/.github/workflows/NextMajor.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/NextMajor.yaml
@@ -104,6 +104,7 @@ jobs:
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
 

--- a/Templates/Per Tenant Extension/.github/workflows/NextMinor.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/NextMinor.yaml
@@ -104,6 +104,7 @@ jobs:
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
 

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -135,6 +135,7 @@ jobs:
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          project: ${{ matrix.project }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
 


### PR DESCRIPTION
The new DetermineArtifactUrl action, doesn't determine the ApplicationDependency based on the apps in the project - instead it returns the default from the settings if UpdateDependencies is set to true.

When UpdateDependencies is set to true, it needs to find the first compatible artifact matching the app dependencies in the project.
