### PR TITLE
support target_commitish in Release Notes

### DIFF
--- a/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
+++ b/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
@@ -5,10 +5,10 @@ Param(
     [string] $token,
     [Parameter(HelpMessage = "Specifies the parent telemetry scope for the telemetry signal", Mandatory = $false)]
     [string] $parentTelemetryScopeJson = '7b7d',
-    [Parameter(HelpMessage = "A GitHub token with permissions to modify workflows", Mandatory = $false)]
-    [string] $workflowToken,
     [Parameter(HelpMessage = "Tag name", Mandatory = $true)]
-    [string] $tag_name
+    [string] $tag_name,
+    [Parameter(HelpMessage = "Last commit to include in release notes", Mandatory = $false)]
+    [string] $target_commitish
 )
 
 $ErrorActionPreference = "Stop"
@@ -54,7 +54,7 @@ try {
             $latestReleaseTag = $latestRelease.tag_name
         }
     
-        $releaseNotes = GetReleaseNotes -token $token -api_url $ENV:GITHUB_API_URL -repository $ENV:GITHUB_REPOSITORY  -tag_name $tag_name -previous_tag_name $latestReleaseTag | ConvertFrom-Json
+        $releaseNotes = GetReleaseNotes -token $token -api_url $ENV:GITHUB_API_URL -repository $ENV:GITHUB_REPOSITORY  -tag_name $tag_name -previous_tag_name $latestReleaseTag -target_commitish $target_commitish | ConvertFrom-Json
         $releaseNotes = $releaseNotes.body -replace '%','%25' -replace '\n','%0A' -replace '\r','%0D' # supports a multiline text
     }
     catch {

--- a/Actions/CreateReleaseNotes/README.md
+++ b/Actions/CreateReleaseNotes/README.md
@@ -9,3 +9,5 @@ The GitHub token running the action
 Specifies the parent telemetry scope for the telemetry signal
 ### tag_name (required)
 This release tag name
+### target_commitish (default last)
+Last commit to include in release notes

--- a/Actions/CreateReleaseNotes/action.yaml
+++ b/Actions/CreateReleaseNotes/action.yaml
@@ -20,13 +20,13 @@ inputs:
     description: Specifies the parent telemetry scope for the telemetry signal
     required: false
     default: '7b7d'
-  workflowToken:
-    description: A GitHub token with permissions to modify workflows
-    required: false
-    default: ''
   tag_name:
     description: Tag name
     required: true
+  target_commitish:
+    description: Last commit to include in release notes
+    required: false
+    default: ''
 outputs:
   ReleaseBranch:
     description: Name of the release branch
@@ -44,9 +44,9 @@ runs:
         _actor: ${{ inputs.actor }}
         _token: ${{ inputs.token }}
         _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-        _workflowToken: ${{ inputs.workflowToken }}
         _tag_name: ${{ inputs.tag_name }}
-      run: try { ${{ github.action_path }}/CreateReleaseNotes.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -workflowToken $ENV:_workflowToken -tag_name $ENV:_tag_name } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
+        _target_commitish: ${{ inputs.target_commitish }}
+      run: try { ${{ github.action_path }}/CreateReleaseNotes.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -tag_name $ENV:_tag_name -target_commitish $ENV:_target_commitish } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal
   color: blue

--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -545,7 +545,8 @@ function GetReleaseNotes {
         [string] $repository = $ENV:GITHUB_REPOSITORY,
         [string] $api_url = $ENV:GITHUB_API_URL,
         [string] $tag_name,
-        [string] $previous_tag_name
+        [string] $previous_tag_name,
+        [string] $target_commitish
     )
     
     Write-Host "Generating release note $api_url/repos/$repository/releases/generate-notes"
@@ -554,8 +555,11 @@ function GetReleaseNotes {
         tag_name = $tag_name;
     }
 
-    if (-not [string]::IsNullOrEmpty($previous_tag_name)) {
+    if ($previous_tag_name) {
         $postParams["previous_tag_name"] = $previous_tag_name
+    }
+    if ($target_commitish) {
+        $postParams["target_commitish"] = $target_commitish
     }
 
     InvokeWebRequest -Headers (GetHeader -token $token) -Method POST -Body ($postParams | ConvertTo-Json) -Uri "$api_url/repos/$repository/releases/generate-notes" 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@ Note that when using the preview version of AL-Go for GitHub, you need to Update
 ### Issues
 
 Issue 542 Deploy Workflow fails
+Issue 559 Changelog includes wrong commits
 
 ### New Settings
 - `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -176,6 +176,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           tag_name: ${{ github.event.inputs.tag }}
+          target_commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
 
       - name: Create release
         uses: actions/github-script@v6

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -176,6 +176,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           tag_name: ${{ github.event.inputs.tag }}
+          target_commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
 
       - name: Create release
         uses: actions/github-script@v6

--- a/Tests/CreateReleaseNotes.Test.ps1
+++ b/Tests/CreateReleaseNotes.Test.ps1
@@ -44,7 +44,7 @@ Describe 'CreateReleaseNotes Tests' {
         Mock DownloadAndImportBcContainerHelper  {}
         Mock CreateScope  {}
 
-        . $scriptPath -token "" -actor "" -workflowToken "" -tag_name "1.0.5" -parentTelemetryScopeJson "{}"
+        . $scriptPath -token "" -actor "" -tag_name "1.0.5" -parentTelemetryScopeJson "{}"
     
         Should -Invoke -CommandName GetLatestRelease -Exactly -Times 1 
         Should -Invoke -CommandName GetReleaseNotes -Exactly -Times 1 -ParameterFilter { $tag_name -eq "1.0.5" -and $previous_tag_name -eq "1.0.0.0" }
@@ -61,7 +61,7 @@ Describe 'CreateReleaseNotes Tests' {
         Mock DownloadAndImportBcContainerHelper  {}
         Mock CreateScope  {}
 
-        . $scriptPath -token "" -actor "" -workflowToken "" -tag_name "1.0.5" -parentTelemetryScopeJson "{}"
+        . $scriptPath -token "" -actor "" -tag_name "1.0.5" -parentTelemetryScopeJson "{}"
     
         Should -Invoke -CommandName GetLatestRelease -Exactly -Times 1 
         Should -Invoke -CommandName GetReleaseNotes -Exactly -Times 1 -ParameterFilter { $tag_name -eq "1.0.5" -and $previous_tag_name -eq "" }


### PR DESCRIPTION
Fix for Issue #559 

The created release notes contains all notes - not just to the target committish.