### PR TITLE
Remove settings json construct from ENV

### DIFF
--- a/.github/workflows/CleanupTempRepos.yaml
+++ b/.github/workflows/CleanupTempRepos.yaml
@@ -45,7 +45,7 @@ jobs:
           if ($orgmap.PSObject.Properties.Name -eq $githubOwner) {
             $githubOwner = $orgmap."$githubOwner"
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "githubOwner=$githubOwner"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "githubOwner=$githubOwner"
           Write-Host "githubOwner=$githubOwner"
 
   RemoveRepositories:

--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -81,9 +81,9 @@ jobs:
           if ($githubOwner -eq $ENV:GITHUB_REPOSITORY_OWNER) {
             $maxParallel = 8
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "maxParallel=$maxParallel"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "maxParallel=$maxParallel"
           Write-Host "maxParallel=$maxParallel"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "githubOwner=$githubOwner"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "githubOwner=$githubOwner"
           Write-Host "githubOwner=$githubOwner"
 
   SetupRepositories:
@@ -150,7 +150,7 @@ jobs:
             "max-parallel" = $maxParallel
             "fail-fast" = $false
           } | ConvertTo-Json -depth 99 -compress
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "testruns=$testrunsJson"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "testruns=$testrunsJson"
           Write-Host "testruns=$testrunsJson"
 
           $releases = @(gh release list --repo microsoft/AL-Go | ForEach-Object { $_.split("`t")[0] })
@@ -161,7 +161,7 @@ jobs:
             "max-parallel" = $maxParallel
             "fail-fast" = $false
           } | ConvertTo-Json -depth 99 -compress
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "releases=$releasesJson"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "releases=$releasesJson"
           Write-Host "releases=$releasesJson"
 
           $scenariosJson = @{
@@ -171,7 +171,7 @@ jobs:
             "max-parallel" = $maxParallel
             "fail-fast" = $false
           } | ConvertTo-Json -depth 99 -compress
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "scenarios=$scenariosJson"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "scenarios=$scenariosJson"
           Write-Host "scenarios=$scenariosJson"
 
   Scenario:
@@ -189,7 +189,7 @@ jobs:
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $reponame = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName())
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "repoName='$repoName'"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "repoName='$repoName'"
           Write-Host "repoName='$repoName'"
           Write-Host "Repo URL: https://github.com/${{ needs.Check.outputs.githubowner }}/$repoName"
 
@@ -231,11 +231,11 @@ jobs:
           else {
             $template = '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "adminCenterApiCredentials='$adminCenterApiCredentials'"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "licenseFileUrl='$licenseFileUrl'"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "template='$template'"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "adminCenterApiCredentials='$adminCenterApiCredentials'"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "licenseFileUrl='$licenseFileUrl'"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "template='$template'"
           $reponame = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName())
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "repoName='$repoName'"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "repoName='$repoName'"
           Write-Host "repoName='$repoName'"
           Write-Host "Repo URL: https://github.com/${{ needs.Check.outputs.githubowner }}/$repoName"
 
@@ -275,11 +275,11 @@ jobs:
             $template = '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}'
             $contentPath = 'pte'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "licenseFileUrl='$licenseFileUrl'"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "template='$template'"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "contentPath='$contentPath'"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "licenseFileUrl='$licenseFileUrl'"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "template='$template'"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "contentPath='$contentPath'"
           $reponame = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName())
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "repoName='$repoName'"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "repoName='$repoName'"
           Write-Host "repoName='$repoName'"
           Write-Host "Repo URL: https://github.com/${{ needs.Check.outputs.githubowner }}/$repoName"
 

--- a/Actions/AnalyzeTests/AnalyzeTests.ps1
+++ b/Actions/AnalyzeTests/AnalyzeTests.ps1
@@ -29,7 +29,7 @@ try {
         $testResults = [xml](Get-Content "$project\TestResults.xml")
         $testResultSummary = GetTestResultSummary -testResults $testResults -includeFailures 50
 
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "TestResultMD=$testResultSummary"
+        Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "TestResultMD=$testResultSummary"
         Write-Host "TestResultMD=$testResultSummary"
     
         Add-Content -path $ENV:GITHUB_STEP_SUMMARY -value "$($testResultSummary.Replace("\n","`n"))`n"

--- a/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
+++ b/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
@@ -13,7 +13,7 @@ Param(
 
 function Set-EnvVariable([string] $name, [string] $value) {
     Write-Host "Assigning $value to $name"
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "$name=$value"
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "$name=$value" -Encoding UTF8
     Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
 }
 

--- a/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
+++ b/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
@@ -13,8 +13,8 @@ Param(
 
 function Set-EnvVariable([string] $name, [string] $value) {
     Write-Host "Assigning $value to $name"
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "$name=$value" -Encoding UTF8
-    Add-Content -Path $env:GITHUB_ENV -Value "$name=$value" -Encoding UTF8
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "$name=$value"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$name=$value"
 }
 
 $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0

--- a/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
+++ b/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
@@ -19,8 +19,13 @@ function Set-EnvVariable([string] $name, [string] $value) {
 
 $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
 
-Write-Host $settingsJson
-$settings = $settingsJson | ConvertFrom-Json
+# Support potentially base64 encoded settings
+try {
+    $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($settingsJson)) | ConvertFrom-Json | ConvertTo-HashTable
+}
+catch {
+    $settings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
+}
 
 if ($project -eq ".") { 
   $project = $settings.repoName 

--- a/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
+++ b/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
@@ -21,10 +21,10 @@ $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-S
 
 # Support potentially base64 encoded settings
 try {
-    $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($settingsJson)) | ConvertFrom-Json | ConvertTo-HashTable
+    $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($settingsJson)) | ConvertFrom-Json
 }
 catch {
-    $settings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
+    $settings = $settingsJson | ConvertFrom-Json
 }
 
 if ($project -eq ".") { 

--- a/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
+++ b/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
@@ -14,7 +14,7 @@ Param(
 function Set-EnvVariable([string] $name, [string] $value) {
     Write-Host "Assigning $value to $name"
     Add-Content -Path $env:GITHUB_OUTPUT -Value "$name=$value" -Encoding UTF8
-    Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
+    Add-Content -Path $env:GITHUB_ENV -Value "$name=$value" -Encoding UTF8
 }
 
 $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0

--- a/Actions/CalculateArtifactNames/action.yaml
+++ b/Actions/CalculateArtifactNames/action.yaml
@@ -59,12 +59,11 @@ runs:
       shell: ${{ inputs.shell }}
       id: calculateartifactnames
       env:
-        _settingsJson: ${{ inputs.settingsJson }}
         _project: ${{ inputs.project }}
         _buildMode: ${{ inputs.buildMode }}
         _branchName: ${{ inputs.branchName }}
         _suffix: ${{ inputs.suffix }}
-      run: try { ${{ github.action_path }}/CalculateArtifactNames.ps1 -settingsJson $ENV:_settingsJson -project $ENV:_project -buildMode $ENV:_buildMode -branchName $ENV:_branchName -suffix $ENV:_suffix } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("*",'').Replace("*",' ')))"; exit 1 }
+      run: try { ${{ github.action_path }}/CalculateArtifactNames.ps1 -settingsJson '${{ inputs.settingsJson }}' -project $ENV:_project -buildMode $ENV:_buildMode -branchName $ENV:_branchName -suffix $ENV:_suffix } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("*",'').Replace("*",' ')))"; exit 1 }
 branding:
   icon: terminal
   color: blue

--- a/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
+++ b/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
@@ -42,7 +42,7 @@ try {
             }
         }
     }
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "releaseBranch=$releaseBranch"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "releaseBranch=$releaseBranch"
     Write-Host "releaseBranch=$releaseBranch"
 
     $latestRelease = GetLatestRelease -token $token -api_url $ENV:GITHUB_API_URL -repository $ENV:GITHUB_REPOSITORY -ref $ENV:GITHUB_REF_NAME
@@ -66,7 +66,7 @@ try {
         OutputWarning -message "You can modify the release note from the release page later."
         $releaseNotes = ""
     }
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "releaseNotes=$releaseNotes"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "releaseNotes=$releaseNotes"
     Write-Host "releaseNotes=$releaseNotes"
 
     TrackTrace -telemetryScope $telemetryScope

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
@@ -43,7 +43,7 @@ try {
     Add-Content -Path $env:GITHUB_OUTPUT -Value "ArtifactCacheKey=$artifactCacheKey"
     Write-Host "ArtifactCacheKey=$artifactCacheKey"
     $outSettingsJson = $projectSettings | ConvertTo-Json -Depth 99 -Compress
-    Add-Content -Path $env:GITHUB_ENV -Value "Settings=$OutSettingsJson"
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
     Write-Host "SettingsJson=$outSettingsJson"
     Add-Content -Path $env:GITHUB_ENV -Value "artifact=$artifactUrl"
     Write-Host "Artifact=$artifactUrl"

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
@@ -42,6 +42,7 @@ try {
     Write-Host "ArtifactUrl=$artifactUrl"
     Add-Content -Path $env:GITHUB_OUTPUT -Value "ArtifactCacheKey=$artifactCacheKey"
     Write-Host "ArtifactCacheKey=$artifactCacheKey"
+
     $outSettingsJson = $projectSettings | ConvertTo-Json -Depth 99 -Compress
     Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
     Write-Host "SettingsJson=$outSettingsJson"

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
@@ -53,13 +53,11 @@ try {
     Add-Content -Path $env:GITHUB_OUTPUT -Value "ArtifactCacheKey=$artifactCacheKey"
     Write-Host "- ArtifactCacheKey=$artifactCacheKey"
     $outSettingsJson = $projectSettings | ConvertTo-Json -Depth 99 -Compress
-    if ($useBase64) {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson)))"
-    }
-    else {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
-    }
     Write-Host "- SettingsJson=$outSettingsJson"
+    if ($useBase64) {
+        $outSettingsJson = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson))
+    }
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
 
 #    Write-Host "ENV:"
 #    Add-Content -Path $env:GITHUB_ENV -Value "artifact=$artifactUrl"

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
@@ -38,16 +38,18 @@ try {
 
     #region Action: Output
     # Set output variables
+    Write-Host "OUTPUTS:"
     Add-Content -Path $env:GITHUB_OUTPUT -Value "ArtifactUrl=$artifactUrl"
-    Write-Host "ArtifactUrl=$artifactUrl"
+    Write-Host "- ArtifactUrl=$artifactUrl"
     Add-Content -Path $env:GITHUB_OUTPUT -Value "ArtifactCacheKey=$artifactCacheKey"
-    Write-Host "ArtifactCacheKey=$artifactCacheKey"
-
+    Write-Host "- ArtifactCacheKey=$artifactCacheKey"
     $outSettingsJson = $projectSettings | ConvertTo-Json -Depth 99 -Compress
     Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
-    Write-Host "SettingsJson=$outSettingsJson"
-    Add-Content -Path $env:GITHUB_ENV -Value "artifact=$artifactUrl"
-    Write-Host "Artifact=$artifactUrl"
+    Write-Host "- SettingsJson=$outSettingsJson"
+
+#    Write-Host "ENV:"
+#    Add-Content -Path $env:GITHUB_ENV -Value "artifact=$artifactUrl"
+#    Write-Host "Artifact=$artifactUrl"
     #endregion
 
     TrackTrace -telemetryScope $telemetryScope

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
@@ -28,11 +28,13 @@ try {
     $insiderSasToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.insiderSasToken))
 
     # Support potentially base64 encoded settings
+    $useBase64 = $true
     try {
         $projectSettings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($settingsJson)) | ConvertFrom-Json | ConvertTo-HashTable
     }
     catch {
         $projectSettings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
+        $useBase64 = $false
     }
     $projectSettings = AnalyzeRepo -settings $projectSettings -project $project -doNotCheckArtifactSetting -doNotIssueWarnings
     $artifactUrl = Determine-ArtifactUrl -projectSettings $projectSettings -insiderSasToken $insiderSasToken
