### PR TITLE
Allow template repos to be private as well as public

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -92,6 +92,7 @@ try {
     # Download the template repository and unpack to a temp folder
     $headers = @{             
         "Accept" = "application/vnd.github.baptiste-preview+json"
+        "token" = $token
     }
     $tempName = Join-Path ([System.IO.Path]::GetTempPath()) ([Guid]::NewGuid().ToString())
     InvokeWebRequest -Headers $headers -Uri $archiveUrl -OutFile "$tempName.zip" -retry


### PR DESCRIPTION
Issue #575

I did run through a number of tests to see whether this had any impact on API rate limits, which is not the case.