### PR TITLE
Issue #542

### DIFF
--- a/Actions/AddExistingApp/AddExistingApp.ps1
+++ b/Actions/AddExistingApp/AddExistingApp.ps1
@@ -225,7 +225,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    OutputError -message "AddExistingApp acion failed.$([environment]::Newline)Error: $($_.Exception.Message)$([environment]::Newline)Stacktrace: $($_.scriptStackTrace)"
+    OutputError -message "AddExistingApp action failed.$([environment]::Newline)Error: $($_.Exception.Message)$([environment]::Newline)Stacktrace: $($_.scriptStackTrace)"
     TrackException -telemetryScope $telemetryScope -errorRecord $_
 }
 finally {

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -165,7 +165,7 @@ try {
             }
             else {
                 Write-Host "Publishing apps using development endpoint"
-                Publish-BcContainerApp -bcAuthContext $bcAuthContext -environment $envName -appFile $apps -useDevEndpoint -checkAlreadyInstalled
+                Publish-BcContainerApp -bcAuthContext $bcAuthContext -environment $envName -appFile $apps -useDevEndpoint -checkAlreadyInstalled -excludeRuntimePackages
             }
         }
         else {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,10 @@
 
 Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.
 
+### Issues
+
+Issue 542 Deploy Workflow fails
+
 ## v3.1
 
 ### Issues


### PR DESCRIPTION
When deploying to online environments in deploy.ps1, it should exclude runtime packages as these cannot be deployed to online environments.

Also fixing a small spelling mistake.