### PR TITLE
Add new apps ahead of .github and .AL-Go

### DIFF
--- a/Actions/CreateApp/AppHelper.psm1
+++ b/Actions/CreateApp/AppHelper.psm1
@@ -195,7 +195,7 @@ function Update-WorkSpaces
                 $workspaceFile = $_.FullName
                 $workspace = Get-Content $workspaceFile -Encoding UTF8 | ConvertFrom-Json
                 if (-not ($workspace.folders | Where-Object { $_.Path -eq $appName })) {
-                    $workspace.folders = Add-NewAppFolder($workspace.folders, $appName)
+                    $workspace.folders = Add-NewAppFolder $workspace.folders $appName
                 }
                 $workspace | Set-JsonContentLF -Path $workspaceFile
             }

--- a/Actions/CreateApp/AppHelper.psm1
+++ b/Actions/CreateApp/AppHelper.psm1
@@ -212,7 +212,13 @@ function Add-NewAppFolderToWorkspaceFolders
 )
 {
     $newAppFolder = [PSCustomObject]@{ "path" = $appFolder }
-    $afterFolder = $workspaceFolders | Where-Object { $_.path -ne '.github' -and $_.path -ne '.AL-Go' } | Select-Object -Last 1
+
+    if ($workspaceFolders){
+        $afterFolder = $workspaceFolders | Where-Object { $_.path -ne '.github' -and $_.path -ne '.AL-Go' } | Select-Object -Last 1
+    }
+    else {
+        return  @($newAppFolder)
+    }
 
     if ($afterFolder) {
         $workspaceFolders = @($workspaceFolders | ForEach-Object {
@@ -236,3 +242,4 @@ Export-ModuleMember -Function New-SampleTestApp
 Export-ModuleMember -Function New-SamplePerformanceTestApp
 Export-ModuleMember -Function Confirm-IdRanges
 Export-ModuleMember -Function Update-WorkSpaces
+Export-ModuleMember -Function Add-NewAppFolderToWorkspaceFolders

--- a/Actions/CreateApp/AppHelper.psm1
+++ b/Actions/CreateApp/AppHelper.psm1
@@ -236,7 +236,7 @@ function Add-NewAppFolder
     $newAppFolder = @(@{ "path" = $appName })
 
     # If found, insert the new app folder ahead of the index. Otherwise, append it.
-    if (index -eq 0) {
+    if ($index -eq 0) {
         $workspaceFolders = $newAppFolder + $workspaceFolders
     }
     elseif ($index -gt 0) {

--- a/Actions/CreateApp/AppHelper.psm1
+++ b/Actions/CreateApp/AppHelper.psm1
@@ -211,24 +211,35 @@ function Add-NewAppFolder
     [string] $appName
 )
 {
-    # Determine the index of either .github or .AL-Go
-    $githubIndex = $workspaceFolders | Where-Object { $_.Path -eq '.github' } | Select-Object -First 1
-    $alGoIndex = $workspaceFolders | Where-Object { $_.Path -eq '.Al-Go' } | Select-Object -First 1
+    # Find the .github and Al-Go folders
+    $githubFolder = $workspaceFolders | Where-Object { $_.Path -eq '.github' } | Select-Object -First 1
+    $alGoFolder = $workspaceFolders | Where-Object { $_.Path -eq '.Al-Go' } | Select-Object -First 1
 
-    if ($githubIndex -ge 0 -and $alGoIndex -ge 0) {
+    # Determine the index of either .github or .AL-Go
+    $githubIndex = $workspaceFolders.IndexOf($githubFolder)
+    $alGoIndex = $workspaceFolders.IndexOf($alGoFolder)
+
+    # Get the lowest valid index between the two
+    if ($null -ne $githubFolder -and $null -ne $alGoFolder) {
         $index = [Math]::Min($githubIndex, $alGoIndex)
     }
-    elseif ($alGoIndex -lt 0) {
+    elseif ($null -ne $githubFolder) {
         $index = $githubIndex
     }
-    else {
+    elseif ($null -ne $alGoFolder) {
         $index = $alGoIndex
+    }
+    else {
+        $index = -1
     }
 
     $newAppFolder = @(@{ "path" = $appName })
 
-    # If found, insert the new app folder before the index. Otherwise, append it.
-    if ($index -ge 0) {
+    # If found, insert the new app folder ahead of the index. Otherwise, append it.
+    if (index -eq 0) {
+        $workspaceFolders = $newAppFolder + $workspaceFolders
+    }
+    elseif ($index -gt 0) {
         $folders1 = $array[$workspaceFolders[0..($index-1)]]
         $folders2 = $array[$workspaceFolders[$index..$workspaceFolders.Length-1]]
         $workspaceFolders = $folders1 + $newAppFolder + $folders2

--- a/Actions/CreateApp/AppHelper.psm1
+++ b/Actions/CreateApp/AppHelper.psm1
@@ -213,12 +213,11 @@ function Add-NewAppFolderToWorkspaceFolders
 {
     $newAppFolder = [PSCustomObject]@{ "path" = $appFolder }
 
-    if ($workspaceFolders){
-        $afterFolder = $workspaceFolders | Where-Object { $_.path -ne '.github' -and $_.path -ne '.AL-Go' } | Select-Object -Last 1
-    }
-    else {
+    if (-not $workspaceFolders){
         return  @($newAppFolder)
     }
+
+    $afterFolder = $workspaceFolders | Where-Object { $_.path -ne '.github' -and $_.path -ne '.AL-Go' } | Select-Object -Last 1
 
     if ($afterFolder) {
         $workspaceFolders = @($workspaceFolders | ForEach-Object {

--- a/Tests/AppHelper.Test.ps1
+++ b/Tests/AppHelper.Test.ps1
@@ -75,42 +75,37 @@ Describe 'AppHelper.psm1 Tests' {
     }
 
     It 'Insert new app folder ahead of .AL-Go' {
-        $appName = -join (((48..57)+(65..90)+(97..122)) * 80 |Get-Random -Count 8 | ForEach-Object {[char]$_})
         $workspaceFolders = '[{"path":".AL-Go"}]' | ConvertFrom-Json
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder $appName
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
 
-        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be ('[{"path":"{0}"},{"path":".AL-Go"}]' -f $appName)
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '[{"path":"newfolder"},{"path":".AL-Go"}]'
     }
 
     It 'Insert new app folder ahead of .AL-Go and .github' {
-        $appName = -join (((48..57)+(65..90)+(97..122)) * 80 |Get-Random -Count 8 | ForEach-Object {[char]$_})
         $workspaceFolders = '[{"path":".AL-Go"},{"path":".github"}]' | ConvertFrom-Json
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder $appName
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
 
-        (ConvertTo-Json -InputObject $workspaceFolders -Compress)  |Should -Be ('[{"path":"{0}"},{"path":".AL-Go"},{"path":".github"}]' -f $appName)
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress)  |Should -Be '[{"path":"newfolder"},{"path":".AL-Go"},{"path":".github"}]'
     }
 
     It 'Insert new app folder after onefolder ahead of .AL-Go and .github' {
-        $appName = -join (((48..57)+(65..90)+(97..122)) * 80 |Get-Random -Count 8 | ForEach-Object {[char]$_})
         $workspaceFolders = '[{"path":"oneFolder"},{"path":".AL-Go"},{"path":".github"}]' | ConvertFrom-Json
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder $appName
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
 
-        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be ('[{"path":"onefolder"},{"path":"{0}"},{"path":".AL-Go"},{"path":".github"}]' -f $appName)
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '[{"path":"onefolder"},{"path":"newfolder"},{"path":".AL-Go"},{"path":".github"}]'
     }
 
     It 'Insert new app folder after .AL-Go, .github and onefolder' {
-        $appName = -join (((48..57)+(65..90)+(97..122)) * 80 |Get-Random -Count 8 | ForEach-Object {[char]$_})
         $workspaceFolders = '[{"path":".AL-Go"},{"path":".github"},{"path":"oneFolder"}]' | ConvertFrom-Json
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder $appName
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
 
-        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be ('[{"path":".AL-Go"},{"path":".github"},{"path":"onefolder"},{"path":"{0}"}]' -f $appName)
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '[{"path":".AL-Go"},{"path":".github"},{"path":"onefolder"},{"path":"newfolder"}]'
     }
 
     It 'Insert new app folder in empty list' {
-        $appName = -join (((48..57)+(65..90)+(97..122)) * 80 |Get-Random -Count 8 | ForEach-Object {[char]$_})
         $workspaceFolders = '[]' | ConvertFrom-Json
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder $appName
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
 
-        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be ('[{"path":"{0}"}]' -f $appName)
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '{"path":"newfolder"}'
     }
 }

--- a/Tests/AppHelper.Test.ps1
+++ b/Tests/AppHelper.Test.ps1
@@ -73,4 +73,44 @@ Describe 'AppHelper.psm1 Tests' {
 
         (Join-Path $sampleAppFolder ".vscode/launch.json") | Should -Exist
     }
+
+    It 'Insert new app folder ahead of .AL-Go' {
+        $appName = -join (((48..57)+(65..90)+(97..122)) * 80 |Get-Random -Count 8 | ForEach-Object {[char]$_})
+        $workspaceFolders = '[{"path":".AL-Go"}]' | ConvertFrom-Json
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder $appName
+
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be ('[{"path":"{0}"},{"path":".AL-Go"}]' -f $appName)
+    }
+
+    It 'Insert new app folder ahead of .AL-Go and .github' {
+        $appName = -join (((48..57)+(65..90)+(97..122)) * 80 |Get-Random -Count 8 | ForEach-Object {[char]$_})
+        $workspaceFolders = '[{"path":".AL-Go"},{"path":".github"}]' | ConvertFrom-Json
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder $appName
+
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress)  |Should -Be ('[{"path":"{0}"},{"path":".AL-Go"},{"path":".github"}]' -f $appName)
+    }
+
+    It 'Insert new app folder after onefolder ahead of .AL-Go and .github' {
+        $appName = -join (((48..57)+(65..90)+(97..122)) * 80 |Get-Random -Count 8 | ForEach-Object {[char]$_})
+        $workspaceFolders = '[{"path":"oneFolder"},{"path":".AL-Go"},{"path":".github"}]' | ConvertFrom-Json
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder $appName
+
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be ('[{"path":"onefolder"},{"path":"{0}"},{"path":".AL-Go"},{"path":".github"}]' -f $appName)
+    }
+
+    It 'Insert new app folder after .AL-Go, .github and onefolder' {
+        $appName = -join (((48..57)+(65..90)+(97..122)) * 80 |Get-Random -Count 8 | ForEach-Object {[char]$_})
+        $workspaceFolders = '[{"path":".AL-Go"},{"path":".github"},{"path":"oneFolder"}]' | ConvertFrom-Json
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder $appName
+
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be ('[{"path":".AL-Go"},{"path":".github"},{"path":"onefolder"},{"path":"{0}"}]' -f $appName)
+    }
+
+    It 'Insert new app folder in empty list' {
+        $appName = -join (((48..57)+(65..90)+(97..122)) * 80 |Get-Random -Count 8 | ForEach-Object {[char]$_})
+        $workspaceFolders = '[]' | ConvertFrom-Json
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder $appName
+
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be ('[{"path":"{0}"}]' -f $appName)
+    }
 }

--- a/Tests/AppHelper.Test.ps1
+++ b/Tests/AppHelper.Test.ps1
@@ -76,43 +76,43 @@ Describe 'AppHelper.psm1 Tests' {
 
     It 'Insert new app folder ahead of .AL-Go' {
         $workspaceFolders = '[{"path":".AL-Go"}]' | ConvertFrom-Json
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
+        $workspaceFolders = @(Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder')
 
         (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '[{"path":"newfolder"},{"path":".AL-Go"}]'
     }
 
     It 'Insert new app folder ahead of .AL-Go and .github' {
         $workspaceFolders = '[{"path":".AL-Go"},{"path":".github"}]' | ConvertFrom-Json
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
+        $workspaceFolders = @(Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder')
 
         (ConvertTo-Json -InputObject $workspaceFolders -Compress)  |Should -Be '[{"path":"newfolder"},{"path":".AL-Go"},{"path":".github"}]'
     }
 
     It 'Insert new app folder after onefolder ahead of .AL-Go and .github' {
         $workspaceFolders = '[{"path":"oneFolder"},{"path":".AL-Go"},{"path":".github"}]' | ConvertFrom-Json
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
+        $workspaceFolders = @(Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder')
 
         (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '[{"path":"onefolder"},{"path":"newfolder"},{"path":".AL-Go"},{"path":".github"}]'
     }
 
     It 'Insert new app folder after .AL-Go, .github and onefolder' {
         $workspaceFolders = '[{"path":".AL-Go"},{"path":".github"},{"path":"oneFolder"}]' | ConvertFrom-Json
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
+        $workspaceFolders = @(Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder')
 
         (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '[{"path":".AL-Go"},{"path":".github"},{"path":"onefolder"},{"path":"newfolder"}]'
     }
 
     It 'Insert new app folder in empty list' {
         $workspaceFolders = '[]' | ConvertFrom-Json
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
+        $workspaceFolders = @(Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder')
 
-        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '{"path":"newfolder"}'
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '[{"path":"newfolder"}]'
     }
 
     It 'Insert new app folder in null object' {
         $workspaceFolders = $null
-        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
+        $workspaceFolders = @(Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder')
 
-        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '{"path":"newfolder"}'
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '[{"path":"newfolder"}]'
     }
 }

--- a/Tests/AppHelper.Test.ps1
+++ b/Tests/AppHelper.Test.ps1
@@ -108,4 +108,11 @@ Describe 'AppHelper.psm1 Tests' {
 
         (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '{"path":"newfolder"}'
     }
+
+    It 'Insert new app folder in null object' {
+        $workspaceFolders = $null
+        $workspaceFolders = Add-NewAppFolderToWorkspaceFolders -workspaceFolder $workspaceFolders -appFolder 'newfolder'
+
+        (ConvertTo-Json -InputObject $workspaceFolders -Compress) | Should -Be '{"path":"newfolder"}'
+    }
 }


### PR DESCRIPTION
Currently, app folders created using the AL Go actions will always be appended at the end of the folder list in the workspace settings. However, for most AL developers, access to the `.github` and `.AL-Go` folders will be low priority. Additionally, some VS Code extensions assume the relevant workspace folder to be the first one, which by default is `.AL-Go`.

When adding a new app, this feature locates both `.github` and `.AL-Go` in the workspace settings, determines which one appears earlier and inserts the newly created app ahead of it. If neither can be found, it will be appended at the end of the list, just like the current behavior.

With this, the first app created will automatically be at first position, with subsequent apps following after.