### PR TITLE
Devprocess

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -326,8 +326,8 @@ try {
                     $originalBranch = "main"
                     $templateRepos = @{
                         "actionsRepo" = "AL-Go/Actions"
-                        "perTenantExtensionRepo" = "AL-Go-PTExxxxx"
-                        "appSourceAppRepo" = "AL-Go-AppSourcexxxxxx"
+                        "perTenantExtensionRepo" = "AL-Go"
+                        "appSourceAppRepo" = "AL-Go"
                     }
                     "actionsRepo","perTenantExtensionRepo","appSourceAppRepo" | ForEach-Object {
                         $regex = "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -57,7 +57,12 @@ try {
     }
 
     # DirectALGo is used to determine if the template is a direct link to an AL-Go repository
-    $directALGo = $templateUrl.ToLowerInvariant().contains("/al-go@")
+    $directALGo = $templateUrl -like 'https://github.com/*/AL-Go@*'
+    if ($directALGo) {
+        if ($templateUrl -like 'https://github.com/microsoft/AL-Go@*') {
+            throw "You cannot use microsoft/AL-Go as a template repository. Please use a fork of AL-Go instead."
+        }
+    }
 
     # TemplateUrl is now always a full url + @ and a branch name
 


### PR DESCRIPTION
Improved development process of AL-Go for GitHub.

Instead of this process when developing AL-Go:
![image](https://github.com/microsoft/AL-Go/assets/10775043/4319c4dd-7c90-4f42-b9ff-eee1bcf7c9ed)

We can also develop AL-Go like this:
![image](https://github.com/microsoft/AL-Go/assets/10775043/94503ae4-32b5-4462-84ca-09994370ec47)

After the completion of this, you can use your fork of AL-Go as template repository when running Update AL-Go System Files.
ex. freddydk/AL-Go@devprocess

Tasks remaining:
- [ ] Currently you cannot change a repository to this by running Update AL-Go System Files, as that will be running the "old" code, which cannot do this - find a way to remove the dependency on the old template from Update AL Go System Files maybe?
- [ ] Add a workflow to AL-Go for GitHub to create a new AppSource or PTE repo, which people can run from their fork now where the PTE and AppSource apps templates no longer exists.
- [ ] Documentation - change the contributing section

