### PR TITLE
Use GitHub environment branch policies (only if defined)

### DIFF
--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -104,8 +104,9 @@ try {
     if ($getenvironments) {
         $environments = @()
         $headers = @{ 
-            "Authorization" = "token $token"
-            "Accept"        = "application/vnd.github.v3+json"
+            "Authorization"        = "token $token"
+            "Accept"               = "application/vnd.github.v3+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
         }
         Write-Host "Requesting environments: $getEnvironments"
         $url = "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/environments"
@@ -149,7 +150,10 @@ try {
                         Write-Host "GitHub Environment $envName has branch policies, getting branches from GitHub API"
                         $branchesUrl = "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/environments//$([Uri]::EscapeDataString($envName))/deployment-branch-policies"
                         Write-Host "Getting Branches for $envName from GitHub API"
-                        $branches = @((InvokeWebRequest -Headers $headers -Uri $branchesUrl -ignoreErrors | ConvertFrom-Json).branch_policies | ForEach-Object { $_.name })
+                        Write-Host "BranchesUrl: $branchesUrl"
+                        $result = InvokeWebRequest -Headers $headers -Uri $branchesUrl -ignoreErrors
+                        $result | Out-Host
+                        $branches = @(($result | ConvertFrom-Json).branch_policies | ForEach-Object { $_.name })
                     }
                     else {
                         Write-Host "GitHub Environment $envName dot not have branch policies, using main as default"

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -117,7 +117,7 @@ try {
             $ghEnvironments = @()
             Write-Host "Failed to get environments from GitHub API - Environments are not supported in this repository"
         }
-        $environments = @($ghEnvironments+@($settings.environments) | Select-Object -unique | Where-Object { $_ -ne "github-pages" })
+        $environments = @(@($ghEnvironments | ForEach-Object { $_.name })+@($settings.environments) | Select-Object -unique | Where-Object { $_ -ne "github-pages" })
         $unknownEnvironment = 0
         if (!($environments)) {
             $unknownEnvironment = 1

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -149,11 +149,8 @@ try {
                     if ($branchPolicy) {
                         Write-Host "GitHub Environment $envName has branch policies, getting branches from GitHub API"
                         $branchesUrl = "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/environments/$([Uri]::EscapeDataString($envName))/deployment-branch-policies"
-                        Write-Host "Getting Branches for $envName from GitHub API"
-                        Write-Host "BranchesUrl: $branchesUrl"
-                        $result = InvokeWebRequest -Headers $headers -Uri $branchesUrl -ignoreErrors
-                        $result | Out-Host
-                        $branches = @(($result | ConvertFrom-Json).branch_policies | ForEach-Object { $_.name })
+                        Write-Host "Getting branches for $envName from GitHub API"
+                        $branches = @((InvokeWebRequest -Headers $headers -Uri $branchesUrl -ignoreErrors | ConvertFrom-Json).branch_policies | ForEach-Object { $_.name })
                     }
                     else {
                         Write-Host "GitHub Environment $envName dot not have branch policies, using main as default"

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -147,8 +147,7 @@ try {
                     if ($branchPolicy) {
                         $branchesUrl = "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/environments//$([Uri]::EscapeDataString($envName))/deployment-branch-policies"
                         Write-Host "Getting Branches for $envName from GitHub API"
-                        $branches @((InvokeWebRequest -Headers $headers -Uri $url -ignoreErrors | ConvertFrom-Json).branch_policies | ForEach-Object { $_.name })
-                        $branches = @( '*' )
+                        $branches = @((InvokeWebRequest -Headers $headers -Uri $branchesUrl -ignoreErrors | ConvertFrom-Json).branch_policies | ForEach-Object { $_.name })
                     }
                     else {
                         $branches = @( 'main' )

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -153,7 +153,7 @@ try {
                         $branches = @((InvokeWebRequest -Headers $headers -Uri $branchesUrl -ignoreErrors | ConvertFrom-Json).branch_policies | ForEach-Object { $_.name })
                     }
                     else {
-                        Write-Host "GitHub Environment $envName dot not have branch policies, using main as default"
+                        Write-Host "GitHub Environment $envName does not have branch policies, using main as default"
                         $branches = @( 'main' )
                     }
                 }

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -115,7 +115,7 @@ try {
             $result = InvokeWebRequest -Headers $headers -Uri $url -ignoreErrors
             Write-Host $result
             Write-Host $getEnvironments
-            $ghEnvironments = @($result | ConvertFrom-Json).environments | Where-Object { $_.name -like $getEnvironments })
+            $ghEnvironments = @(($result | ConvertFrom-Json).environments | Where-Object { $_.name -like $getEnvironments })
             $ghEnvironments | Out-Host
         #} 
         #catch {

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -148,7 +148,7 @@ try {
                     $branchPolicy = ($ghEnvironment.protection_rules | Where-Object { $_.type -eq "branch_policy" })
                     if ($branchPolicy) {
                         Write-Host "GitHub Environment $envName has branch policies, getting branches from GitHub API"
-                        $branchesUrl = "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/environments//$([Uri]::EscapeDataString($envName))/deployment-branch-policies"
+                        $branchesUrl = "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/environments/$([Uri]::EscapeDataString($envName))/deployment-branch-policies"
                         Write-Host "Getting Branches for $envName from GitHub API"
                         Write-Host "BranchesUrl: $branchesUrl"
                         $result = InvokeWebRequest -Headers $headers -Uri $branchesUrl -ignoreErrors

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -109,14 +109,15 @@ try {
         }
         Write-Host "Requesting environments: $getEnvironments"
         $url = "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/environments"
-        try {
+        #try {
             Write-Host "Trying to get environments from GitHub API with branch policies set"
             $ghEnvironments = @((InvokeWebRequest -Headers $headers -Uri $url -ignoreErrors | ConvertFrom-Json).environments | Where-Object { $_.name -match $getEnvironments })
-        } 
-        catch {
-            $ghEnvironments = @()
-            Write-Host "Failed to get environments from GitHub API - Environments are not supported in this repository"
-        }
+            $ghEnvironments | Out-Host
+        #} 
+        #catch {
+        #    $ghEnvironments = @()
+        #    Write-Host "Failed to get environments from GitHub API - Environments are not supported in this repository"
+        #}
         $environments = @(@($ghEnvironments | ForEach-Object { $_.name })+@($settings.environments) | Select-Object -unique | Where-Object { $_ -ne "github-pages" })
         $unknownEnvironment = 0
         if (!($environments)) {

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -111,7 +111,11 @@ try {
         $url = "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/environments"
         #try {
             Write-Host "Trying to get environments from GitHub API with branch policies set"
-            $ghEnvironments = @((InvokeWebRequest -Headers $headers -Uri $url -ignoreErrors | ConvertFrom-Json).environments | Where-Object { $_.name -match $getEnvironments })
+            Write-Host $url
+            $result = InvokeWebRequest -Headers $headers -Uri $url -ignoreErrors
+            Write-Host $result
+            Write-Host $getEnvironments
+            $ghEnvironments = @($result | ConvertFrom-Json).environments | Where-Object { $_.name -like $getEnvironments })
             $ghEnvironments | Out-Host
         #} 
         #catch {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@ Note that when using the preview version of AL-Go for GitHub, you need to Update
 ### Issues
 
 Issue 542 Deploy Workflow fails
+Issue 558 CI/CD attempts to deploy from feature branch
 
 ### New Settings
 - `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module


### PR DESCRIPTION
Fix for issue #558

The problem here was, that if the environment was defined in GitHub, then AL-Go would assume that branch policies was defined on the environment and select all branches itself - waiting for GitHub to reject the branch.

The problem with this approach is that if you have a Teams or Enterprise SKU, then the environment will be auto-created when deploying the first time (even if defined in settings).

The fix for this is to only rely on GitHub branch policies if they actually are defined - else use the default branch policies.