@@ -51,7 +53,12 @@ try {
     Add-Content -Path $env:GITHUB_OUTPUT -Value "ArtifactCacheKey=$artifactCacheKey"
     Write-Host "- ArtifactCacheKey=$artifactCacheKey"
     $outSettingsJson = $projectSettings | ConvertTo-Json -Depth 99 -Compress
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
+    if ($useBase64) {
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
+    }
+    else {
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettings"
+    }
     Write-Host "- SettingsJson=$outSettingsJson"
 
 #    Write-Host "ENV:"

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
@@ -54,10 +54,10 @@ try {
     Write-Host "- ArtifactCacheKey=$artifactCacheKey"
     $outSettingsJson = $projectSettings | ConvertTo-Json -Depth 99 -Compress
     if ($useBase64) {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson)))"
     }
     else {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettings"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
     }
     Write-Host "- SettingsJson=$outSettingsJson"
 

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.Action.ps1
@@ -56,6 +56,7 @@ try {
     Write-Host "- SettingsJson=$outSettingsJson"
     if ($useBase64) {
         $outSettingsJson = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson))
+        Write-Host "::add-mask::$outSettingsJson"
     }
     Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
 

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
@@ -50,9 +50,9 @@ try {
     #region Action: Output
     # Set output variables
     Write-Host "OUTPUTS:"
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "ArtifactUrl=$artifactUrl"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ArtifactUrl=$artifactUrl"
     Write-Host "- ArtifactUrl=$artifactUrl"
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "ArtifactCacheKey=$artifactCacheKey"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ArtifactCacheKey=$artifactCacheKey"
     Write-Host "- ArtifactCacheKey=$artifactCacheKey"
     $outSettingsJson = $projectSettings | ConvertTo-Json -Depth 99 -Compress
     Write-Host "- SettingsJson=$outSettingsJson"
@@ -60,7 +60,7 @@ try {
         $outSettingsJson = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson))
         Write-Host "::add-mask::$outSettingsJson"
     }
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
     #endregion
 
     TrackTrace -telemetryScope $telemetryScope

--- a/Actions/DetermineArtifactUrl/action.yaml
+++ b/Actions/DetermineArtifactUrl/action.yaml
@@ -22,6 +22,9 @@ inputs:
     required: false
     default: '{"insiderSasToken":""}'
 outputs:
+  SettingsJson:
+    description: Settings in compressed Json format
+    value: ${{ steps.determineArtifactUrl.outputs.SettingsJson }}
   ArtifactUrl:
     description: The ArtifactUrl to use for building this project
     value: ${{ steps.determineArtifactUrl.outputs.ArtifactUrl }}

--- a/Actions/DetermineArtifactUrl/action.yaml
+++ b/Actions/DetermineArtifactUrl/action.yaml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: '.'
   settingsJson:
-    description: Settings from repository in compressed Json format
+    description: Settings from repository in compressed Json format (base64 encoded)
     required: false
     default: '{"appBuild":0,"appRevision":0}'
   secretsJson:
@@ -23,7 +23,7 @@ inputs:
     default: '{"insiderSasToken":""}'
 outputs:
   SettingsJson:
-    description: Settings in compressed Json format
+    description: Settings (with modified artifact setting) in compressed Json format (base64 encoded)
     value: ${{ steps.determineArtifactUrl.outputs.SettingsJson }}
   ArtifactUrl:
     description: The ArtifactUrl to use for building this project
@@ -34,16 +34,14 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Determine ArtifactUrl
+    - name: run
       shell: ${{ inputs.shell }}
       id: determineArtifactUrl
       env:
         _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
         _project: ${{ inputs.project }}
         _secretsJson: ${{ inputs.secretsJson }}
-      run: try { 
-          ${{ github.action_path }}/DetermineArtifactUrl.Action.ps1 -parentTelemetryScopeJson $env:_parentTelemetryScopeJson  -project $ENV:_project -settingsJson '${{ inputs.settingsJson }}' -secretsJson $ENV:_secretsJson
-        } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
+      run: try { ${{ github.action_path }}/DetermineArtifactUrl.ps1 -parentTelemetryScopeJson $env:_parentTelemetryScopeJson -project $ENV:_project -settingsJson '${{ inputs.settingsJson }}' -secretsJson $ENV:_secretsJson } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal
   color: blue

--- a/Actions/DetermineArtifactUrl/action.yaml
+++ b/Actions/DetermineArtifactUrl/action.yaml
@@ -40,10 +40,9 @@ runs:
       env:
         _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
         _project: ${{ inputs.project }}
-        _settingsJson: ${{ inputs.settingsJson }}
         _secretsJson: ${{ inputs.secretsJson }}
       run: try { 
-          ${{ github.action_path }}/DetermineArtifactUrl.Action.ps1 -parentTelemetryScopeJson $env:_parentTelemetryScopeJson  -project $ENV:_project -settingsJson $ENV:_settingsJson -secretsJson $ENV:_secretsJson
+          ${{ github.action_path }}/DetermineArtifactUrl.Action.ps1 -parentTelemetryScopeJson $env:_parentTelemetryScopeJson  -project $ENV:_project -settingsJson '${{ inputs.settingsJson }}' -secretsJson $ENV:_secretsJson
         } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
@@ -41,9 +41,10 @@ try {
     Add-Content -Path $env:GITHUB_OUTPUT -Value "ProjectDependenciesJson=$projectDependenciesJson"
     Add-Content -Path $env:GITHUB_OUTPUT -Value "BuildOrderJson=$buildOrderJson"    
     
-    Write-Host "ProjectsJson=$projectsJson"
-    Write-Host "ProjectDependenciesJson=$projectDependenciesJson"
-    Write-Host "BuildOrderJson=$buildOrderJson"
+    Write-Host "OUTPUTS:"
+    Write-Host "- ProjectsJson=$projectsJson"
+    Write-Host "- ProjectDependenciesJson=$projectDependenciesJson"
+    Write-Host "- BuildOrderJson=$buildOrderJson"
     #endregion
 
     TrackTrace -telemetryScope $telemetryScope

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
@@ -37,9 +37,9 @@ try {
     $buildOrderJson = ConvertTo-Json $buildOrder -Depth 99 -Compress
     
     # Set output variables
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "ProjectsJson=$projectsJson"
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "ProjectDependenciesJson=$projectDependenciesJson"
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "BuildOrderJson=$buildOrderJson"    
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ProjectsJson=$projectsJson"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ProjectDependenciesJson=$projectDependenciesJson"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "BuildOrderJson=$buildOrderJson"    
     
     Write-Host "OUTPUTS:"
     Write-Host "- ProjectsJson=$projectsJson"

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -128,6 +128,7 @@ try {
     Write-Host "- SettingsJson=$outSettingsJson"
     if ($useBase64) {
         $outSettingsJson = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson))
+        Write-Host "::add-mask::$outSettingsJson"
     }
     Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
 

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -46,12 +46,6 @@ try {
         $settings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
         $useBase64 = $false
     }
-    
-    if ($settings.ContainsKey('repoName')) {
-        Write-Host "-------------"
-        Write-Host $settings.repoName
-        Write-Host "-------------"
-    }
 
     $outSettings = $settings
     $keyVaultName = $settings.keyVaultName

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -125,13 +125,11 @@ try {
 
     Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
-    if ($useBase64) {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson)))"
-    }
-    else {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
-    }
     Write-Host "- SettingsJson=$outSettingsJson"
+    if ($useBase64) {
+        $outSettingsJson = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson))
+    }
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
 
     $outSecretsJson = $outSecrets | ConvertTo-Json -Compress
     Add-Content -Path $env:GITHUB_ENV -Value "RepoSecrets=$outSecretsJson"

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -113,11 +113,12 @@ try {
         }) -join ', ')"
     }
 
-    $outSecretsJson = $outSecrets | ConvertTo-Json -Compress
-    Add-Content -Path $env:GITHUB_ENV -Value "RepoSecrets=$outSecretsJson"
-
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
     Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$OutSettingsJson"
+    Write-Host "SettingsJson=$outSettingsJson"
+
+    $outSecretsJson = $outSecrets | ConvertTo-Json -Compress
+    Add-Content -Path $env:GITHUB_ENV -Value "RepoSecrets=$outSecretsJson"
 
     TrackTrace -telemetryScope $telemetryScope
 }

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -117,7 +117,7 @@ try {
     Add-Content -Path $env:GITHUB_ENV -Value "RepoSecrets=$outSecretsJson"
 
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
-    Add-Content -Path $env:GITHUB_ENV -Value "Settings=$OutSettingsJson"
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$OutSettingsJson"
 
     TrackTrace -telemetryScope $telemetryScope
 }

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -44,6 +44,10 @@ try {
         $settings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
     }
     
+    Write-Host "-------------"
+    Write-Host $settings.repoName
+    Write-Host "-------------"
+
     $outSettings = $settings
     $keyVaultName = $settings.keyVaultName
     if ([string]::IsNullOrEmpty($keyVaultName) -and (IsKeyVaultSet)) {

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -95,7 +95,7 @@ try {
                     }
                 }
                 $base64value = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($value))
-                Add-Content -Path $env:GITHUB_ENV -Value "$envVar=$base64value"
+                Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$envVar=$base64value"
                 $outSecrets += @{ "$envVar" = $base64value }
                 Write-Host "$envVar successfully read from secret $secret"
                 $secretsCollection.Remove($_)
@@ -133,10 +133,10 @@ try {
         $outSettingsJson = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson))
         Write-Host "::add-mask::$outSettingsJson"
     }
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
 
     $outSecretsJson = $outSecrets | ConvertTo-Json -Compress
-    Add-Content -Path $env:GITHUB_ENV -Value "RepoSecrets=$outSecretsJson"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "RepoSecrets=$outSecretsJson"
 
     #endregion
 

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -42,6 +42,7 @@ try {
         $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($settingsJson)) | ConvertFrom-Json | ConvertTo-HashTable
     }
     catch {
+        Write-Host $settingsJson
         $settings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
         $useBase64 = $false
     }

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -130,10 +130,10 @@ try {
     Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
     if ($useBase64) {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson)))"
     }
     else {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettings"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
     }
     Write-Host "- SettingsJson=$outSettingsJson"
 

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -38,10 +38,6 @@ try {
     $outSecrets = [ordered]@{}
     $settings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
     
-    Write-Host "----------"
-    Write-Host $settings.repoName
-    Write-Host "----------"
-    
     $outSettings = $settings
     $keyVaultName = $settings.keyVaultName
     if ([string]::IsNullOrEmpty($keyVaultName) -and (IsKeyVaultSet)) {
@@ -118,9 +114,10 @@ try {
         }) -join ', ')"
     }
 
+    Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
     Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$OutSettingsJson"
-    Write-Host "SettingsJson=$outSettingsJson"
+    Write-Host "- SettingsJson=$outSettingsJson"
 
     $outSecretsJson = $outSecrets | ConvertTo-Json -Compress
     Add-Content -Path $env:GITHUB_ENV -Value "RepoSecrets=$outSecretsJson"

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -37,11 +37,13 @@ try {
 
     $outSecrets = [ordered]@{}
     # Support potentially base64 encoded settings
+    $useBase64 = $true
     try {
         $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($settingsJson)) | ConvertFrom-Json | ConvertTo-HashTable
     }
     catch {
         $settings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
+        $useBase64 = $false
     }
     
     Write-Host "-------------"
