### PR TITLE
Bug in Create Online Development Environment

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -627,6 +627,13 @@ function ReadSettings {
     if ($settings.githubRunnerShell -eq "") {
         $settings.githubRunnerShell = $settings.shell
     }
+    # Check that gitHubRunnerShell and Shell is valid
+    if ($settings.githubRunnerShell -ne "powershell" -and $settings.githubRunnerShell -ne "pwsh") {
+        throw "Invalid value for setting: gitHubRunnerShell: $($settings.githubRunnerShell)"
+    }
+    if ($settings.shell -ne "powershell" -and $settings.shell -ne "pwsh") {
+        throw "Invalid value for setting: shell: $($settings.githubRunnerShell)"
+    }
     $settings
 }
 

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -17,7 +17,7 @@ $RepoSettingsFile = Join-Path '.github' 'AL-Go-Settings.json'
 $defaultCICDPushBranches = @( 'main', 'release/*', 'feature/*' )
 $defaultCICDPullRequestBranches = @( 'main' )
 $runningLocal = $local.IsPresent
-$defaultBcContainerHelperVersion = "https://github.com/freddydk/navcontainerhelper/archive/master.zip" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
+$defaultBcContainerHelperVersion = "preview" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
 $microsoftTelemetryConnectionString = "InstrumentationKey=84bd9223-67d4-4378-8590-9e4a46023be2;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/"
 
 $runAlPipelineOverrides = @(

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -17,7 +17,7 @@ $RepoSettingsFile = Join-Path '.github' 'AL-Go-Settings.json'
 $defaultCICDPushBranches = @( 'main', 'release/*', 'feature/*' )
 $defaultCICDPullRequestBranches = @( 'main' )
 $runningLocal = $local.IsPresent
-$defaultBcContainerHelperVersion = "" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
+$defaultBcContainerHelperVersion = "private" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
 $microsoftTelemetryConnectionString = "InstrumentationKey=84bd9223-67d4-4378-8590-9e4a46023be2;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/"
 
 $runAlPipelineOverrides = @(

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -17,7 +17,7 @@ $RepoSettingsFile = Join-Path '.github' 'AL-Go-Settings.json'
 $defaultCICDPushBranches = @( 'main', 'release/*', 'feature/*' )
 $defaultCICDPullRequestBranches = @( 'main' )
 $runningLocal = $local.IsPresent
-$defaultBcContainerHelperVersion = "private" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
+$defaultBcContainerHelperVersion = "https://github.com/freddydk/navcontainerhelper/archive/master.zip" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step
 $microsoftTelemetryConnectionString = "InstrumentationKey=84bd9223-67d4-4378-8590-9e4a46023be2;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/"
 
 $runAlPipelineOverrides = @(

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -350,8 +350,8 @@ try {
 
                     Write-Host "Replace URLs to actions repos first"
                     # Replace URL's to actions repository first
-                    $regex = "^https:\/\/raw\.githubusercontent\.com\/microsoft\/AL-Go-Actions\/$originalBranch(.*)$"
-                    $replace = "https://raw.githubusercontent.com/$($templateOwner)/AL-Go/$($templateBranch)/Actions`$1"
+                    $regex = "^(.*)https:\/\/raw\.githubusercontent\.com\/microsoft\/AL-Go-Actions\/$originalBranch(.*)$"
+                    $replace = "`$1https://raw.githubusercontent.com/$($templateOwner)/AL-Go/$($templateBranch)/Actions`$2"
                     $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
 
                     # Replace the owner and repo names in the workflow

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -330,9 +330,9 @@ try {
                     
                     # The Original Owner and Repo in the AL-Go repository are microsoft/AL-Go-Actions, microsoft/AL-Go-PTE and microsoft/AL-Go-AppSource
                     $originalOwnerAndRepo = @{
-                        "actionsRepo" = "microsoft\/AL-Go-Actions"
-                        "perTenantExtensionRepo" = "microsoft\/AL-Go-PTE"
-                        "appSourceAppRepo" = "microsoft\/AL-Go-AppSource"
+                        "actionsRepo" = "microsoft/AL-Go-Actions"
+                        "perTenantExtensionRepo" = "microsoft/AL-Go-PTE"
+                        "appSourceAppRepo" = "microsoft/AL-Go-AppSource"
                     }
                     # Original branch is always main
                     $originalBranch = "main"

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -325,10 +325,6 @@ try {
 
                 $srcContent = $srcContent.Replace('{TEMPLATEURL}', "$($templateUrl)@$($templateBranch)")
                 if ($directALGo) {
-                    if ($fileName -eq 'CreateOnlineDevelopmentEnvironment.yaml') {
-                        Write-Host $srcContent
-                    }
-
                     # If we are using the direct AL-Go repo, we need to change the owner and repo names in the workflow
                     $lines = $srcContent.Split("`n")
                     
@@ -348,7 +344,6 @@ try {
                         "appSourceAppRepo" = "AL-Go"
                     }
 
-                    Write-Host "Replace URLs to actions repos first"
                     # Replace URL's to actions repository first
                     $regex = "^(.*)https:\/\/raw\.githubusercontent\.com\/microsoft\/AL-Go-Actions\/$originalBranch(.*)$"
                     $replace = "`$1https://raw.githubusercontent.com/$($templateOwner)/AL-Go/$($templateBranch)/Actions`$2"
@@ -356,15 +351,11 @@ try {
 
                     # Replace the owner and repo names in the workflow
                     "actionsRepo","perTenantExtensionRepo","appSourceAppRepo" | ForEach-Object {
-                        Write-Host "Replace $($_)"
                         $regex = "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"
                         $replace = "`$1$($templateOwner)/$($templateRepos."$_")`$2$($templateBranch)`$3"
                         $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
                     }
                     $srcContent = $lines -join "`n"
-                    if ($fileName -eq 'CreateOnlineDevelopmentEnvironment.yaml') {
-                        Write-Host $srcContent
-                    }
                 }
 
                 $dstFile = Join-Path $dstFolder $fileName

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -325,6 +325,10 @@ try {
 
                 $srcContent = $srcContent.Replace('{TEMPLATEURL}', "$($templateUrl)@$($templateBranch)")
                 if ($directALGo) {
+                    if ($fileName -eq 'CreateOnlineDevelopmentEnvironment.yaml') {
+                        Write-Host $srcContent
+                    }
+
                     # If we are using the direct AL-Go repo, we need to change the owner and repo names in the workflow
                     $lines = $srcContent.Split("`n")
                     
@@ -358,6 +362,9 @@ try {
                         $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
                     }
                     $srcContent = $lines -join "`n"
+                    if ($fileName -eq 'CreateOnlineDevelopmentEnvironment.yaml') {
+                        Write-Host $srcContent
+                    }
                 }
 
                 $dstFile = Join-Path $dstFolder $fileName

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -344,6 +344,11 @@ try {
                         "appSourceAppRepo" = "AL-Go"
                     }
 
+                    # Replace URL's to actions repository first
+                    $regex = "^https://raw.githubusercontent.com/microsoft/AL-Go-Actions/$originalBranch(.*)$"
+                    $replace = "https://raw.githubusercontent.com/$($templateOwner)/AL-Go/$($templateBranch)/Actions`$1"
+                    $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
+
                     # Replace the owner and repo names in the workflow
                     "actionsRepo","perTenantExtensionRepo","appSourceAppRepo" | ForEach-Object {
                         $regex = "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -330,9 +330,9 @@ try {
                     
                     # The Original Owner and Repo in the AL-Go repository are microsoft/AL-Go-Actions, microsoft/AL-Go-PTE and microsoft/AL-Go-AppSource
                     $originalOwnerAndRepo = @{
-                        "actionsRepo" = "microsoft/AL-Go-Actions"
-                        "perTenantExtensionRepo" = "microsoft/AL-Go-PTE"
-                        "appSourceAppRepo" = "microsoft/AL-Go-AppSource"
+                        "actionsRepo" = "microsoft\/AL-Go-Actions"
+                        "perTenantExtensionRepo" = "microsoft\/AL-Go-PTE"
+                        "appSourceAppRepo" = "microsoft\/AL-Go-AppSource"
                     }
                     # Original branch is always main
                     $originalBranch = "main"
@@ -344,13 +344,15 @@ try {
                         "appSourceAppRepo" = "AL-Go"
                     }
 
+                    Write-Host "Replace URLs to actions repos first"
                     # Replace URL's to actions repository first
-                    $regex = "^https://raw.githubusercontent.com/microsoft/AL-Go-Actions/$originalBranch(.*)$"
+                    $regex = "^https:\/\/raw\.githubusercontent\.com\/microsoft\/AL-Go-Actions\/$originalBranch(.*)$"
                     $replace = "https://raw.githubusercontent.com/$($templateOwner)/AL-Go/$($templateBranch)/Actions`$1"
                     $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
 
                     # Replace the owner and repo names in the workflow
                     "actionsRepo","perTenantExtensionRepo","appSourceAppRepo" | ForEach-Object {
+                        Write-Host "Replace $($_)"
                         $regex = "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"
                         $replace = "`$1$($templateOwner)/$($templateRepos."$_")`$2$($templateBranch)`$3"
                         $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }

--- a/Actions/CreateDevelopmentEnvironment/CreateDevelopmentEnvironment.ps1
+++ b/Actions/CreateDevelopmentEnvironment/CreateDevelopmentEnvironment.ps1
@@ -7,6 +7,8 @@ Param(
     [string] $parentTelemetryScopeJson = '7b7d',
     [Parameter(HelpMessage = "Name of the online environment", Mandatory = $true)]
     [string] $environmentName,
+    [Parameter(HelpMessage = "Project name if the repository is setup for multiple projects", Mandatory = $false)]
+    [string] $project = '.',
     [Parameter(HelpMessage = "Admin center API credentials", Mandatory = $false)]
     [string] $adminCenterApiCredentials,
     [Parameter(HelpMessage = "Reuse environment if it exists", Mandatory = $false)]
@@ -49,7 +51,7 @@ try {
         -environmentName $environmentName `
         -reUseExistingEnvironment:$reUseExistingEnvironment `
         -baseFolder $repoBaseFolder `
-        -project '.' `
+        -project $project `
         -bcContainerHelperPath $bcContainerHelperPath `
         -adminCenterApiCredentials ($adminCenterApiCredentials | ConvertFrom-Json | ConvertTo-HashTable)
 

--- a/Actions/CreateDevelopmentEnvironment/CreateDevelopmentEnvironment.ps1
+++ b/Actions/CreateDevelopmentEnvironment/CreateDevelopmentEnvironment.ps1
@@ -49,6 +49,7 @@ try {
         -environmentName $environmentName `
         -reUseExistingEnvironment:$reUseExistingEnvironment `
         -baseFolder $repoBaseFolder `
+        -project '.' `
         -bcContainerHelperPath $bcContainerHelperPath `
         -adminCenterApiCredentials ($adminCenterApiCredentials | ConvertFrom-Json | ConvertTo-HashTable)
 

--- a/Actions/CreateDevelopmentEnvironment/action.yaml
+++ b/Actions/CreateDevelopmentEnvironment/action.yaml
@@ -23,6 +23,10 @@ inputs:
   environmentName:
     description: Name of the online environment
     required: true
+  project:
+    description: Project name if the repository is setup for multiple projects
+    required: false
+    default: '.'
   adminCenterApiCredentials:
     description: Admin center API credentials
     required: false
@@ -49,11 +53,12 @@ runs:
         _token: ${{ inputs.token }}
         _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
         _environmentName: ${{ inputs.environmentName }}
+        _project: ${{ inputs.project }}
         _adminCenterApiCredentials: ${{ inputs.adminCenterApiCredentials }}
         _reUseExistingEnvironment: ${{ inputs.reUseExistingEnvironment }}
         _updateBranch: ${{ inputs.updateBranch }}
         _directCommit: ${{ inputs.directCommit }}
-      run: try { ${{ github.action_path }}/CreateDevelopmentEnvironment.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -environmentName $ENV:_environmentName -adminCenterApiCredentials $ENV:_adminCenterApiCredentials -reUseExistingEnvironment ($ENV:_reUseExistingEnvironment -eq 'Y') -updateBranch $ENV:_updateBranch -directCommit ($ENV:_directCommit -eq 'Y') } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
+      run: try { ${{ github.action_path }}/CreateDevelopmentEnvironment.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -environmentName $ENV:_environmentName -project $ENV:_project -adminCenterApiCredentials $ENV:_adminCenterApiCredentials -reUseExistingEnvironment ($ENV:_reUseExistingEnvironment -eq 'Y') -updateBranch $ENV:_updateBranch -directCommit ($ENV:_directCommit -eq 'Y') } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal
   color: blue

--- a/Internal/Deploy.ps1
+++ b/Internal/Deploy.ps1
@@ -321,7 +321,7 @@ try {
                 }
                 if ($_.Name -eq "AL-Go-Helper.ps1" -and ($config.PSObject.Properties.Name -eq "defaultBcContainerHelperVersion") -and ($config.defaultBcContainerHelperVersion)) {
                     # replace defaultBcContainerHelperVersion (even if a version is set)
-                    $lines = $lines | ForEach-Object { $_ -replace '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)" # (.*)$', "`$1`$defaultBcContainerHelperVersion`$2=`$3""$defaultBcContainerHelperVersion"" # `$5" }
+                    $lines = $lines | ForEach-Object { $_ -replace '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)" # (.*)$', "`$1`$defaultBcContainerHelperVersion`$2=`$3""$($config.defaultBcContainerHelperVersion)"" # `$5" }
                 }
                 [System.IO.File]::WriteAllText($dstFile, "$($lines -join "`n")`n")
             }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -9,6 +9,9 @@ Issue 558 CI/CD attempts to deploy from feature branch
 Issue 559 Changelog includes wrong commits
 Publish to AppSource fails if publisher name or app name contains national or special characters
 Issue 598 Cleanup during flush if build pipeline doesn't cleanup properly
+Create Online Development environment workflow failed in AppSource template unless AppSourceCopMandatoryAffixes is defined in repository settings file
+Create Online Development environment workflow didn't have a project parameter and only worked for single project repositories
+Create Online Development environment workflow didn't work if runs-on was set to Linux
 
 ### New Settings
 - `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -34,11 +34,13 @@ env:
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
-  Initialize:
+  Initialization:
     runs-on: [ windows-latest ]
     outputs:
       deviceCode: ${{ steps.authenticate.outputs.deviceCode }}
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+      githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
+      githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -90,11 +92,14 @@ jobs:
           }
 
   CreateDevelopmentEnvironment:
-    runs-on: [ windows-latest ]
+    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
+    defaults:
+      run:
+        shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
     name: Create Development Environment
-    needs: [ Initialize ]
+    needs: [ Initialization ]
     env:
-      deviceCode: ${{ needs.Initialize.outputs.deviceCode }}
+      deviceCode: ${{ needs.Initialization.outputs.deviceCode }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -103,7 +108,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -111,7 +116,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           settingsJson: ${{ env.Settings }}
           secrets: 'adminCenterApiCredentials'
 
@@ -126,7 +131,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
           project: ${{ github.event.inputs.project }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}
@@ -139,4 +144,4 @@ jobs:
         with:
           shell: powershell
           eventId: "DO0093"
-          telemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -53,6 +53,7 @@ jobs:
           eventId: "DO0093"
 
       - name: Read settings
+        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -1,6 +1,6 @@
 name: ' Create Online Dev. Environment'
 
-run-name: "Create Online Dev. Environment for [${{ github.ref_name }}]"
+run-name: "Create Online Dev. Environment for [${{ github.ref_name }} / ${{ github.event.inputs.project }}]"
 
 on:
   workflow_dispatch:

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -5,6 +5,10 @@ run-name: "Create Online Dev. Environment for [${{ github.ref_name }}]"
 on:
   workflow_dispatch:
     inputs:
+      project:
+        description: Project name if the repository is setup for multiple projects
+        required: false
+        default: '.'
       environmentName:
         description: Name of the online environment
         required: true
@@ -124,6 +128,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
+          project: ${{ github.event.inputs.project }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}
           directCommit: ${{ github.event.inputs.directCommit }}
           adminCenterApiCredentials: ${{ env.adminCenterApiCredentials }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -34,11 +34,13 @@ env:
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
-  Initialize:
+  Initialization:
     runs-on: [ windows-latest ]
     outputs:
       deviceCode: ${{ steps.authenticate.outputs.deviceCode }}
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+      githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
+      githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -90,11 +92,14 @@ jobs:
           }
 
   CreateDevelopmentEnvironment:
-    runs-on: [ windows-latest ]
+    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
+    defaults:
+      run:
+        shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
     name: Create Development Environment
-    needs: [ Initialize ]
+    needs: [ Initialization ]
     env:
-      deviceCode: ${{ needs.Initialize.outputs.deviceCode }}
+      deviceCode: ${{ needs.Initialization.outputs.deviceCode }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -103,7 +108,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -111,7 +116,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           settingsJson: ${{ env.Settings }}
           secrets: 'adminCenterApiCredentials'
 
@@ -126,7 +131,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
           project: ${{ github.event.inputs.project }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}
@@ -139,4 +144,4 @@ jobs:
         with:
           shell: powershell
           eventId: "DO0093"
-          telemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -53,6 +53,7 @@ jobs:
           eventId: "DO0093"
 
       - name: Read settings
+        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -1,6 +1,6 @@
 name: ' Create Online Dev. Environment'
 
-run-name: "Create Online Dev. Environment for [${{ github.ref_name }}]"
+run-name: "Create Online Dev. Environment for [${{ github.ref_name }} / ${{ github.event.inputs.project }}]"
 
 on:
   workflow_dispatch:

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -5,6 +5,10 @@ run-name: "Create Online Dev. Environment for [${{ github.ref_name }}]"
 on:
   workflow_dispatch:
     inputs:
+      project:
+        description: Project name if the repository is setup for multiple projects
+        required: false
+        default: '.'
       environmentName:
         description: Name of the online environment
         required: true
@@ -124,6 +128,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
+          project: ${{ github.event.inputs.project }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}
           directCommit: ${{ github.event.inputs.directCommit }}
           adminCenterApiCredentials: ${{ env.adminCenterApiCredentials }}


### PR DESCRIPTION
This PR contains 3 bug fixes:

1. You cannot specify a project in Create Online Development Environment, meaning that it only works in single project repositories and in AppSource Apps it will (in v3.1) give an error, because it doesn't read the project settings file:
![image](https://github.com/microsoft/AL-Go/assets/10775043/12750732-c2ab-46f1-ae63-d9f7c9b6d6c7)
https://github.com/freddydk/bcsamples-bingmaps.appsource/actions/runs/5634571925

2. When fixing this bug, I found that the new development mechanism (freddydk/AL-Go@branch) doesn't get the URL for downloading AL-Go-Helper correct. The Update AL-Go System Files will update the URL as this:
    - https://raw.githubusercontent.com/freddydk/AL-Go/Actions/branch/AL-Go-Helper.ps1
where it should be:
    - https://raw.githubusercontent.com/freddydk/AL-Go/branch/Actions/AL-Go-Helper.ps1

3. Next problem I ran into was that Create Online Development environment was using the runson setting for GitHub runner - it should be using GitHubRunner, since it builds and deploys the apps to the environment.
https://github.com/freddydk/bcsamples-bingmaps.appsource/actions/runs/5634826649

With these fixes, it works
https://github.com/freddydk/bcsamples-bingmaps.appsource/actions/runs/5635363958/job/15266272300