### PR TITLE
Substitution pattern problem

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -348,13 +348,13 @@ try {
 
                     # Replace URL's to actions repository first
                     $regex = "^(.*)https:\/\/raw\.githubusercontent\.com\/microsoft\/AL-Go-Actions\/$originalBranch(.*)$"
-                    $replace = "`$1https://raw.githubusercontent.com/$($templateOwner)/AL-Go/$($templateBranch)/Actions`$2"
+                    $replace = "`${1}https://raw.githubusercontent.com/$($templateOwner)/AL-Go/$($templateBranch)/Actions`${2}"
                     $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
 
                     # Replace the owner and repo names in the workflow
                     "actionsRepo","perTenantExtensionRepo","appSourceAppRepo" | ForEach-Object {
                         $regex = "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"
-                        $replace = "`$1$($templateOwner)/$($templateRepos."$_")`$2$($templateBranch)`$3"
+                        $replace = "`${1}$($templateOwner)/$($templateRepos."$_")`${2}$($templateBranch)`${3}"
                         $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
                     }
                     $srcContent = $lines -join "`n"

--- a/Internal/Collect.ps1
+++ b/Internal/Collect.ps1
@@ -157,11 +157,11 @@ try {
             $lines = ([string](Get-ContentLF -path $dstFile)).Split("`n")
             "actionsRepo", "perTenantExtensionRepo", "appSourceAppRepo" | ForEach-Object {
                 $regex = "^(.*)$($config.githubOwner)\/$($config."$_")(.*)$($config.branch)(.*)$"
-                $replace = "`$1$($originalOwnerAndRepo."$_")`$2$originalBranch`$3"
+                $replace = "`${1}$($originalOwnerAndRepo."$_")`${2}$originalBranch`${3}"
                 $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
             }
             if ($_.Name -eq "AL-Go-Helper.ps1") {
-                $lines = $lines | ForEach-Object { $_ -replace '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)"(.*)$', "`$1`$defaultBcContainerHelperVersion`$2=`$3""""`$5" }
+                $lines = $lines | ForEach-Object { $_ -replace '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)"(.*)$', "`${1}`$defaultBcContainerHelperVersion`${2}=`${3}""""`${5}" }
             }
             [System.IO.File]::WriteAllText($srcFile, "$($lines -join "`n")`n")
         }

--- a/Internal/Deploy.ps1
+++ b/Internal/Deploy.ps1
@@ -186,8 +186,6 @@ try {
                 }
 
                 # Replace the owner and repo names in the workflow
-                Write-Host "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"
-                Write-Host "`${1}$useRepo`${2}$($useBranch)`${3}"
                 $regex = "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"
                 $replace = "`${1}$useRepo`${2}$($useBranch)`${3}"
                 $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }

--- a/Internal/Deploy.ps1
+++ b/Internal/Deploy.ps1
@@ -186,6 +186,8 @@ try {
                 }
 
                 # Replace the owner and repo names in the workflow
+                Write-Host "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"
+                Write-Host "`$1$useRepo`$2$($useBranch)`$3"
                 $regex = "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"
                 $replace = "`$1$useRepo`$2$($useBranch)`$3"
                 $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }

--- a/Internal/Deploy.ps1
+++ b/Internal/Deploy.ps1
@@ -181,20 +181,20 @@ try {
                 # When deploying to a release branch, these URLs are replaced by the following code
                 if ($config.branch -eq 'preview') {
                     $regex = "^(.*)https:\/\/raw\.githubusercontent\.com\/microsoft\/AL-Go-Actions\/$originalBranch(.*)$"
-                    $replace = "`$1https://raw.githubusercontent.com/$srcOwnerAndRepo/$($srcSHA)/Actions`$2"
+                    $replace = "`${1}https://raw.githubusercontent.com/$srcOwnerAndRepo/$($srcSHA)/Actions`${2}"
                     $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
                 }
 
                 # Replace the owner and repo names in the workflow
                 Write-Host "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"
-                Write-Host "`$1$useRepo`$2$($useBranch)`$3"
+                Write-Host "`${1}$useRepo`${2}$($useBranch)`${3}"
                 $regex = "^(.*)$($originalOwnerAndRepo."$_")(.*)$originalBranch(.*)$"
-                $replace = "`$1$useRepo`$2$($useBranch)`$3"
+                $replace = "`${1}$useRepo`${2}$($useBranch)`${3}"
                 $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
             }
             if ($_.Name -eq "AL-Go-Helper.ps1" -and ($config.ContainsKey("defaultBcContainerHelperVersion") -and $config.defaultBcContainerHelperVersion)) {
                 # replace defaultBcContainerHelperVersion (even if a version is set)
-                $lines = $lines | ForEach-Object { $_ -replace '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)" # (.*)$', "`$1`$defaultBcContainerHelperVersion`$2=`$3""$($config.defaultBcContainerHelperVersion)"" # `$5" }
+                $lines = $lines | ForEach-Object { $_ -replace '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)" # (.*)$', "`${1}`$defaultBcContainerHelperVersion`${2}=`${3}""$($config.defaultBcContainerHelperVersion)"" # `${5}" }
             }
             [System.IO.File]::WriteAllText($dstFile, "$($lines -join "`n")`n")
         }

--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -400,12 +400,12 @@ function CreateAlGoRepository {
         
             # Replace URL's to actions repository first
             $regex = "^(.*)https:\/\/raw\.githubusercontent\.com\/microsoft\/AL-Go-Actions\/main(.*)$"
-            $replace = "`$1https://raw.githubusercontent.com/$($templateOwner)/AL-Go/$($templateBranch)/Actions`$2"
+            $replace = "`${1}https://raw.githubusercontent.com/$($templateOwner)/AL-Go/$($templateBranch)/Actions`${2}"
             $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
         
             # Replace AL-Go-Actions references
             $regex = "^(.*)microsoft\/AL-Go-Actions(.*)main(.*)$"
-            $replace = "`$1$($templateOwner)/AL-Go/Actions`$2$($templateBranch)`$3"
+            $replace = "`${1}$($templateOwner)/AL-Go/Actions`${2}$($templateBranch)`${3}"
             $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
         
             $content = "$($lines -join "`n")`n"


### PR DESCRIPTION
When using regex and the substitution pattern has replacements starting with a number (branch, repo, SHA, ...) regex will fail.
This lead to wrong deployment to preview ealier.