@@ -126,7 +128,12 @@ try {
 
     Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
+    if ($useBase64) {
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
+    }
+    else {
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettings"
+    }
     Write-Host "- SettingsJson=$outSettingsJson"
 
     $outSecretsJson = $outSecrets | ConvertTo-Json -Compress

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -37,6 +37,11 @@ try {
 
     $outSecrets = [ordered]@{}
     $settings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
+    
+    Write-Host "----------"
+    Write-Host $settings.repoName
+    Write-Host "----------"
+    
     $outSettings = $settings
     $keyVaultName = $settings.keyVaultName
     if ([string]::IsNullOrEmpty($keyVaultName) -and (IsKeyVaultSet)) {

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -47,9 +47,11 @@ try {
         $useBase64 = $false
     }
     
-    Write-Host "-------------"
-    Write-Host $settings.repoName
-    Write-Host "-------------"
+    if ($settings.ContainsKey('repoName')) {
+        Write-Host "-------------"
+        Write-Host $settings.repoName
+        Write-Host "-------------"
+    }
 
     $outSettings = $settings
     $keyVaultName = $settings.keyVaultName

--- a/Actions/ReadSecrets/ReadSecretsHelper.psm1
+++ b/Actions/ReadSecrets/ReadSecretsHelper.psm1
@@ -49,7 +49,7 @@ function GetGithubSecret {
         $value = $script:githubSecrets."$secret"
         if ($value) {
             MaskValue -key $secret -value $value
-            Add-Content -Path $env:GITHUB_ENV -Value "$envVar=$value"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$envVar=$value"
             return $value
         }
     }

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: powershell
   settingsJson:
-    description: Settings from template repository in compressed Json format
+    description: Settings from repository in compressed Json format (base64 encoded)
     required: false
     default: '{"keyVaultName": ""}'
   secrets:
@@ -18,7 +18,7 @@ inputs:
     default: '7b7d'
 outputs:
   SettingsJson:
-    description: Settings in compressed Json format
+    description: Settings (with modified appDependencyProbingPaths setting) in compressed Json format (base64 encoded)
     value: ${{ steps.readSecrets.outputs.SettingsJson }}
 runs:
   using: composite

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -30,7 +30,7 @@ runs:
         _settingsJson: ${{ inputs.settingsJson }}
         _secrets: ${{ inputs.secrets }}
         _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-      run: try { ${{ github.action_path }}/ReadSecrets.ps1 -settingsJson '${{ inputs.settingsJson }}' -secrets $ENV:_secrets -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
+      run: try { ${{ github.action_path }}/ReadSecrets.ps1 -settingsJson $ENV:_settingsJson -secrets $ENV:_secrets -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal
   color: blue

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -19,12 +19,13 @@ inputs:
 outputs:
   SettingsJson:
     description: Settings in compressed Json format
-    value: ${{ steps.determineArtifactUrl.outputs.SettingsJson }}
+    value: ${{ steps.readSecrets.outputs.SettingsJson }}
 runs:
   using: composite
   steps:
     - name: run
       shell: ${{ inputs.shell }}
+      id: readSecrets
       env:
         _settingsJson: ${{ inputs.settingsJson }}
         _secrets: ${{ inputs.secrets }}

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -16,6 +16,10 @@ inputs:
     description: Specifies the parent telemetry scope for the telemetry signal
     required: false
     default: '7b7d'
+outputs:
+  SettingsJson:
+    description: Settings in compressed Json format
+    value: ${{ steps.determineArtifactUrl.outputs.SettingsJson }}
 runs:
   using: composite
   steps:

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -30,7 +30,7 @@ runs:
         _settingsJson: ${{ inputs.settingsJson }}
         _secrets: ${{ inputs.secrets }}
         _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-      run: try { ${{ github.action_path }}/ReadSecrets.ps1 -settingsJson $ENV:_settingsJson -secrets $ENV:_secrets -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
+      run: try { ${{ github.action_path }}/ReadSecrets.ps1 -settingsJson '${{ inputs.settingsJson }}' -secrets $ENV:_secrets -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal
   color: blue

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -27,10 +27,9 @@ runs:
       shell: ${{ inputs.shell }}
       id: readSecrets
       env:
-        _settingsJson: ${{ inputs.settingsJson }}
         _secrets: ${{ inputs.secrets }}
         _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-      run: try { ${{ github.action_path }}/ReadSecrets.ps1 -settingsJson $ENV:_settingsJson -secrets $ENV:_secrets -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
+      run: try { ${{ github.action_path }}/ReadSecrets.ps1 -settingsJson '${{ inputs.settingsJson }}' -secrets $ENV:_secrets -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal
   color: blue

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -94,6 +94,7 @@ try {
     Write-Host "- SettingsJson=$outSettingsJson"
     if ($useBase64) {
         $outSettingsJson = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson))
+        Write-Host "::add-mask::$outSettingsJson"
     }
     Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
 

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -89,8 +89,6 @@ try {
         }
     }
 
-    $useBase64 = $false # test with UTF8 encoding
-
     Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
     Write-Host "- SettingsJson=$outSettingsJson"

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -93,7 +93,6 @@ try {
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
     if ($useBase64) {
         Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
     }
     else {
         Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettings"

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -89,7 +89,7 @@ try {
 
     Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
     Write-Host "- SettingsJson=$outSettingsJson"
 
     $gitHubRunner = $settings.githubRunner.Split(',').Trim() | ConvertTo-Json -compress

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -87,17 +87,18 @@ try {
         }
     }
 
+    Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
     Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
-    Write-Host "SettingsJson=$outSettingsJson"
+    Write-Host "- SettingsJson=$outSettingsJson"
 
     $gitHubRunner = $settings.githubRunner.Split(',').Trim() | ConvertTo-Json -compress
     Add-Content -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerJson=$githubRunner"
-    Write-Host "GitHubRunnerJson=$githubRunner"
+    Write-Host "- GitHubRunnerJson=$githubRunner"
 
     $gitHubRunnerShell = $settings.githubRunnerShell
     Add-Content -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerShell=$githubRunnerShell"
-    Write-Host "GitHubRunnerShell=$githubRunnerShell"
+    Write-Host "- GitHubRunnerShell=$githubRunnerShell"
 
     if ($getenvironments) {
         $environments = @()
@@ -185,14 +186,15 @@ try {
             }
             $json.matrix.include += @{ "environment" = $_; "os" = "$($runson | ConvertTo-Json -compress)" }
         }
+        Write-Host "OUTPUTS:"
         $environmentsJson = $json | ConvertTo-Json -Depth 99 -compress
         Add-Content -Path $env:GITHUB_OUTPUT -Value "EnvironmentsJson=$environmentsJson"
-        Add-Content -Path $env:GITHUB_ENV -Value "environments=$environmentsJson"
-        Write-Host "EnvironmentsJson=$environmentsJson"
+#        Add-Content -Path $env:GITHUB_ENV -Value "environments=$environmentsJson"
+        Write-Host "- EnvironmentsJson=$environmentsJson"
         Add-Content -Path $env:GITHUB_OUTPUT -Value "EnvironmentCount=$($environments.Count)"
-        Write-Host "EnvironmentCount=$($environments.Count)"
+        Write-Host "- EnvironmentCount=$($environments.Count)"
         Add-Content -Path $env:GITHUB_OUTPUT -Value "UnknownEnvironment=$unknownEnvironment"
-        Write-Host "UnknownEnvironment=$unknownEnvironment"
+        Write-Host "- UnknownEnvironment=$unknownEnvironment"
     }
 
     TrackTrace -telemetryScope $telemetryScope

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -82,12 +82,14 @@ try {
         $settingValue = $settings."$setting"
         $outSettings += @{ "$setting" = $settingValue }
         if ($settingValue -is [System.Collections.Specialized.OrderedDictionary]) {
-            Add-Content -Path $env:GITHUB_ENV -Value "$setting=$($settingValue | ConvertTo-Json -Depth 99 -Compress)"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$setting=$($settingValue | ConvertTo-Json -Depth 99 -Compress)"
         }
         else {
-            Add-Content -Path $env:GITHUB_ENV -Value "$setting=$settingValue"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$setting=$settingValue"
         }
     }
+
+    $useBase64 = $false # test with UTF8 encoding
 
     Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
@@ -96,14 +98,14 @@ try {
         $outSettingsJson = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson))
         Write-Host "::add-mask::$outSettingsJson"
     }
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
 
     $gitHubRunner = $settings.githubRunner.Split(',').Trim() | ConvertTo-Json -compress
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerJson=$githubRunner"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerJson=$githubRunner"
     Write-Host "- GitHubRunnerJson=$githubRunner"
 
     $gitHubRunnerShell = $settings.githubRunnerShell
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerShell=$githubRunnerShell"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerShell=$githubRunnerShell"
     Write-Host "- GitHubRunnerShell=$githubRunnerShell"
 
     if ($getenvironments) {
@@ -194,12 +196,11 @@ try {
         }
         Write-Host "OUTPUTS:"
         $environmentsJson = $json | ConvertTo-Json -Depth 99 -compress
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "EnvironmentsJson=$environmentsJson"
-#        Add-Content -Path $env:GITHUB_ENV -Value "environments=$environmentsJson"
+        Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "EnvironmentsJson=$environmentsJson"
         Write-Host "- EnvironmentsJson=$environmentsJson"
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "EnvironmentCount=$($environments.Count)"
+        Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "EnvironmentCount=$($environments.Count)"
         Write-Host "- EnvironmentCount=$($environments.Count)"
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "UnknownEnvironment=$unknownEnvironment"
+        Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "UnknownEnvironment=$unknownEnvironment"
         Write-Host "- UnknownEnvironment=$unknownEnvironment"
     }
 

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -91,13 +91,11 @@ try {
 
     Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
-    if ($useBase64) {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson)))"
-    }
-    else {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
-    }
     Write-Host "- SettingsJson=$outSettingsJson"
+    if ($useBase64) {
+        $outSettingsJson = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson))
+    }
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
 
     $gitHubRunner = $settings.githubRunner.Split(',').Trim() | ConvertTo-Json -compress
     Add-Content -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerJson=$githubRunner"

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -92,10 +92,10 @@ try {
     Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
     if ($useBase64) {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettingsJson)))"
     }
     else {
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettings"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
     }
     Write-Host "- SettingsJson=$outSettingsJson"
 

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -89,7 +89,6 @@ try {
 
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
     Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettingsJson"
-    Add-Content -Path $env:GITHUB_ENV -Value "Settings=$OutSettingsJson"
     Write-Host "SettingsJson=$outSettingsJson"
 
     $gitHubRunner = $settings.githubRunner.Split(',').Trim() | ConvertTo-Json -compress

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -14,7 +14,9 @@ Param(
     [Parameter(HelpMessage = "Indicates whether this is called from a release pipeline", Mandatory = $false)]
     [bool] $release,
     [Parameter(HelpMessage = "Specifies which properties to get from the settings file, default is all", Mandatory = $false)]
-    [string] $get = ""
+    [string] $get = "",
+    [Parameter(HelpMessage = "Specifies whether or not to use base64 encoding for the settings output", Mandatory = $false)]
+    [bool] $useBase64
 )
 
 $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
@@ -89,7 +91,13 @@ try {
 
     Write-Host "OUTPUTS:"
     $outSettingsJson = $outSettings | ConvertTo-Json -Depth 99 -Compress
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
+    if ($useBase64) {
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($outSettings)))"
+    }
+    else {
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "SettingsJson=$outSettings"
+    }
     Write-Host "- SettingsJson=$outSettingsJson"
 
     $gitHubRunner = $settings.githubRunner.Split(',').Trim() | ConvertTo-Json -compress

--- a/Actions/ReadSettings/action.yaml
+++ b/Actions/ReadSettings/action.yaml
@@ -37,6 +37,10 @@ inputs:
     description: Specifies which properties to get from the settings file, default is all
     required: false
     default: ''
+  useBase64:
+    description: Specifies whether or not to use base64 encoding for the settings output
+    required: false
+    default: 'N'
 outputs:
   SettingsJson:
     description: Settings in compressed Json format
@@ -71,7 +75,8 @@ runs:
         _includeProduction: ${{ inputs.includeProduction }}
         _release: ${{ inputs.release }}
         _get: ${{ inputs.get }}
