### PR TITLE
BuildBy

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -17,7 +17,7 @@ $RepoSettingsFile = Join-Path '.github' 'AL-Go-Settings.json'
 $defaultCICDPushBranches = @( 'main', 'release/*', 'feature/*' )
 $defaultCICDPullRequestBranches = @( 'main' )
 $runningLocal = $local.IsPresent
-$defaultBcContainerHelperVersion = "https://github.com/freddydk/navcontainerhelper/archive/master.zip" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
+$defaultBcContainerHelperVersion = "" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
 $microsoftTelemetryConnectionString = "InstrumentationKey=84bd9223-67d4-4378-8590-9e4a46023be2;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/"
 
 $runAlPipelineOverrides = @(

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -17,7 +17,7 @@ $RepoSettingsFile = Join-Path '.github' 'AL-Go-Settings.json'
 $defaultCICDPushBranches = @( 'main', 'release/*', 'feature/*' )
 $defaultCICDPullRequestBranches = @( 'main' )
 $runningLocal = $local.IsPresent
-$defaultBcContainerHelperVersion = "" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
+$defaultBcContainerHelperVersion = "https://github.com/freddydk/navcontainerhelper/archive/master.zip" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
 $microsoftTelemetryConnectionString = "InstrumentationKey=84bd9223-67d4-4378-8590-9e4a46023be2;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/"
 
 $runAlPipelineOverrides = @(

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -44,8 +44,6 @@ try {
   
     $containerName = GetContainerName($project)
 
-    Write-Host "xxxxxxxx $ENV:GITHUB_ACTION_PATH"
-    
     $ap = "$ENV:GITHUB_ACTION_PATH".Split('\')
     $branch = $ap[$ap.Count-2]
     $owner = $ap[$ap.Count-4]

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -44,7 +44,25 @@ try {
   
     $containerName = GetContainerName($project)
 
-    $runAlPipelineParams = @{}
+    Write-Host "xxxxxxxx $ENV:GITHUB_ACTION_PATH"
+    
+    $ap = "$ENV:GITHUB_ACTION_PATH".Split('\')
+    $branch = $ap[$ap.Count-2]
+    $owner = $ap[$ap.Count-4]
+
+    if ($owner -ne "microsoft") {
+        $verstr = "dev"
+    }
+    else {
+        $verstr = $branch
+    }
+
+    $runAlPipelineParams = @{
+        "sourceRepositoryUrl" = "$ENV:GITHUB_SERVER_URL/$ENV:GITHUB_REPOSITORY"
+        "sourceCommit" = $ENV:GITHUB_SHA
+        "buildBy" = "AL-Go for GitHub,$verstr"
+        "buildUrl" = "$ENV:GITHUB_SERVER_URL/$ENV:GITHUB_REPOSITORY/actions/runs/$ENV:GITHUB_RUN_ID"
+    }
     if ($project  -eq ".") { $project = "" }
     $baseFolder = $ENV:GITHUB_WORKSPACE
     if ($bcContainerHelperConfig.useVolumes -and $bcContainerHelperConfig.hostHelperFolder -eq "HostHelperFolder") {

--- a/Internal/Deploy.ps1
+++ b/Internal/Deploy.ps1
@@ -320,7 +320,8 @@ try {
                     $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
                 }
                 if ($_.Name -eq "AL-Go-Helper.ps1" -and ($config.PSObject.Properties.Name -eq "defaultBcContainerHelperVersion") -and ($config.defaultBcContainerHelperVersion)) {
-                    $lines = $lines | ForEach-Object { $_ -replace '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)""(.*)$', "`$1`$defaultBcContainerHelperVersion`$2=`$3""$($config.defaultBcContainerHelperVersion)""`$4" }
+                    # replace defaultBcContainerHelperVersion (even if a version is set)
+                    $lines = $lines | ForEach-Object { $_ -replace '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)" # (.*)$', "`$1`$defaultBcContainerHelperVersion`$2=`$3""$defaultBcContainerHelperVersion"" # `$5" }
                 }
                 [System.IO.File]::WriteAllText($dstFile, "$($lines -join "`n")`n")
             }


### PR DESCRIPTION
Fill out 4 new parameters on Run-AlPipeline (and the Compile functions), to specify the origin of the app inside the app manifest.

- SourceRepositoryUrl specifies the repository URL
- SourceCommit specifies the SHA used for the build
- BuildBy specifies the product used to perform the build
- BuildUrl is the URL to the workflow run

Parameters dumped in the RunPipeline Action are:
![image](https://github.com/microsoft/AL-Go/assets/10775043/829a1216-0c1a-427e-94e3-392814dc1baf)

NavxManifest.xml in the app package will contain properties like this:
```
<Source RepositoryUrl="https://github.com/BusinessCentralApps/buildorder" Commit="5523f3678064a9f425e1825ef94583d6f3136ebc" />
<Build By="AL-Go for GitHub,v3.1" Url="https://github.com/BusinessCentralApps/buildorder/actions/runs/5435941342" Timestamp="2023-07-07T10:01:13.8159082Z" CompilerVersion="12.0.12.44111" />
```
