### PR TITLE
Allow using ghTokenWorkflow in workflows creating pull requests (issue555)

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -627,6 +627,13 @@ function ReadSettings {
     if ($settings.githubRunnerShell -eq "") {
         $settings.githubRunnerShell = $settings.shell
     }
+    # Check that gitHubRunnerShell and Shell is valid
+    if ($settings.githubRunnerShell -ne "powershell" -and $settings.githubRunnerShell -ne "pwsh") {
+        throw "Invalid value for setting: gitHubRunnerShell: $($settings.githubRunnerShell)"
+    }
+    if ($settings.shell -ne "powershell" -and $settings.shell -ne "pwsh") {
+        throw "Invalid value for setting: shell: $($settings.githubRunnerShell)"
+    }
     $settings
 }
 

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -17,7 +17,7 @@ $RepoSettingsFile = Join-Path '.github' 'AL-Go-Settings.json'
 $defaultCICDPushBranches = @( 'main', 'release/*', 'feature/*' )
 $defaultCICDPullRequestBranches = @( 'main' )
 $runningLocal = $local.IsPresent
-$defaultBcContainerHelperVersion = "" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
+$defaultBcContainerHelperVersion = "https://github.com/freddydk/navcontainerhelper/archive/master.zip" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
 $microsoftTelemetryConnectionString = "InstrumentationKey=84bd9223-67d4-4378-8590-9e4a46023be2;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/"
 
 $runAlPipelineOverrides = @(

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -13,6 +13,13 @@ Issue 598 Cleanup during flush if build pipeline doesn't cleanup properly
 ### New Settings
 - `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module
 
+### Issue 555
+AL-Go contains several workflows, which create a Pull Request or pushes code directly.
+All (except Update AL-Go System Files) earlier used the GITHUB_TOKEN to create the PR or commit.
+The problem using GITHUB_TOKEN is that is doesn't trigger a pull request build or a commit build.
+This is by design: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+Now, you can set the checkbox called Use GhTokenWorkflow to allowing you to use the GhTokenWorkflow instead of the GITHUB_TOKEN - making sure that workflows are triggered
+
 ## v3.1
 
 ### Issues

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -47,7 +47,7 @@ jobs:
           eventId: "DO0090"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go/Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -55,7 +55,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -47,7 +47,7 @@ jobs:
           eventId: "DO0090"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -55,7 +55,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -16,6 +16,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -43,10 +46,42 @@ jobs:
           shell: powershell
           eventId: "DO0090"
 
+      - name: Read settings
+        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+
       - name: Add existing app
         uses: microsoft/AL-Go-Actions/AddExistingApp@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           url: ${{ github.event.inputs.url }}

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -64,7 +64,7 @@ jobs:
           get: type,keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -64,7 +64,7 @@ jobs:
           get: type,keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -26,6 +26,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: "N"
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -58,12 +61,36 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          get: type
+          get: type,keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Creating a new app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: ${{ env.type }}

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -16,6 +16,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -109,7 +112,19 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
           settingsJson: ${{ env.Settings }}
-          secrets: 'adminCenterApiCredentials'
+          secrets: 'adminCenterApiCredentials,ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Set AdminCenterApiCredentials
         run: |
@@ -122,6 +137,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -63,7 +63,7 @@ jobs:
           eventId: "DO0102"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go/Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -71,7 +71,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -32,6 +32,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -59,10 +62,42 @@ jobs:
           shell: powershell
           eventId: "DO0102"
 
+      - name: Read settings
+        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Performance Test App'

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -63,7 +63,7 @@ jobs:
           eventId: "DO0102"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -71,7 +71,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -337,7 +337,7 @@ jobs:
     needs: [ CreateRelease, UploadArtifacts ]
     steps:
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go/Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -345,7 +345,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -338,7 +338,7 @@ jobs:
     needs: [ CreateRelease, UploadArtifacts ]
     steps:
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -346,7 +346,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -35,6 +35,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -333,10 +336,42 @@ jobs:
     runs-on: [ windows-latest ]
     needs: [ CreateRelease, UploadArtifacts ]
     steps:
+      - name: Read settings
+        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+
       - name: Update Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
           versionNumber: ${{ github.event.inputs.updateVersionNumber }}
           directCommit: ${{ github.event.inputs.directCommit }}

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -59,7 +59,7 @@ jobs:
           eventId: "DO0095"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -67,7 +67,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -28,6 +28,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -55,10 +58,42 @@ jobs:
           shell: powershell
           eventId: "DO0095"
 
+      - name: Read settings
+        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Test App'

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -59,7 +59,7 @@ jobs:
           eventId: "DO0095"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go/Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -67,7 +67,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -16,6 +16,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -43,10 +46,42 @@ jobs:
           shell: powershell
           eventId: "DO0096"
 
+      - name: Read settings
+        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+
       - name: Increment Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           versionNumber: ${{ github.event.inputs.versionNumber }}

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -47,7 +47,7 @@ jobs:
           eventId: "DO0096"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -55,7 +55,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -47,7 +47,7 @@ jobs:
           eventId: "DO0096"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go/Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -55,7 +55,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -47,7 +47,7 @@ jobs:
           eventId: "DO0090"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go/Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -55,7 +55,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -47,7 +47,7 @@ jobs:
           eventId: "DO0090"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -55,7 +55,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -16,6 +16,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -43,10 +46,42 @@ jobs:
           shell: powershell
           eventId: "DO0090"
 
+      - name: Read settings
+        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+
       - name: Add existing app
         uses: microsoft/AL-Go-Actions/AddExistingApp@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           url: ${{ github.event.inputs.url }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -64,7 +64,7 @@ jobs:
           get: type,keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -64,7 +64,7 @@ jobs:
           get: type,keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -26,6 +26,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: "N"
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -58,12 +61,36 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          get: type
+          get: type,keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Creating a new app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: ${{ env.type }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -103,7 +103,6 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
-          get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -16,6 +16,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -100,6 +103,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -109,7 +113,19 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
           settingsJson: ${{ env.Settings }}
-          secrets: 'adminCenterApiCredentials'
+          secrets: 'adminCenterApiCredentials,ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Set AdminCenterApiCredentials
         run: |
@@ -122,6 +138,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -63,7 +63,7 @@ jobs:
           eventId: "DO0102"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go/Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -71,7 +71,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -32,6 +32,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -59,10 +62,42 @@ jobs:
           shell: powershell
           eventId: "DO0102"
 
+      - name: Read settings
+        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Performance Test App'

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -63,7 +63,7 @@ jobs:
           eventId: "DO0102"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -71,7 +71,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -337,7 +337,7 @@ jobs:
     needs: [ CreateRelease, UploadArtifacts ]
     steps:
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go/Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -345,7 +345,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -338,7 +338,7 @@ jobs:
     needs: [ CreateRelease, UploadArtifacts ]
     steps:
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -346,7 +346,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -35,6 +35,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -333,10 +336,42 @@ jobs:
     runs-on: [ windows-latest ]
     needs: [ CreateRelease, UploadArtifacts ]
     steps:
+      - name: Read settings
+        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+
       - name: Update Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
           versionNumber: ${{ github.event.inputs.updateVersionNumber }}
           directCommit: ${{ github.event.inputs.directCommit }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -59,7 +59,7 @@ jobs:
           eventId: "DO0095"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -67,7 +67,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -28,6 +28,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -55,10 +58,42 @@ jobs:
           shell: powershell
           eventId: "DO0095"
 
+      - name: Read settings
+        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Test App'

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -59,7 +59,7 @@ jobs:
           eventId: "DO0095"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go/Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -67,7 +67,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -16,6 +16,9 @@ on:
         description: Direct COMMIT (Y/N)
         required: false
         default: 'N'
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        type: boolean
 
 permissions:
   contents: write
@@ -43,10 +46,42 @@ jobs:
           shell: powershell
           eventId: "DO0096"
 
+      - name: Read settings
+        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          get: keyVaultName,ghTokenWorkflowSecretName
+
+      - name: Read secrets
+        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        if: github.event.inputs.useGhTokenWorkflow == 'true'
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
+
+      - name: CalculateToken
+        id: CalculateToken
+        env:
+          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
+        run: |
+          if ($env:useGhTokenWorkflow -eq 'true') {
+            $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:GHTOKENWORKFLOW))
+          } else {
+            $ghToken = '${{ secrets.GITHUB_TOKEN }}'
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+
       - name: Increment Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
+          token: ${{ steps.CalculateToken.outputs.ghToken }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           versionNumber: ${{ github.event.inputs.versionNumber }}

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -47,7 +47,7 @@ jobs:
           eventId: "DO0096"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -55,7 +55,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -47,7 +47,7 @@ jobs:
           eventId: "DO0096"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@main
+        uses: microsoft/AL-Go/Actions/ReadSettings@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -55,7 +55,7 @@ jobs:
           get: keyVaultName,ghTokenWorkflowSecretName
 
       - name: Read secrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@main
+        uses: microsoft/AL-Go/Actions/ReadSecrets@main
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}


### PR DESCRIPTION
This is a fix for issue #555

AL-Go contains several workflows, which create a Pull Request or pushes code directly.
All (except Update AL-Go System Files) will use the GITHUB_TOKEN to create the PR or commit.
The problem using GITHUB_TOKEN is that is doesn't trigger a pull request build or a commit build.
This is by design: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

This PR adds a checkbox to all these actions allowing you to use the GhTokenWorkflow instead of the GITHUB_TOKEN.