-      run: try { ${{ github.action_path }}/ReadSettings.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -project $ENV:_project -getenvironments $ENV:_getenvironments -includeProduction ($ENV:_includeProduction -eq 'Y') -release ($ENV:_release -eq 'Y') -get $ENV:_get } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
+        _useBase64: ${{ inputs.useBase64 }}
+      run: try { ${{ github.action_path }}/ReadSettings.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -project $ENV:_project -getenvironments $ENV:_getenvironments -includeProduction ($ENV:_includeProduction -eq 'Y') -release ($ENV:_release -eq 'Y') -get $ENV:_get -useBase64 ($ENV:_useBase64 -eq 'Y') } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal
   color: blue

--- a/Actions/ReadSettings/action.yaml
+++ b/Actions/ReadSettings/action.yaml
@@ -43,7 +43,7 @@ inputs:
     default: 'N'
 outputs:
   SettingsJson:
-    description: Settings in compressed Json format
+    description: Settings in compressed Json format (base64 encoded if requested)
     value: ${{ steps.readsettings.outputs.SettingsJson }}
   GitHubRunnerJson:
     description: GitHubRunner in compressed Json format

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -278,7 +278,7 @@ try {
     $buildOutputFile = Join-Path $projectPath "BuildOutput.txt"
     $containerEventLogFile = Join-Path $projectPath "ContainerEventLog.evtx"
 
-    "containerName=$containerName" | Add-Content $ENV:GITHUB_ENV
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "containerName=$containerName"
 
     Set-Location $projectPath
     $runAlPipelineOverrides | ForEach-Object {

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -33,6 +33,14 @@ try {
     import-module (Join-Path -path $PSScriptRoot -ChildPath "..\TelemetryHelper.psm1" -Resolve)
     $telemetryScope = CreateScope -eventId 'DO0080' -parentTelemetryScopeJson $parentTelemetryScopeJson
 
+    # Support potentially base64 encoded settings
+    try {
+        $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($settingsJson)) | ConvertFrom-Json | ConvertTo-HashTable
+    }
+    catch {
+        $settings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
+    }
+
     if ($isWindows) {
         # Pull docker image in the background
         $genericImageName = Get-BestGenericImageName
@@ -82,7 +90,6 @@ try {
     $workflowName = "$env:GITHUB_WORKFLOW".Trim()
 
     Write-Host "use settings and secrets"
-    $settings = $settingsJson | ConvertFrom-Json | ConvertTo-HashTable
     $secrets = $secretsJson | ConvertFrom-Json | ConvertTo-HashTable
     $appBuild = $settings.appBuild
     $appRevision = $settings.appRevision

--- a/Actions/RunPipeline/action.yaml
+++ b/Actions/RunPipeline/action.yaml
@@ -48,10 +48,9 @@ runs:
         _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
         _project: ${{ inputs.project }}
         _projectDependenciesJson: ${{ inputs.projectDependenciesJson }}
-        _settingsJson: ${{ inputs.settingsJson }}
         _secretsJson: ${{ inputs.secretsJson }}
         _buildMode: ${{ inputs.buildMode }}
-      run: try { ${{ github.action_path }}/RunPipeline.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -project $ENV:_project -projectDependenciesJson $ENV:_projectDependenciesJson -settingsJson $ENV:_settingsJson -secretsJson $ENV:_secretsJson -buildMode $ENV:_buildMode } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
+      run: try { ${{ github.action_path }}/RunPipeline.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -project $ENV:_project -projectDependenciesJson $ENV:_projectDependenciesJson -settingsJson '${{ inputs.settingsJson }}' -secretsJson $ENV:_secretsJson -buildMode $ENV:_buildMode } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 }
 branding:
   icon: terminal
   color: blue

--- a/Actions/Sign/Sign.ps1
+++ b/Actions/Sign/Sign.ps1
@@ -1,16 +1,16 @@
 param(
     [Parameter(HelpMessage = "Azure Key Vault URI.", Mandatory = $true)]
-    [string]$AzureCredentialsJson,
+    [string] $AzureCredentialsJson,
     [Parameter(HelpMessage = "Settings from repository in compressed Json format", Mandatory = $true)]
-    [string]$settingsJson,
+    [string] $settingsJson,
     [Parameter(HelpMessage = "Paths to the files to be signed.", Mandatory = $true)]
-    [String]$PathToFiles,
+    [String] $PathToFiles,
     [Parameter(HelpMessage = "Timestamp service.", Mandatory = $false)]
-    [string]$TimestampService = "http://timestamp.digicert.com",
+    [string] $TimestampService = "http://timestamp.digicert.com",
     [Parameter(HelpMessage = "Timestamp digest algorithm.", Mandatory = $false)]
-    [string]$TimestampDigest = "sha256",
+    [string] $TimestampDigest = "sha256",
     [Parameter(HelpMessage = "File digest algorithm.", Mandatory = $false)]
-    [string]$FileDigest = "sha256",
+    [string] $FileDigest = "sha256",
     [Parameter(HelpMessage = "Specifies the parent telemetry scope for the telemetry signal", Mandatory = $false)]
     [string] $ParentTelemetryScopeJson = '7b7d'
 )
@@ -39,7 +39,13 @@ try {
     }
 
     $AzureCredentials = ConvertFrom-Json $AzureCredentialsJson
-    $settings = ConvertFrom-Json $settingsJson
+    # Support potentially base64 encoded settings
+    try {
+        $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($settingsJson)) | ConvertFrom-Json
+    }
+    catch {
+        $settings = $settingsJson | ConvertFrom-Json
+    }
     if ($AzureCredentials.PSobject.Properties.name -eq "keyVaultName") {
         $AzureKeyVaultName = $AzureCredentials.keyVaultName
     } elseif ($settings.PSobject.Properties.name -eq "keyVaultName") {

--- a/Actions/Sign/action.yaml
+++ b/Actions/Sign/action.yaml
@@ -41,13 +41,13 @@ runs:
       id: Sign
       run: | 
         try { 
-          ${{ github.action_path }}/Sign.ps1 -AzureCredentialsJson "$ENV:_azureCredentialsJson" `
-                                      -settingsJson "$ENV:_settingsJson" `
-                                      -TimestampService "$ENV:_timestampService" `
-                                      -TimestampDigest "$ENV:_digestAlgorithm" `
-                                      -FileDigest "$ENV:_digestAlgorithm" `
-                                      -PathToFiles "$ENV:_pathToFiles" `
-                                      -ParentTelemetryScopeJson "$ENV:_parentTelemetryScopeJson"
+          ${{ github.action_path }}/Sign.ps1 -AzureCredentialsJson $ENV:_azureCredentialsJson `
+                                      -settingsJson $ENV:_settingsJson `
+                                      -TimestampService $ENV:_timestampService `
+                                      -TimestampDigest $ENV:_digestAlgorithm `
+                                      -FileDigest $ENV:_digestAlgorithm `
+                                      -PathToFiles $ENV:_pathToFiles `
+                                      -ParentTelemetryScopeJson $ENV:_parentTelemetryScopeJson
         } catch { 
           Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message.Replace("`r",'').Replace("`n",' ')))"; exit 1 
         }

--- a/Actions/Sign/action.yaml
+++ b/Actions/Sign/action.yaml
@@ -33,7 +33,6 @@ runs:
       shell: ${{ inputs.shell }}
       env:
         _azureCredentialsJson: ${{ inputs.azureCredentialsJson }}
-        _settingsJson: ${{ inputs.settingsJson }}
         _timestampService: ${{ inputs.timestampService }}
         _digestAlgorithm: ${{ inputs.digestAlgorithm }}
         _pathToFiles: ${{ inputs.pathToFiles }}
@@ -42,7 +41,7 @@ runs:
       run: | 
         try { 
           ${{ github.action_path }}/Sign.ps1 -AzureCredentialsJson $ENV:_azureCredentialsJson `
-                                      -settingsJson $ENV:_settingsJson `
+                                      -settingsJson '${{ inputs.settingsJson }}' `
                                       -TimestampService $ENV:_timestampService `
                                       -TimestampDigest $ENV:_digestAlgorithm `
                                       -FileDigest $ENV:_digestAlgorithm `

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -66,11 +66,12 @@ try {
         $correlationId = [guid]::Empty.ToString()
     }
 
+    Write-Host "OUTPUTS:"
     Add-Content -Path $env:GITHUB_OUTPUT -Value "telemetryScopeJson=$scopeJson"
-    Write-Host "telemetryScopeJson=$scopeJson"
+    Write-Host "- telemetryScopeJson=$scopeJson"
 
     Add-Content -Path $env:GITHUB_OUTPUT -Value "correlationId=$correlationId"
-    Write-Host "correlationId=$correlationId"
+    Write-Host "- correlationId=$correlationId"
 }
 catch {
     OutputError -message "WorkflowInitialize action failed.$([environment]::Newline)Error: $($_.Exception.Message)$([environment]::Newline)Stacktrace: $($_.scriptStackTrace)"

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -67,10 +67,10 @@ try {
     }
 
     Write-Host "OUTPUTS:"
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "telemetryScopeJson=$scopeJson"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "telemetryScopeJson=$scopeJson"
     Write-Host "- telemetryScopeJson=$scopeJson"
 
-    Add-Content -Path $env:GITHUB_OUTPUT -Value "correlationId=$correlationId"
+    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "correlationId=$correlationId"
     Write-Host "- correlationId=$correlationId"
 }
 catch {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -25,6 +25,10 @@ The problem using GITHUB_TOKEN is that is doesn't trigger a pull request build o
 This is by design: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
 Now, you can set the checkbox called Use GhTokenWorkflow to allowing you to use the GhTokenWorkflow instead of the GITHUB_TOKEN - making sure that workflows are triggered
 
+### Settings environment variable
+Up until v3.1 the settings were transferred around as environment variables.
+Due to size constraints in environment variables, we have removed the settings environment variable and are using the GITHUB_OUTPUT construct instead.
+
 ## v3.1
 
 ### Issues

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -14,6 +14,7 @@ Issue 528 Give better error messages when uploading to storage accounts
 Create Online Development environment workflow failed in AppSource template unless AppSourceCopMandatoryAffixes is defined in repository settings file
 Create Online Development environment workflow didn't have a project parameter and only worked for single project repositories
 Create Online Development environment workflow didn't work if runs-on was set to Linux
+Issue 629 Invalid characters in the file path installing app
 
 ### New Settings
 - `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -77,7 +77,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Add existing app
         uses: microsoft/AL-Go-Actions/AddExistingApp@main

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -54,6 +54,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -62,7 +63,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -144,13 +144,13 @@ jobs:
             }
             $include
           })
+          Write-Host "OUTPUTS:"
           $deliveryTargetsJson = $deliveryTargets | ConvertTo-Json -Depth 99 -compress
           if ($deliveryTargets.Count -lt 2) { $deliveryTargetsJson = "[$($deliveryTargetsJson)]" }
           Add-Content -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetsJson=$deliveryTargetsJson"
-          Write-Host "DeliveryTargetsJson=$deliveryTargetsJson"
+          Write-Host "- DeliveryTargetsJson=$deliveryTargetsJson"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetCount=$($deliveryTargets.Count)"
-          Write-Host "DeliveryTargetCount=$($deliveryTargets.Count)"
-          Add-Content -Path $env:GITHUB_ENV -Value "DeliveryTargets=$deliveryTargetsJson"
+          Write-Host "- DeliveryTargetCount=$($deliveryTargets.Count)"
 
   CheckForUpdates:
     runs-on: [ windows-latest ]

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -27,7 +27,6 @@ jobs:
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-      settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
       environments: ${{ steps.ReadSettings.outputs.EnvironmentsJson }}
       environmentCount: ${{ steps.ReadSettings.outputs.EnvironmentCount }}
       deliveryTargets: ${{ steps.DetermineDeliveryTargets.outputs.DeliveryTargetsJson }}
@@ -126,7 +125,7 @@ jobs:
             $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
             if ($deliveryContext) {
               $settingName = "DeliverTo$_"
-              $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${{ steps.ReadSecrets.outputs.SettingsJson }}')) | ConvertFrom-Json | ConvertTo-HashTable
+              $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${{ steps.ReadSecrets.outputs.SettingsJson }}')) | ConvertFrom-Json
               if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
                 Write-Host "Branches:"
                 $settings."$settingName".Branches | ForEach-Object {

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -86,6 +86,7 @@ jobs:
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
+        id: ReadSecrets
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -96,7 +97,7 @@ jobs:
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
         env:
-          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
+          settingsJson: ${{ steps.ReadSecrets.outputs.SettingsJson }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $deliveryTargets = @('GitHubPackages','NuGet','Storage')
@@ -346,6 +347,7 @@ jobs:
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
+        id: ReadSecrets
         env:
           secrets: ${{ toJson(secrets) }}
         with:

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -95,6 +95,8 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
+        env:
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $deliveryTargets = @('GitHubPackages','NuGet','Storage')
@@ -124,7 +126,7 @@ jobs:
             $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
             if ($deliveryContext) {
               $settingName = "DeliverTo$_"
-              $settings = ('${{ steps.ReadSettings.outputs.SettingsJson }}' | ConvertFrom-Json)
+              $settings = $ENV:SettingsJson | ConvertFrom-Json
               if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
                 Write-Host "Branches:"
                 $settings."$settingName".Branches | ForEach-Object {

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -165,6 +165,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           get: templateUrl
+          useBase64: 'Y'
 
       - name: Check for updates to AL-Go system files
         uses: microsoft/AL-Go-Actions/CheckForUpdates@main
@@ -225,6 +226,7 @@ jobs:
         id: ReadSettings
         with:
           shell: powershell
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -342,6 +344,7 @@ jobs:
         id: ReadSettings
         with:
           shell: powershell
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -90,7 +90,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: ${{ steps.DetermineDeliveryTargetSecrets.outputs.Secrets }}
 
       - name: Determine Delivery Targets
@@ -124,7 +124,7 @@ jobs:
             $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
             if ($deliveryContext) {
               $settingName = "DeliverTo$_"
-              $settings = $env:Settings | ConvertFrom-Json
+              $settings = ('${{ steps.ReadSettings.outputs.SettingsJson }}' | ConvertFrom-Json)
               if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
                 Write-Host "Branches:"
                 $settings."$settingName".Branches | ForEach-Object {
@@ -221,6 +221,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
 
@@ -230,7 +231,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects'
 
       - name: AuthContext
@@ -337,6 +338,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
 
@@ -346,7 +348,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: DeliveryContext

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -53,12 +53,13 @@ jobs:
           eventId: "DO0091"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           getEnvironments: '*'
+          useBase64: 'Y'
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -96,8 +96,6 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        env:
-          _SettingsJson: ${{ steps.ReadSecrets.outputs.SettingsJson }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $deliveryTargets = @('GitHubPackages','NuGet','Storage')
@@ -127,7 +125,7 @@ jobs:
             $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
             if ($deliveryContext) {
               $settingName = "DeliverTo$_"
-              $settings = $ENV:_SettingsJson | ConvertFrom-Json
+              $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${{ steps.ReadSecrets.outputs.SettingsJson }}')) | ConvertFrom-Json | ConvertTo-HashTable
               if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
                 Write-Host "Branches:"
                 $settings."$settingName".Branches | ForEach-Object {

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
         env:
-          settingsJson: ${{ steps.ReadSecrets.outputs.SettingsJson }}
+          _SettingsJson: ${{ steps.ReadSecrets.outputs.SettingsJson }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $deliveryTargets = @('GitHubPackages','NuGet','Storage')
@@ -127,7 +127,7 @@ jobs:
             $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
             if ($deliveryContext) {
               $settingName = "DeliverTo$_"
-              $settings = $ENV:SettingsJson | ConvertFrom-Json
+              $settings = $ENV:_SettingsJson | ConvertFrom-Json
               if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
                 Write-Host "Branches:"
                 $settings."$settingName".Branches | ForEach-Object {

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
@@ -82,7 +82,7 @@ jobs:
             $deliveryTarget = [System.IO.Path]::GetFileNameWithoutExtension($_.Name.SubString($namePrefix.Length))
             $deliveryTargetSecrets += @("$($deliveryTarget)Context")
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "Secrets=$($deliveryTargetSecrets -join ',')"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "Secrets=$($deliveryTargetSecrets -join ',')"
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -147,9 +147,9 @@ jobs:
           Write-Host "OUTPUTS:"
           $deliveryTargetsJson = $deliveryTargets | ConvertTo-Json -Depth 99 -compress
           if ($deliveryTargets.Count -lt 2) { $deliveryTargetsJson = "[$($deliveryTargetsJson)]" }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetsJson=$deliveryTargetsJson"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetsJson=$deliveryTargetsJson"
           Write-Host "- DeliveryTargetsJson=$deliveryTargetsJson"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetCount=$($deliveryTargets.Count)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetCount=$($deliveryTargets.Count)"
           Write-Host "- DeliveryTargetCount=$($deliveryTargets.Count)"
 
   CheckForUpdates:
@@ -219,7 +219,7 @@ jobs:
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $envName = '${{ matrix.environment }}'.split(' ')[0]
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
@@ -302,12 +302,12 @@ jobs:
             $projects = ($projects.Split(',') | Where-Object { $buildProjects -contains $_ }) -join ','
           }
 
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
           Write-Host "authContext=$authContext"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
           Write-Host "environmentName=$([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($environmentName)))"
           Write-Host "environmentName (as Base64)=$environmentName"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
           Write-Host "projects=$projects"
 
       - name: Deploy
@@ -362,7 +362,7 @@ jobs:
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $contextName = '${{ matrix.deliveryTarget }}Context'
           $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "deliveryContext=$deliveryContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "deliveryContext=$deliveryContext"
           Write-Host "deliveryContext=$deliveryContext"
 
       - name: Deliver

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -63,6 +63,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: type,keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -86,7 +86,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Creating a new app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -71,7 +72,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -92,7 +92,7 @@ jobs:
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
             CleanupAfterBcContainerHelper -bcContainerHelperPath $bcContainerHelperPath
             Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Admin Center Api and could not locate a secret called $($ENV:adminCenterApiCredentialsSecretName) (https://aka.ms/ALGoSettings#AdminCenterApiCredentialsSecretName)`n`n$($authContext.message)"
-            Add-Content -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
           }
 
   CreateDevelopmentEnvironment:
@@ -136,13 +136,13 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Set AdminCenterApiCredentials
         run: |
           if ($env:deviceCode) {
             $adminCenterApiCredentials = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("{""deviceCode"":""$($env:deviceCode)""}"))
-            Add-Content -path $env:GITHUB_ENV -value "adminCenterApiCredentials=$adminCenterApiCredentials"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -value "adminCenterApiCredentials=$adminCenterApiCredentials"
           }
 
       - name: Create Development Environment

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -56,11 +56,12 @@ jobs:
           eventId: "DO0093"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'adminCenterApiCredentials'
 
       - name: Check AdminCenterApiCredentials / Initiate Device Login (open to see code)
@@ -109,6 +109,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -120,7 +121,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'adminCenterApiCredentials,ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -113,6 +113,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -69,6 +69,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -72,13 +72,14 @@ jobs:
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
+        id: ReadSettings
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         env:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -93,7 +93,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -166,11 +166,12 @@ jobs:
             }
           }
           $artifacts = @{ "include" = $include }
+          Write-Host "OUTPUTS:"
           $artifactsJson = $artifacts | ConvertTo-Json -compress
           Add-Content -Path $env:GITHUB_OUTPUT -Value "artifacts=$artifactsJson"
-          Write-Host "artifacts=$artifactsJson"
+          Write-Host "- artifacts=$artifactsJson"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "commitish=$sha"
-          Write-Host "commitish=$sha"
+          Write-Host "- commitish=$sha"
 
       - name: Prepare release notes
         id: createreleasenotes

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -75,12 +75,13 @@ jobs:
           eventId: "DO0094"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: templateUrl,repoName
+          useBase64: 'Y'
 
       - name: Determine Projects
         id: determineProjects

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -217,6 +217,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
@@ -228,7 +229,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'nuGetContext,storageContext'
 
       - name: Download artifact
@@ -334,6 +335,7 @@ jobs:
     steps:
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -348,7 +350,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -221,6 +221,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -341,6 +342,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -168,9 +168,9 @@ jobs:
           $artifacts = @{ "include" = $include }
           Write-Host "OUTPUTS:"
           $artifactsJson = $artifacts | ConvertTo-Json -compress
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "artifacts=$artifactsJson"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "artifacts=$artifactsJson"
           Write-Host "- artifacts=$artifactsJson"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "commitish=$sha"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "commitish=$sha"
           Write-Host "- commitish=$sha"
 
       - name: Prepare release notes
@@ -273,7 +273,7 @@ jobs:
           if ('${{ matrix.atype }}' -eq 'Apps') {
             $nuGetContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('nuGetContext')))
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "nuGetContext=$nuGetContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "nuGetContext=$nuGetContext"
 
       - name: Deliver to NuGet
         uses: microsoft/AL-Go-Actions/Deliver@main
@@ -297,7 +297,7 @@ jobs:
           if ('${{ matrix.atype }}' -eq 'Apps') {
             $storageContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('storageContext')))
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "storageContext=$storageContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "storageContext=$storageContext"
 
       - name: Deliver to Storage
         uses: microsoft/AL-Go-Actions/Deliver@main
@@ -367,7 +367,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Update Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -89,7 +89,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -66,6 +66,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -74,7 +75,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/AppSource App/.github/workflows/Current.yaml
+++ b/Templates/AppSource App/.github/workflows/Current.yaml
@@ -41,11 +41,12 @@ jobs:
           eventId: "DO0101"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/AppSource App/.github/workflows/Current.yaml
+++ b/Templates/AppSource App/.github/workflows/Current.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
       
       - name: Determine Projects To Build
         id: determineProjectsToBuild

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -77,7 +77,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Increment Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -54,6 +54,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -62,7 +63,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/AppSource App/.github/workflows/NextMajor.yaml
+++ b/Templates/AppSource App/.github/workflows/NextMajor.yaml
@@ -41,11 +41,12 @@ jobs:
           eventId: "DO0099"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/AppSource App/.github/workflows/NextMajor.yaml
+++ b/Templates/AppSource App/.github/workflows/NextMajor.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild

--- a/Templates/AppSource App/.github/workflows/NextMinor.yaml
+++ b/Templates/AppSource App/.github/workflows/NextMinor.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild

--- a/Templates/AppSource App/.github/workflows/NextMinor.yaml
+++ b/Templates/AppSource App/.github/workflows/NextMinor.yaml
@@ -41,11 +41,12 @@ jobs:
           eventId: "DO0100"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/AppSource App/.github/workflows/PublishToAppSource.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToAppSource.yaml
@@ -58,6 +58,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/PublishToAppSource.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToAppSource.yaml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -64,7 +65,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'appSourceContext'
 
       - name: DeliveryContext

--- a/Templates/AppSource App/.github/workflows/PublishToAppSource.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToAppSource.yaml
@@ -75,7 +75,7 @@ jobs:
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $contextName = 'appSourceContext'
           $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "deliveryContext=$deliveryContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "deliveryContext=$deliveryContext"
           Write-Host "deliveryContext=$deliveryContext"
 
       - name: Deliver

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -45,13 +45,14 @@ jobs:
           eventId: "DO0097"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           getEnvironments: ${{ github.event.inputs.environmentName }}
           includeProduction: 'Y'
+          useBase64: 'Y'
 
       - name: EnvName
         id: envName

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext'
 
       - name: Authenticate
@@ -128,6 +128,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
 
@@ -137,7 +138,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects'
 
       - name: AuthContext

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $envName = '${{ fromJson(steps.ReadSettings.outputs.environmentsJson).matrix.include[0].environment }}'.split(' ')[0]
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -103,7 +103,7 @@ jobs:
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
             CleanupAfterBcContainerHelper -bcContainerHelperPath $bcContainerHelperPath
             Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Environment $('${{ steps.envName.outputs.envName }}'.Split(' ')[0]) and could not locate a secret called ${{ steps.envName.outputs.envName }}_AuthContext`n`n$($authContext.message)"
-            Add-Content -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
           }
 
   Deploy:
@@ -125,7 +125,7 @@ jobs:
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $envName = '${{ matrix.environment }}'.split(' ')[0]
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
@@ -209,11 +209,11 @@ jobs:
             $buildProjects = '${{ needs.Initialization.outputs.projects }}' | ConvertFrom-Json
             $projects = ($projects.Split(',') | Where-Object { $buildProjects -contains $_ }) -join ','
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
           Write-Host "environmentName=$([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($environmentName)))"
           Write-Host "environmentName (as Base64)=$environmentName"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
           Write-Host "projects=$projects"
 
       - name: Deploy

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -131,6 +131,7 @@ jobs:
         id: ReadSettings
         with:
           shell: powershell
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -68,12 +68,13 @@ jobs:
           eventId: "DO0104"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           getEnvironments: '*'
+          useBase64: 'Y'
       
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild

--- a/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -64,7 +64,7 @@ jobs:
           $templateUrl = $ENV:templateUrl
           if ($templateUrl) {
             Write-Host "Using Template Url: $templateUrl"
-            Add-Content -Path $env:GITHUB_ENV -Value "templateUrl=$templateUrl"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "templateUrl=$templateUrl"
           }
 
       - name: Calculate DirectCommit
@@ -79,7 +79,7 @@ jobs:
             Write-Host "Running Update AL-Go System Files on a schedule. Setting DirectCommit = Y"
             $directCommit = 'Y'
           }
-          Add-Content -Path $env:GITHUB_ENV -Value "DirectCommit=$directCommit"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "DirectCommit=$directCommit"
 
       - name: Update AL-Go system files
         uses: microsoft/AL-Go-Actions/CheckForUpdates@main

--- a/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -44,6 +44,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName,templateUrl
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -51,7 +52,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: Override templateUrl

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -93,6 +93,7 @@ jobs:
 
         - name: Read secrets
           uses: microsoft/AL-Go-Actions/ReadSecrets@main
+          id: ReadSecrets
           env:
             secrets: ${{ toJson(secrets) }}
           with:
@@ -108,7 +109,7 @@ jobs:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
-            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
+            settingsJson: ${{ steps.ReadSecrets.outputs.SettingsJson }}
             secretsJson: ${{ env.RepoSecrets }}
 
         - name: Cache Business Central Artifacts
@@ -128,7 +129,7 @@ jobs:
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
             projectDependenciesJson: ${{ inputs.projectDependenciesJson }}
-            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
+            settingsJson: ${{ steps.determineArtifactUrl.outputs.SettingsJson }}
             secretsJson: ${{ env.RepoSecrets }}
             buildMode: ${{ inputs.buildMode }}
 
@@ -139,7 +140,7 @@ jobs:
           with:
             shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
             azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
-            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
+            settingsJson: ${{ steps.determineArtifactUrl.outputs.SettingsJson }}
             pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
             parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
@@ -149,7 +150,7 @@ jobs:
           if: success() || failure()
           with:
             shell: ${{ inputs.shell }}
-            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
+            settingsJson: ${{ steps.determineArtifactUrl.outputs.SettingsJson }}
             project: ${{ inputs.project }}
             buildMode: ${{ inputs.buildMode }}
             branchName: ${{ github.ref_name }}

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -178,7 +178,7 @@ jobs:
           uses: actions/upload-artifact@v3
           if: inputs.publishArtifacts
           with:
-            name: ${{ steps.calculateArtifactsNames.outputs.AppsArtifactsName }}
+            name: ${{ env.AppsArtifactsName }}
             path: '${{ inputs.project }}/.buildartifacts/Apps/'
             if-no-files-found: ignore
 

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -85,6 +85,7 @@ jobs:
 
         - name: Read settings
           uses: microsoft/AL-Go-Actions/ReadSettings@main
+          id: ReadSettings
           with:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
@@ -97,7 +98,7 @@ jobs:
           with:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-            settingsJson: ${{ env.Settings }}
+            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
             secrets: ${{ inputs.secrets }}
 
         - name: Determine ArtifactUrl
@@ -107,7 +108,7 @@ jobs:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
-            settingsJson: ${{ env.Settings }}
+            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
             secretsJson: ${{ env.RepoSecrets }}
 
         - name: Cache Business Central Artifacts
@@ -127,7 +128,7 @@ jobs:
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
             projectDependenciesJson: ${{ inputs.projectDependenciesJson }}
-            settingsJson: ${{ env.Settings }}
+            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
             secretsJson: ${{ env.RepoSecrets }}
             buildMode: ${{ inputs.buildMode }}
 
@@ -138,7 +139,7 @@ jobs:
           with:
             shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
             azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
-            settingsJson: ${{ env.Settings }}
+            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
             pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
             parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
@@ -148,7 +149,7 @@ jobs:
           if: success() || failure()
           with:
             shell: ${{ inputs.shell }}
-            settingsJson: ${{ env.Settings }}
+            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
             project: ${{ inputs.project }}
             buildMode: ${{ inputs.buildMode }}
             branchName: ${{ github.ref_name }}

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -178,7 +178,7 @@ jobs:
           uses: actions/upload-artifact@v3
           if: inputs.publishArtifacts
           with:
-            name: ${{ env.AppsArtifactsName }}
+            name: ${{ steps.calculateArtifactsNames.outputs.AppsArtifactsName }}
             path: '${{ inputs.project }}/.buildartifacts/Apps/'
             if-no-files-found: ignore
 

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -77,7 +77,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Add existing app
         uses: microsoft/AL-Go-Actions/AddExistingApp@main

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -54,6 +54,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -62,7 +63,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
         env:
-          SettingsJson: ${{ steps.ReadSecrets.outputs.SettingsJson }}
+          _SettingsJson: ${{ steps.ReadSecrets.outputs.SettingsJson }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $deliveryTargets = @('GitHubPackages','NuGet','Storage')
@@ -127,7 +127,7 @@ jobs:
             $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
             if ($deliveryContext) {
               $settingName = "DeliverTo$_"
-              $settings = $ENV:SettingsJson | ConvertFrom-Json
+              $settings = $ENV:_SettingsJson | ConvertFrom-Json
               if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
                 Write-Host "Branches:"
                 $settings."$settingName".Branches | ForEach-Object {

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -144,13 +144,13 @@ jobs:
             }
             $include
           })
+          Write-Host "OUTPUTS:"
           $deliveryTargetsJson = $deliveryTargets | ConvertTo-Json -Depth 99 -compress
           if ($deliveryTargets.Count -lt 2) { $deliveryTargetsJson = "[$($deliveryTargetsJson)]" }
           Add-Content -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetsJson=$deliveryTargetsJson"
-          Write-Host "DeliveryTargetsJson=$deliveryTargetsJson"
+          Write-Host "- DeliveryTargetsJson=$deliveryTargetsJson"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetCount=$($deliveryTargets.Count)"
-          Write-Host "DeliveryTargetCount=$($deliveryTargets.Count)"
-          Add-Content -Path $env:GITHUB_ENV -Value "DeliveryTargets=$deliveryTargetsJson"
+          Write-Host "- DeliveryTargetCount=$($deliveryTargets.Count)"
 
   CheckForUpdates:
     runs-on: [ windows-latest ]

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -95,6 +95,8 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
+        env:
+          SettingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $deliveryTargets = @('GitHubPackages','NuGet','Storage')
@@ -124,7 +126,7 @@ jobs:
             $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
             if ($deliveryContext) {
               $settingName = "DeliverTo$_"
-              $settings = ('${{ steps.ReadSettings.outputs.SettingsJson }}' | ConvertFrom-Json)
+              $settings = $ENV:SettingsJson | ConvertFrom-Json
               if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
                 Write-Host "Branches:"
                 $settings."$settingName".Branches | ForEach-Object {

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -27,7 +27,6 @@ jobs:
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-      settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
       environments: ${{ steps.ReadSettings.outputs.EnvironmentsJson }}
       environmentCount: ${{ steps.ReadSettings.outputs.EnvironmentCount }}
       deliveryTargets: ${{ steps.DetermineDeliveryTargets.outputs.DeliveryTargetsJson }}
@@ -126,7 +125,7 @@ jobs:
             $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
             if ($deliveryContext) {
               $settingName = "DeliverTo$_"
-              $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${{ steps.ReadSecrets.outputs.SettingsJson }}')) | ConvertFrom-Json | ConvertTo-HashTable
+              $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${{ steps.ReadSecrets.outputs.SettingsJson }}')) | ConvertFrom-Json
               if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
                 Write-Host "Branches:"
                 $settings."$settingName".Branches | ForEach-Object {

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -165,6 +165,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           get: templateUrl
+          useBase64: 'Y'
 
       - name: Check for updates to AL-Go system files
         uses: microsoft/AL-Go-Actions/CheckForUpdates@main
@@ -225,6 +226,7 @@ jobs:
         id: ReadSettings
         with:
           shell: powershell
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -342,6 +344,7 @@ jobs:
         id: ReadSettings
         with:
           shell: powershell
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -90,7 +90,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: ${{ steps.DetermineDeliveryTargetSecrets.outputs.Secrets }}
 
       - name: Determine Delivery Targets
@@ -124,7 +124,7 @@ jobs:
             $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
             if ($deliveryContext) {
               $settingName = "DeliverTo$_"
-              $settings = $env:Settings | ConvertFrom-Json
+              $settings = ('${{ steps.ReadSettings.outputs.SettingsJson }}' | ConvertFrom-Json)
               if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
                 Write-Host "Branches:"
                 $settings."$settingName".Branches | ForEach-Object {
@@ -221,6 +221,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
 
@@ -230,7 +231,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects'
 
       - name: AuthContext
@@ -337,6 +338,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
 
@@ -346,7 +348,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: DeliveryContext

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -53,12 +53,13 @@ jobs:
           eventId: "DO0091"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           getEnvironments: '*'
+          useBase64: 'Y'
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -96,8 +96,6 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        env:
-          _SettingsJson: ${{ steps.ReadSecrets.outputs.SettingsJson }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $deliveryTargets = @('GitHubPackages','NuGet','Storage')
@@ -127,7 +125,7 @@ jobs:
             $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
             if ($deliveryContext) {
               $settingName = "DeliverTo$_"
-              $settings = $ENV:_SettingsJson | ConvertFrom-Json
+              $settings = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${{ steps.ReadSecrets.outputs.SettingsJson }}')) | ConvertFrom-Json | ConvertTo-HashTable
               if (($settings.PSObject.Properties.Name -eq $settingName) -and ($settings."$settingName".PSObject.Properties.Name -eq "Branches")) {
                 Write-Host "Branches:"
                 $settings."$settingName".Branches | ForEach-Object {

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -86,6 +86,7 @@ jobs:
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
+        id: ReadSecrets
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -96,7 +97,7 @@ jobs:
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
         env:
-          SettingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
+          SettingsJson: ${{ steps.ReadSecrets.outputs.SettingsJson }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $deliveryTargets = @('GitHubPackages','NuGet','Storage')

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
@@ -82,7 +82,7 @@ jobs:
             $deliveryTarget = [System.IO.Path]::GetFileNameWithoutExtension($_.Name.SubString($namePrefix.Length))
             $deliveryTargetSecrets += @("$($deliveryTarget)Context")
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "Secrets=$($deliveryTargetSecrets -join ',')"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "Secrets=$($deliveryTargetSecrets -join ',')"
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -147,9 +147,9 @@ jobs:
           Write-Host "OUTPUTS:"
           $deliveryTargetsJson = $deliveryTargets | ConvertTo-Json -Depth 99 -compress
           if ($deliveryTargets.Count -lt 2) { $deliveryTargetsJson = "[$($deliveryTargetsJson)]" }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetsJson=$deliveryTargetsJson"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetsJson=$deliveryTargetsJson"
           Write-Host "- DeliveryTargetsJson=$deliveryTargetsJson"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetCount=$($deliveryTargets.Count)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "DeliveryTargetCount=$($deliveryTargets.Count)"
           Write-Host "- DeliveryTargetCount=$($deliveryTargets.Count)"
 
   CheckForUpdates:
@@ -219,7 +219,7 @@ jobs:
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $envName = '${{ matrix.environment }}'.split(' ')[0]
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
@@ -302,12 +302,12 @@ jobs:
             $projects = ($projects.Split(',') | Where-Object { $buildProjects -contains $_ }) -join ','
           }
 
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
           Write-Host "authContext=$authContext"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
           Write-Host "environmentName=$([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($environmentName)))"
           Write-Host "environmentName (as Base64)=$environmentName"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
           Write-Host "projects=$projects"
 
       - name: Deploy
@@ -361,7 +361,7 @@ jobs:
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $contextName = '${{ matrix.deliveryTarget }}Context'
           $deliveryContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($contextName)))
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "deliveryContext=$deliveryContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "deliveryContext=$deliveryContext"
           Write-Host "deliveryContext=$deliveryContext"
 
       - name: Deliver

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -63,6 +63,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: type,keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -86,7 +86,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Creating a new app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -71,7 +72,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -92,7 +92,7 @@ jobs:
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
             CleanupAfterBcContainerHelper -bcContainerHelperPath $bcContainerHelperPath
             Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Admin Center Api and could not locate a secret called $($ENV:adminCenterApiCredentialsSecretName) (https://aka.ms/ALGoSettings#AdminCenterApiCredentialsSecretName)`n`n$($authContext.message)"
-            Add-Content -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
           }
 
   CreateDevelopmentEnvironment:
@@ -136,13 +136,13 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Set AdminCenterApiCredentials
         run: |
           if ($env:deviceCode) {
             $adminCenterApiCredentials = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("{""deviceCode"":""$($env:deviceCode)""}"))
-            Add-Content -path $env:GITHUB_ENV -value "adminCenterApiCredentials=$adminCenterApiCredentials"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -value "adminCenterApiCredentials=$adminCenterApiCredentials"
           }
 
       - name: Create Development Environment

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -56,11 +56,12 @@ jobs:
           eventId: "DO0093"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'adminCenterApiCredentials'
 
       - name: Check AdminCenterApiCredentials / Initiate Device Login (open to see code)
@@ -109,6 +109,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -120,7 +121,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'adminCenterApiCredentials,ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -113,6 +113,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -64,6 +64,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -78,7 +79,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -70,6 +70,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -93,7 +93,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -166,11 +166,12 @@ jobs:
             }
           }
           $artifacts = @{ "include" = $include }
+          Write-Host "OUTPUTS:"
           $artifactsJson = $artifacts | ConvertTo-Json -compress
           Add-Content -Path $env:GITHUB_OUTPUT -Value "artifacts=$artifactsJson"
-          Write-Host "artifacts=$artifactsJson"
+          Write-Host "- artifacts=$artifactsJson"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "commitish=$sha"
-          Write-Host "commitish=$sha"
+          Write-Host "- commitish=$sha"
 
       - name: Prepare release notes
         id: createreleasenotes

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -75,12 +75,13 @@ jobs:
           eventId: "DO0094"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: templateUrl,repoName
+          useBase64: 'Y'
 
       - name: Determine Projects
         id: determineProjects

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -217,6 +217,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
@@ -228,7 +229,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'nuGetContext,storageContext'
 
       - name: Download artifact
@@ -334,6 +335,7 @@ jobs:
     steps:
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -348,7 +350,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -221,6 +221,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -341,6 +342,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -168,9 +168,9 @@ jobs:
           $artifacts = @{ "include" = $include }
           Write-Host "OUTPUTS:"
           $artifactsJson = $artifacts | ConvertTo-Json -compress
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "artifacts=$artifactsJson"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "artifacts=$artifactsJson"
           Write-Host "- artifacts=$artifactsJson"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "commitish=$sha"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "commitish=$sha"
           Write-Host "- commitish=$sha"
 
       - name: Prepare release notes
@@ -273,7 +273,7 @@ jobs:
           if ('${{ matrix.atype }}' -eq 'Apps') {
             $nuGetContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('nuGetContext')))
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "nuGetContext=$nuGetContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "nuGetContext=$nuGetContext"
 
       - name: Deliver to NuGet
         uses: microsoft/AL-Go-Actions/Deliver@main
@@ -297,7 +297,7 @@ jobs:
           if ('${{ matrix.atype }}' -eq 'Apps') {
             $storageContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('storageContext')))
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "storageContext=$storageContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "storageContext=$storageContext"
 
       - name: Deliver to Storage
         uses: microsoft/AL-Go-Actions/Deliver@main
@@ -367,7 +367,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Update Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -89,7 +89,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -66,6 +66,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -74,7 +75,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/Per Tenant Extension/.github/workflows/Current.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/Current.yaml
@@ -41,11 +41,12 @@ jobs:
           eventId: "DO0101"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
       
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/Per Tenant Extension/.github/workflows/Current.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/Current.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
       
       - name: Determine Projects To Build
         id: determineProjectsToBuild

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -77,7 +77,7 @@ jobs:
           } else {
             $ghToken = '${{ secrets.GITHUB_TOKEN }}'
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
 
       - name: Increment Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -54,6 +54,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
@@ -62,7 +63,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: CalculateToken

--- a/Templates/Per Tenant Extension/.github/workflows/NextMajor.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/NextMajor.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild

--- a/Templates/Per Tenant Extension/.github/workflows/NextMajor.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/NextMajor.yaml
@@ -41,11 +41,12 @@ jobs:
           eventId: "DO0099"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
       
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/Per Tenant Extension/.github/workflows/NextMinor.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/NextMinor.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild

--- a/Templates/Per Tenant Extension/.github/workflows/NextMinor.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/NextMinor.yaml
@@ -41,11 +41,12 @@ jobs:
           eventId: "DO0100"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          useBase64: 'Y'
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -45,13 +45,14 @@ jobs:
           eventId: "DO0097"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           getEnvironments: ${{ github.event.inputs.environmentName }}
           includeProduction: 'Y'
+          useBase64: 'Y'
 
       - name: EnvName
         id: envName

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext'
 
       - name: Authenticate
@@ -128,6 +128,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
 
@@ -137,7 +138,7 @@ jobs:
           secrets: ${{ toJson(secrets) }}
         with:
           shell: powershell
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects'
 
       - name: AuthContext

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $envName = '${{ fromJson(steps.ReadSettings.outputs.environmentsJson).matrix.include[0].environment }}'.split(' ')[0]
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
@@ -103,7 +103,7 @@ jobs:
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
             CleanupAfterBcContainerHelper -bcContainerHelperPath $bcContainerHelperPath
             Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Environment $('${{ steps.envName.outputs.envName }}'.Split(' ')[0]) and could not locate a secret called ${{ steps.envName.outputs.envName }}_AuthContext`n`n$($authContext.message)"
-            Add-Content -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
           }
 
   Deploy:
@@ -125,7 +125,7 @@ jobs:
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $envName = '${{ matrix.environment }}'.split(' ')[0]
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
@@ -209,11 +209,11 @@ jobs:
             $buildProjects = '${{ needs.Initialization.outputs.projects }}' | ConvertFrom-Json
             $projects = ($projects.Split(',') | Where-Object { $buildProjects -contains $_ }) -join ','
           }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
           Write-Host "environmentName=$([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($environmentName)))"
           Write-Host "environmentName (as Base64)=$environmentName"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
           Write-Host "projects=$projects"
 
       - name: Deploy

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -131,6 +131,7 @@ jobs:
         id: ReadSettings
         with:
           shell: powershell
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -68,12 +68,13 @@ jobs:
           eventId: "DO0104"
 
       - name: Read settings
-        id: ReadSettings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           getEnvironments: '*'
+          useBase64: 'Y'
       
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -64,7 +64,7 @@ jobs:
           $templateUrl = $ENV:templateUrl
           if ($templateUrl) {
             Write-Host "Using Template Url: $templateUrl"
-            Add-Content -Path $env:GITHUB_ENV -Value "templateUrl=$templateUrl"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "templateUrl=$templateUrl"
           }
 
       - name: Calculate DirectCommit
@@ -79,7 +79,7 @@ jobs:
             Write-Host "Running Update AL-Go System Files on a schedule. Setting DirectCommit = Y"
             $directCommit = 'Y'
           }
-          Add-Content -Path $env:GITHUB_ENV -Value "DirectCommit=$directCommit"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "DirectCommit=$directCommit"
 
       - name: Update AL-Go system files
         uses: microsoft/AL-Go-Actions/CheckForUpdates@main

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -44,6 +44,7 @@ jobs:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName,templateUrl
+          useBase64: 'Y'
 
       - name: Read secrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
+        id: ReadSettings
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -51,7 +52,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
+          settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
           secrets: 'ghTokenWorkflow=${{ env.GHTOKENWORKFLOWSECRETNAME }}'
 
       - name: Override templateUrl

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -93,6 +93,7 @@ jobs:
 
         - name: Read secrets
           uses: microsoft/AL-Go-Actions/ReadSecrets@main
+          id: ReadSecrets
           env:
             secrets: ${{ toJson(secrets) }}
           with:
@@ -108,7 +109,7 @@ jobs:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
-            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
+            settingsJson: ${{ steps.ReadSecrets.outputs.SettingsJson }}
             secretsJson: ${{ env.RepoSecrets }}
 
         - name: Cache Business Central Artifacts
@@ -128,7 +129,7 @@ jobs:
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
             projectDependenciesJson: ${{ inputs.projectDependenciesJson }}
-            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
+            settingsJson: ${{ steps.determineArtifactUrl.outputs.SettingsJson }}
             secretsJson: ${{ env.RepoSecrets }}
             buildMode: ${{ inputs.buildMode }}
 
@@ -139,7 +140,7 @@ jobs:
           with:
             shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
             azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
-            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
+            settingsJson: ${{ steps.determineArtifactUrl.outputs.SettingsJson }}
             pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
             parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
@@ -149,7 +150,7 @@ jobs:
           if: success() || failure()
           with:
             shell: ${{ inputs.shell }}
-            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
+            settingsJson: ${{ steps.determineArtifactUrl.outputs.SettingsJson }}
             project: ${{ inputs.project }}
             buildMode: ${{ inputs.buildMode }}
             branchName: ${{ github.ref_name }}

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -85,6 +85,7 @@ jobs:
 
         - name: Read settings
           uses: microsoft/AL-Go-Actions/ReadSettings@main
+          id: ReadSettings
           with:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
@@ -97,7 +98,7 @@ jobs:
           with:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-            settingsJson: ${{ env.Settings }}
+            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
             secrets: ${{ inputs.secrets }}
 
         - name: Determine ArtifactUrl
@@ -107,7 +108,7 @@ jobs:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
-            settingsJson: ${{ env.Settings }}
+            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
             secretsJson: ${{ env.RepoSecrets }}
 
         - name: Cache Business Central Artifacts
@@ -127,7 +128,7 @@ jobs:
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
             projectDependenciesJson: ${{ inputs.projectDependenciesJson }}
-            settingsJson: ${{ env.Settings }}
+            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
             secretsJson: ${{ env.RepoSecrets }}
             buildMode: ${{ inputs.buildMode }}
 
@@ -138,7 +139,7 @@ jobs:
           with:
             shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
             azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
-            settingsJson: ${{ env.Settings }}
+            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
             pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
             parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
@@ -148,7 +149,7 @@ jobs:
           if: success() || failure()
           with:
             shell: ${{ inputs.shell }}
-            settingsJson: ${{ env.Settings }}
+            settingsJson: ${{ steps.ReadSettings.outputs.SettingsJson }}
             project: ${{ inputs.project }}
             buildMode: ${{ inputs.buildMode }}
             branchName: ${{ github.ref_name }}

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -90,6 +90,7 @@ jobs:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
+            useBase64: 'Y'
 
         - name: Read secrets
           uses: microsoft/AL-Go-Actions/ReadSecrets@main

--- a/Tests/DetermineArtifactUrl.Test.ps1
+++ b/Tests/DetermineArtifactUrl.Test.ps1
@@ -8,7 +8,7 @@ $bcContainerHelperPath = $null
 # - applicationDependency - specifies the applicationDependency of the app
 # - additionalCountries - additional countries to use (artifact must exist for all)
 
-Describe "DetermineArtifactUrl" {
+Describe "DetermineArtifactUrl functionality test" {
     BeforeAll {
         . (Join-Path -Path $PSScriptRoot -ChildPath "../Actions/AL-Go-Helper.ps1" -Resolve)
         $bcContainerHelperPath = DownloadAndImportBcContainerHelper -baseFolder $([System.IO.Path]::GetTempPath())
@@ -115,5 +115,29 @@ Describe "DetermineArtifactUrl" {
 
     AfterAll {
         CleanupAfterBcContainerHelper -bcContainerHelperPath $bcContainerHelperPath
+    }
+}
+
+Describe "DetermineArtifactUrl Action Test" {
+    BeforeAll {
+        $actionName = "DetermineArtifactUrl"
+        $scriptRoot = Join-Path $PSScriptRoot "..\Actions\$actionName" -Resolve
+        $scriptName = "$actionName.ps1"
+        $actionScript = GetActionScript -scriptRoot $scriptRoot -scriptName $scriptName
+    }
+
+    It 'Compile Action' {
+        Invoke-Expression $actionScript
+    }
+
+    It 'Test action.yaml matches script' {
+        $permissions = [ordered]@{
+        }
+        $outputs = [ordered]@{
+            "SettingsJson" = "Settings (with modified artifact setting) in compressed Json format (base64 encoded)"
+            "ArtifactUrl" = "The ArtifactUrl to use for building this project"
+            "ArtifactCacheKey" = "The Artifact Cache Key to use for building this project (if using CompilerFolder)"
+        }
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
     }
 }

--- a/Tests/ReadSecrets.Action.Test.ps1
+++ b/Tests/ReadSecrets.Action.Test.ps1
@@ -18,7 +18,7 @@ Describe "ReadSecrets Action Tests" {
         $permissions = [ordered]@{
         }
         $outputs = [ordered]@{
-            "SettingsJson" = "Settings in compressed Json format"
+            "SettingsJson" = "Settings (with modified appDependencyProbingPaths setting) in compressed Json format (base64 encoded)"
         }
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
     }

--- a/Tests/ReadSecrets.Action.Test.ps1
+++ b/Tests/ReadSecrets.Action.Test.ps1
@@ -18,6 +18,7 @@ Describe "ReadSecrets Action Tests" {
         $permissions = [ordered]@{
         }
         $outputs = [ordered]@{
+            "SettingsJson" = "Settings in compressed Json format"
         }
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
     }

--- a/Tests/ReadSettings.Action.Test.ps1
+++ b/Tests/ReadSettings.Action.Test.ps1
@@ -18,7 +18,7 @@ Describe "ReadSettings Action Tests" {
         $permissions = [ordered]@{
         }
         $outputs = [ordered]@{
-            "SettingsJson" = "Settings in compressed Json format"
+            "SettingsJson" = "Settings in compressed Json format (base64 encoded if requested)"
             "GitHubRunnerJson" = "GitHubRunner in compressed Json format"
             "GitHubRunnerShell" = "Shell for GitHubRunner jobs"
             "EnvironmentsJson" = "Environments in compressed Json format"

--- a/Tests/TestActionsHelper.psm1
+++ b/Tests/TestActionsHelper.psm1
@@ -47,6 +47,7 @@ function YamlTest {
         $outputs = @{}
     )
 
+    Write-Host "Testing $actionName action.yaml matches script"
     $emptyActionScript = "function emptyAction {`n[CmdletBinding()]`nParam()`n}`n"
     Invoke-Expression $emptyActionScript
     $emptyCmd = get-command emptyAction

--- a/Tests/TestActionsHelper.psm1
+++ b/Tests/TestActionsHelper.psm1
@@ -83,21 +83,26 @@ function YamlTest {
                 $yaml.AppendLine("  $($name):") | Out-Null
                 $yaml.AppendLine("    description: $description") | Out-Null
                 $yaml.AppendLine("    required: $($required.ToString().ToLowerInvariant())") | Out-Null
-                $envLines.AppendLine("        _$($name): `${{ inputs.$($name) }}")
-                if ($type -eq "System.String" -or $type -eq "System.Int32") {
-                    $parameterString += " -$($name) `$ENV:_$($name)"
-                    if (!$required) {
-                        $yaml.AppendLine("    default: *") | Out-Null
-                    }
-                }
-                elseif ($type -eq "System.Boolean") {
-                    $parameterString += " -$($name) (`$ENV:_$($name) -eq 'Y')"
-                    if (!$required) {
-                        $yaml.AppendLine("    default: 'N'") | Out-Null
-                    }
+                if ($name -eq 'settingsJson') {
+                    $parameterString += " -$($name) '`${{ inputs.$($name) }}'"
                 }
                 else {
-                    throw "Unknown parameter type: $type. Only String, Int and Bool allowed"
+                    $envLines.AppendLine("        _$($name): `${{ inputs.$($name) }}")
+                    if ($type -eq "System.String" -or $type -eq "System.Int32") {
+                        $parameterString += " -$($name) `$ENV:_$($name)"
+                        if (!$required) {
+                            $yaml.AppendLine("    default: *") | Out-Null
+                        }
+                    }
+                    elseif ($type -eq "System.Boolean") {
+                        $parameterString += " -$($name) (`$ENV:_$($name) -eq 'Y')"
+                        if (!$required) {
+                            $yaml.AppendLine("    default: 'N'") | Out-Null
+                        }
+                    }
+                    else {
+                        throw "Unknown parameter type: $type. Only String, Int and Bool allowed"
+                    }
                 }
             }
         }

