### PR TITLE
Create New App and other workflows ignores selected branch

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1109,7 +1109,6 @@ function CloneIntoNewFolder {
     invoke-git clone $serverUrl
 
     Set-Location *
-    Write-Host "Using branch $ENV:GITHUB_REF_NAME"
     invoke-git checkout $ENV:GITHUB_REF_NAME
 
     if ($branch) {
@@ -1130,7 +1129,6 @@ function CommitFromNewFolder {
     if ($commitMessage.Length -gt 250) {
         $commitMessage = "$($commitMessage.Substring(0,250))...)"
     }
-    Write-Host $commitMessage
     invoke-git commit --allow-empty -m "'$commitMessage'"
     if ($branch) {
         invoke-git push -u $serverUrl $branch

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1109,6 +1109,8 @@ function CloneIntoNewFolder {
     invoke-git clone $serverUrl
 
     Set-Location *
+    Write-Host "Using branch $ENV:GITHUB_REF_NAME"
+    invoke-git checkout $ENV:GITHUB_REF_NAME
 
     if ($branch) {
         invoke-git checkout -b $branch
@@ -1128,10 +1130,11 @@ function CommitFromNewFolder {
     if ($commitMessage.Length -gt 250) {
         $commitMessage = "$($commitMessage.Substring(0,250))...)"
     }
+    Write-Host $commitMessage
     invoke-git commit --allow-empty -m "'$commitMessage'"
     if ($branch) {
         invoke-git push -u $serverUrl $branch
-        invoke-gh pr create --fill --head $branch --repo $env:GITHUB_REPOSITORY
+        invoke-gh pr create --fill --head $branch --repo $env:GITHUB_REPOSITORY --base $ENV:GITHUB_REF_NAME
     }
     else {
         invoke-git push $serverUrl

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,18 +3,37 @@
 Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.
 
 ### Issues
+
 Issue #446 Wrong NewLine character in Release Notes
 Issue #453 DeliverToStorage - override fails reading secrets
 Issue #434 Use gh auth token to get authentication token instead of gh auth status
 Issue #501 The Create New App action will now use 22.0.0.0 as default application reference and include NoImplicitwith feature.
+
+
+### New behavior
+
+The following workflows:
+
+- Create New App
+- Create New Test App
+- Create New Performance Test App
+- Increment Version Number
+- Add Existing App
+- Create Online Development Environment
+
+All these actions now uses the selected branch in the **Run workflow** dialog as the target for the Pull Request or Direct COMMIT.
+
 ### New Settings
+
 - `UseCompilerFolder`: Setting useCompilerFolder to true causes your pipelines to use containerless compiling. Unless you also set `doNotPublishApps` to true, setting useCompilerFolder to true won't give you any performance advantage, since AL-Go for GitHub will still need to create a container in order to publish and test the apps. In the future, publishing and testing will be split from building and there will be other options for getting an instance of Business Central for publishing and testing. 
 - `vsixFile`: vsixFile should be a direct download URL to the version of the AL Language extension you want to use for building the project or repo. By default, AL-Go will use the AL Language extension that comes with the Business Central Artifacts.
 
 ### New Actions
+
 - **DetermineArtifactUrl** is used to determine which artifacts to use for building a project in CI/CD, PullRequestHandler, Current, NextMinor and NextMajor workflows.
 
 ### License File
+
 With the changes to the CRONUS license in Business Central version 22, that license can in most cases be used as a developer license for AppSource Apps and it is no longer mandatory to specify a license file in AppSource App repositories.
 Obviously, if you build and test your app for Business Central versions prior to 21, it will fail if you don't specify a licenseFileUrl secret.
 

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -1,5 +1,7 @@
 name: 'Add existing app or test app'
 
+run-name: "Add existing app or test app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -1,5 +1,7 @@
 name: 'Create a new app'
 
+run-name: "Create a new app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -1,5 +1,7 @@
 name: ' Create Online Dev. Environment'
 
+run-name: "Create Online Dev. Environment for [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -1,5 +1,7 @@
 name: 'Create a new performance test app'
 
+run-name: "Create a new performance test app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -1,5 +1,7 @@
 name: 'Create a new test app'
 
+run-name: "Create a new test app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -1,5 +1,7 @@
 name: ' Increment Version Number'
 
+run-name: "Increment Version Number in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -1,5 +1,7 @@
 name: 'Add existing app or test app'
 
+run-name: "Add existing app or test app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -1,5 +1,7 @@
 name: 'Create a new app'
 
+run-name: "Create a new app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -1,5 +1,7 @@
 name: ' Create Online Dev. Environment'
 
+run-name: "Create Online Dev. Environment for [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -1,5 +1,7 @@
 name: 'Create a new performance test app'
 
+run-name: "Create a new performance test app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -1,5 +1,7 @@
 name: 'Create a new test app'
 
+run-name: "Create a new test app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -1,5 +1,7 @@
 name: ' Increment Version Number'
 
+run-name: "Increment Version Number in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
The following workflows:
- Create New App
- Create New Test App
- Create New Performance Test App
- Increment Version Number
- Add Existing App
- Create Online Development Environment

All uses the Direct COMMIT pattern.
This pattern ignores the branch selected in the run workflow - and always targets main (actually the code runs from the branch selected, targetting main)

This PR fixes this and creates a direct commit or a PR against the selected branch.
It also adds the target branch to the title of the workflow (run_name)
It looks like:
![image](https://github.com/microsoft/AL-Go/assets/10775043/c8f4e621-71a4-4b63-b215-889efeffca08)



leading to:



![image](https://github.com/microsoft/AL-Go/assets/10775043/24a887ae-deda-4d3b-afec-571bdc0b368e)



and:



![image](https://github.com/microsoft/AL-Go/assets/10775043/00ca3698-98a1-4dbe-8b7d-61e5468c613e)

