### PR TITLE
Fix pathToFiles parameter for Sign action

### DIFF
--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -139,7 +139,7 @@ jobs:
             shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
             azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
             settingsJson: ${{ env.Settings }}
-            pathToFiles: '${{ matrix.project }}/.buildartifacts/Apps/*.app'
+            pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
             parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
         - name: Calculate Artifact names

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -139,7 +139,7 @@ jobs:
             shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
             azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
             settingsJson: ${{ env.Settings }}
-            pathToFiles: '${{ matrix.project }}/.buildartifacts/Apps/*.app'
+            pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
             parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
         - name: Calculate Artifact names


### PR DESCRIPTION
When moving to reusable workflows, we forgot to update a reference to matrix. Therefore the sign action is throwing: 
`Error: Sign action failed. Error: Cannot find path 'D:\.buildartifacts\Apps' because it does not exist. Stacktrace: at <ScriptBlock>, D:\a\_actions\microsoft\AL-Go-Actions\preview\Sign\Sign.ps1: line 36 at <ScriptBlock>, D:\a\_temp\41c73416-43db-4b6c-9797-1aae7a7ca5eb.ps1: line 3 at <ScriptBlock>, <No file>: line 1`

Updating the pathToFiles to get the project name from inputs. Tested here: https://github.com/aholstrup1/ALAppExtensions/actions/runs/5483226732