--- a/Tests/TestActionsHelper.psm1
+++ b/Tests/TestActionsHelper.psm1
@@ -84,6 +84,9 @@ function YamlTest {
                 $yaml.AppendLine("    description: $description") | Out-Null
                 $yaml.AppendLine("    required: $($required.ToString().ToLowerInvariant())") | Out-Null
                 if ($name -eq 'settingsJson') {
+                    # settingsJson is a special case. It is a json string that is base64 encoded
+                    # We do not want to add the settings to environment variables as it takes up a lot of space
+                    # Being base64 encoded, settings won't have a problem with special characters (which is one of the reasons for using environment variables)
                     $parameterString += " -$($name) '`${{ inputs.$($name) }}'"
                     if (!$required) {
                         $yaml.AppendLine("    default: *") | Out-Null

--- a/Tests/TestActionsHelper.psm1
+++ b/Tests/TestActionsHelper.psm1
@@ -85,6 +85,9 @@ function YamlTest {
                 $yaml.AppendLine("    required: $($required.ToString().ToLowerInvariant())") | Out-Null
                 if ($name -eq 'settingsJson') {
                     $parameterString += " -$($name) '`${{ inputs.$($name) }}'"
+                    if (!$required) {
+                        $yaml.AppendLine("    default: *") | Out-Null
+                    }
                 }
                 else {
                     $envLines.AppendLine("        _$($name): `${{ inputs.$($name) }}")

--- a/e2eTests/SetupRepositories.ps1
+++ b/e2eTests/SetupRepositories.ps1
@@ -31,9 +31,9 @@ $settings | Set-JsonContentLF -path $settingsFile
 . (Join-Path $PSScriptRoot "..\Internal\Deploy.ps1") -configName $settingsFile -githubOwner $githubOwner -token $token -github:$github
 
 Write-Host "OUTPUTS:"
-Add-Content -Path $env:GITHUB_OUTPUT -Value "actionsRepo=$actionsRepo"
+Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "actionsRepo=$actionsRepo"
 Write-Host "- actionsRepo=$actionsRepo"
-Add-Content -Path $env:GITHUB_OUTPUT -Value "perTenantExtensionRepo=$perTenantExtensionRepo"
+Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "perTenantExtensionRepo=$perTenantExtensionRepo"
 Write-Host "- perTenantExtensionRepo=$perTenantExtensionRepo"
-Add-Content -Path $env:GITHUB_OUTPUT -Value "appSourceAppRepo=$appSourceAppRepo"
+Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "appSourceAppRepo=$appSourceAppRepo"
 Write-Host "- appSourceAppRepo=$appSourceAppRepo"

--- a/e2eTests/SetupRepositories.ps1
+++ b/e2eTests/SetupRepositories.ps1
@@ -30,9 +30,10 @@ $settings | Set-JsonContentLF -path $settingsFile
 
 . (Join-Path $PSScriptRoot "..\Internal\Deploy.ps1") -configName $settingsFile -githubOwner $githubOwner -token $token -github:$github
 
+Write-Host "OUTPUTS:"
 Add-Content -Path $env:GITHUB_OUTPUT -Value "actionsRepo=$actionsRepo"
-Write-Host "actionsRepo=$actionsRepo"
+Write-Host "- actionsRepo=$actionsRepo"
 Add-Content -Path $env:GITHUB_OUTPUT -Value "perTenantExtensionRepo=$perTenantExtensionRepo"
-Write-Host "perTenantExtensionRepo=$perTenantExtensionRepo"
+Write-Host "- perTenantExtensionRepo=$perTenantExtensionRepo"
 Add-Content -Path $env:GITHUB_OUTPUT -Value "appSourceAppRepo=$appSourceAppRepo"
-Write-Host "appSourceAppRepo=$appSourceAppRepo"
+Write-Host "- appSourceAppRepo=$appSourceAppRepo"

--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -353,6 +353,11 @@ function CreateAlGoRepository {
     $path = Join-Path $tempPath ([GUID]::NewGuid().ToString())
     New-Item $path -ItemType Directory | Out-Null
     Set-Location $path
+    $waitMinutes = Get-Random -Minimum 0 -Maximum 4
+    if ($waitMinutes) {
+        Write-Host "Waiting $waitMinutes minutes"
+        Start-Sleep -seconds ($waitMinutes*60)
+    }
     if ($private) {
         Write-Host -ForegroundColor Yellow "`nCreating private repository $repository (based on $template)"
         invoke-gh repo create $repository --private --clone


### PR DESCRIPTION
Fix for issue #620

Things changed in this PR:
- ReadSettings will now output the settings to GITHUB_OUTPUT instead of GITHUB_ENV
- Actions expecting a settingsJSON will no longer set the input parameter to ENV:_settingsJson, causing the PS script to have an encoding problem (settings might contain special characters) - therefore ReadSettings now needs to output as Base64
- ReadSettings has a parameter on whether to use base64 - set to Y in this version, notifying the action that Base64 response is expected. If this was not done - we might get issues during Update AL-Go System files.
- ReadSecrets and DetermineArtifactUrl did earlier just re-write the settings environment variable. With GITHUB_OUTPUT, they now have to output to GITHUB_OUTPUT as well and the subsequent usages of settings needs to be from there
- ReadSecrets and DetermineArtifactUrl will output base64 if they were given base64 - only ReadSettings will have the useBase64 parameter.

Additional fix:
- removed the string around $ENV:_parameter in the sign action.yaml - no reason for that.

If you want to try this out - you can update AL-Go System Files with freddydk/AL-Go@SettingsEnv - until the branch is deleted (after the merge of this PR) 