### PR TITLE
Secrets refactoring part II

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1142,7 +1142,7 @@ function CheckAppDependencyProbingPaths {
                             Push-Location $projectPath
                             try {
                                 foreach($propertyName in "appFolders", "testFolders", "bcptTestFolders") {
-                                    Write-Host "Adding folders from $depProject to $_ in $project"
+                                    Write-Host "Adding folders from $depProject to $propertyName in $project"
                                     $found = $false
                                     foreach($_ in $depSettings."$propertyName") {
                                         $folder = Resolve-Path -Path (Join-Path $baseFolder "$depProject/$_") -Relative

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1137,7 +1137,7 @@ function CheckAppDependencyProbingPaths {
                             $dependencyIds = @( @($settings.appDependencies + $settings.testDependencies) | ForEach-Object { $_.id })
                             $thisIncludeOnlyAppIds = @($dependencyIds + $includeOnlyAppIds + $dependency.alwaysIncludeApps)
                             $depSettings = ReadSettings -baseFolder $baseFolder -project $depProject -workflowName "CI/CD"
-                            $depSettings = AnalyzeRepo -settings $depSettings -token $token -baseFolder $baseFolder -project $project -includeOnlyAppIds $thisIncludeOnlyAppIds -doNotCheckArtifactSetting -doNotIssueWarnings
+                            $depSettings = AnalyzeRepo -settings $depSettings -token $token -baseFolder $baseFolder -project $depProject -includeOnlyAppIds $thisIncludeOnlyAppIds -doNotCheckArtifactSetting -doNotIssueWarnings
                             $depSettings = CheckAppDependencyProbingPaths -settings $depSettings -token $token -baseFolder $baseFolder -project $depProject -includeOnlyAppIds $thisIncludeOnlyAppIds
 
                             $projectPath = Join-Path $baseFolder $depProject -Resolve

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1066,8 +1066,7 @@ function CheckAppDependencyProbingPaths {
                     New-Object -Type PSObject -Property $_
                 }
             })
-        $settings.appDependencyProbingPaths | ForEach-Object {
-            $dependency = $_
+        foreach($dependency in settings.appDependencyProbingPaths) {
             if (-not ($dependency.PsObject.Properties.name -eq "repo")) {
                 throw "The Setting AppDependencyProbingPaths needs to contain a repo property, pointing to the repository on which your project have a dependency"
             }
@@ -1126,12 +1125,11 @@ function CheckAppDependencyProbingPaths {
                     OutputWarning "Dependencies with release_status 'include' must be to other projects in the same repository."
                 }
                 else {
-                    $dependency.projects.Split(',') | ForEach-Object {
-                        if ($_ -eq '*') {
+                    foreach($depProject in $dependency.projects.Split(',')) {
+                        if ($depProject -eq '*') {
                             OutputWarning "Dependencies to the same repository cannot specify all projects (*)"
                         }
                         else {
-                            $depProject = $_
                             Write-Host "Identified dependency to project $depProject in the same repository"
 
                             $dependencyIds = @( @($settings.appDependencies + $settings.testDependencies) | ForEach-Object { $_.id })
@@ -1143,11 +1141,10 @@ function CheckAppDependencyProbingPaths {
                             $projectPath = Join-Path $baseFolder $project -Resolve
                             Push-Location $projectPath
                             try {
-                                "appFolders", "testFolders", "bcptTestFolders" | ForEach-Object {
-                                    $propertyName = $_
+                                foreach($propertyName in "appFolders", "testFolders", "bcptTestFolders") {
                                     Write-Host "Adding folders from $depProject to $_ in $project"
                                     $found = $false
-                                    $depSettings."$propertyName" | ForEach-Object {
+                                    foreach($_ in $depSettings."$propertyName") {
                                         $folder = Resolve-Path -Path (Join-Path $baseFolder "$depProject/$_") -Relative
                                         if (!$settings."$propertyName".Contains($folder)) {
                                             $settings."$propertyName" += @($folder)

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1051,7 +1051,8 @@ function CheckAppDependencyProbingPaths {
         [hashTable] $settings,
         $token,
         [string] $baseFolder = $ENV:GITHUB_WORKSPACE,
-        [string] $project = '.'
+        [string] $project = '.',
+        [string[]] $includeOnlyAppIds
     )
 
     Write-Host "Checking appDependencyProbingPaths"
@@ -1134,9 +1135,10 @@ function CheckAppDependencyProbingPaths {
                             Write-Host "Identified dependency to project $depProject in the same repository"
 
                             $dependencyIds = @( @($settings.appDependencies + $settings.testDependencies) | ForEach-Object { $_.id })
+                            $thisIncludeOnlyAppIds = @($dependencyIds + $includeOnlyAppIds + $dependency.alwaysIncludeApps)
                             $depSettings = ReadSettings -baseFolder $baseFolder -project $depProject -workflowName "CI/CD"
-                            $depSettings = AnalyzeRepo -settings $depSettings -token $token -baseFolder $baseFolder -project $project -doNotCheckArtifactSetting -doNotIssueWarnings
-                            $depSettings = CheckAppDependencyProbingPaths -settings $depSettings -token $token -baseFolder $baseFolder -project $depProject
+                            $depSettings = AnalyzeRepo -settings $depSettings -token $token -baseFolder $baseFolder -project $project -includeOnlyAppIds $thisIncludeOnlyAppIds -doNotIssueWarnings
+                            $depSettings = CheckAppDependencyProbingPaths -settings $depSettings -token $token -baseFolder $baseFolder -project $depProject -includeOnlyAppIds $thisIncludeOnlyAppIds
 
                             Push-Location $projectPath
                             try {

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1166,14 +1166,12 @@ function CheckAppDependencyProbingPaths {
     }
 }
 
-
-
 function Get-ProjectFolders {
     Param(
         [string] $baseFolder,
         [string] $project,
         [switch] $includeALGoFolder,
-        [string[]] $includeOnlyAppIds
+        [string[]] $includeOnlyAppIds,
         $token
     )
 

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -823,11 +823,8 @@ function AnalyzeRepo {
         [string] $project = '.',
         [string] $insiderSasToken,
         [switch] $doNotCheckArtifactSetting,
-        [switch] $doNotCheckAppDependencyProbingPaths,
         [switch] $doNotIssueWarnings,
-        [string[]] $includeOnlyAppIds,
-        [string] $server_url = $ENV:GITHUB_SERVER_URL,
-        [string] $repository = $ENV:GITHUB_REPOSITORY
+        [string[]] $includeOnlyAppIds
     )
 
     $settings = $settings | Copy-HashTable
@@ -1034,116 +1031,6 @@ function AnalyzeRepo {
         Write-Host "::endgroup::"
     }
 
-    Write-Host "Checking project dependencies"
-
-    if (!$doNotCheckAppDependencyProbingPaths) {
-        Write-Host "Checking appDependencyProbingPaths"
-        if ($settings.appDependencyProbingPaths) {
-            $settings.appDependencyProbingPaths = @($settings.appDependencyProbingPaths | ForEach-Object {
-                    if ($_.GetType().Name -eq "PSCustomObject") {
-                        $_
-                    }
-                    else {
-                        New-Object -Type PSObject -Property $_
-                    }
-                })
-            $settings.appDependencyProbingPaths | ForEach-Object {
-                $dependency = $_
-                if (-not ($dependency.PsObject.Properties.name -eq "repo")) {
-                    throw "The Setting AppDependencyProbingPaths needs to contain a repo property, pointing to the repository on which your project have a dependency"
-                }
-                if ($dependency.Repo -eq ".") {
-                    $dependency.Repo = "$server_url/$repository"
-                }
-                elseif ($dependency.Repo -notlike "https://*") {
-                    $dependency.Repo = "$server_url/$($dependency.Repo)"
-                }
-                if (-not ($dependency.PsObject.Properties.name -eq "Version")) {
-                    $dependency | Add-Member -name "Version" -MemberType NoteProperty -Value "latest"
-                }
-                if (-not ($dependency.PsObject.Properties.name -eq "projects")) {
-                    $dependency | Add-Member -name "projects" -MemberType NoteProperty -Value "*"
-                }
-                elseif ([String]::IsNullOrEmpty($dependency.projects)) {
-                    $dependency.projects = '*'
-                }
-                if (-not ($dependency.PsObject.Properties.name -eq "release_status")) {
-                    $dependency | Add-Member -name "release_status" -MemberType NoteProperty -Value "release"
-                }
-                if (-not ($dependency.PsObject.Properties.name -eq "branch")) {
-                    $dependency | Add-Member -name "branch" -MemberType NoteProperty -Value "main"
-                }
-                Write-Host "Dependency to projects '$($dependency.projects)' in $($dependency.Repo)@$($dependency.branch), version $($dependency.version), release status $($dependency.release_status)"
-                if ($dependency.PsObject.Properties.name -eq "AuthTokenSecret") {
-                    Write-Host "Using secret $($dependency.AuthTokenSecret) for access to repository"
-                    $secrets = $env:Secrets | ConvertFrom-Json
-                    # AuthTokenSecret is specified, use the value of that secret
-                    $dependency.AuthTokenSecret = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets."$($dependency.AuthTokenSecret)"))
-                }
-                else {
-                    if ($token) {
-                        Write-Host "Using GITHUB_TOKEN for access to repository"
-                    }
-                    else {
-                        Write-Host "No token available, will attempt to invoke gh auth token for access to repository"
-                    }
-                    $dependency | Add-Member -name "AuthTokenSecret" -MemberType NoteProperty -Value $token
-                }
-                if (-not ($dependency.PsObject.Properties.name -eq "alwaysIncludeApps")) {
-                    $dependency | Add-Member -name "alwaysIncludeApps" -MemberType NoteProperty -Value @()
-                }
-                elseif ($dependency.alwaysIncludeApps -is [string]) {
-                    $dependency.alwaysIncludeApps = $dependency.alwaysIncludeApps.Split(' ')
-                }
-                if ($dependency.alwaysIncludeApps) {
-                    Write-Host "Always including apps: $($dependency.alwaysIncludeApps -join ", ")"
-                }
-
-                if ($dependency.release_status -eq "include") {
-                    if ($dependency.Repo -ne "$server_url/$repository") {
-                        OutputWarning "Dependencies with release_status 'include' must be to other projects in the same repository."
-                    }
-                    else {
-                        $dependency.projects.Split(',') | ForEach-Object {
-                            if ($_ -eq '*') {
-                                OutputWarning "Dependencies to the same repository cannot specify all projects (*)"
-                            }
-                            else {
-                                $depProject = $_
-                                Write-Host "Identified dependency to project $depProject in the same repository"
-
-                                $dependencyIds = @( @($settings.appDependencies + $settings.testDependencies) | ForEach-Object { $_.id })
-                                $depSettings = ReadSettings -baseFolder $baseFolder -project $depProject -workflowName "CI/CD"
-                                $depSettings = AnalyzeRepo -settings $depSettings -token $token -baseFolder $baseFolder -project $depProject -includeOnlyAppIds @($dependencyIds + $includeOnlyAppIds + $dependency.alwaysIncludeApps) -doNotIssueWarnings -doNotCheckArtifactSetting -server_url $server_url -repository $repository
-
-                                Push-Location $projectPath
-                                try {
-                                    "appFolders", "testFolders", "bcptTestFolders" | ForEach-Object {
-                                        $propertyName = $_
-                                        Write-Host "Adding folders from $depProject to $_"
-                                        $found = $false
-                                        $depSettings."$propertyName" | ForEach-Object {
-                                            $folder = Resolve-Path -Path (Join-Path $baseFolder "$depProject/$_") -Relative
-                                            if (!$settings."$propertyName".Contains($folder)) {
-                                                $settings."$propertyName" += @($folder)
-                                                $found = $true
-                                                Write-Host "- $folder"
-                                            }
-                                        }
-                                        if (!$found) { Write-Host "- No folders added" }
-                                    }
-                                }
-                                finally {
-                                    Pop-Location
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     if (!$settings.doNotRunBcptTests -and -not $settings.bcptTestFolders) {
         if (!$doNotIssueWarnings) { OutputWarning -message "No performance test apps found in bcptTestFolders in $ALGoSettingsFile" }
         $settings.doNotRunBcptTests = $true
@@ -1159,14 +1046,134 @@ function AnalyzeRepo {
     $settings
 }
 
+function CheckAppDependencyProbingPaths {
+    Param(
+        [hashTable] $settings,
+        $token,
+        [string] $baseFolder = $ENV:GITHUB_WORKSPACE,
+        [string] $project = '.'
+    )
+
+    Write-Host "Checking appDependencyProbingPaths"
+    $settings = $settings | Copy-HashTable
+    if ($settings.appDependencyProbingPaths) {
+        $settings.appDependencyProbingPaths = @($settings.appDependencyProbingPaths | ForEach-Object {
+                if ($_.GetType().Name -eq "PSCustomObject") {
+                    $_
+                }
+                else {
+                    New-Object -Type PSObject -Property $_
+                }
+            })
+        $settings.appDependencyProbingPaths | ForEach-Object {
+            $dependency = $_
+            if (-not ($dependency.PsObject.Properties.name -eq "repo")) {
+                throw "The Setting AppDependencyProbingPaths needs to contain a repo property, pointing to the repository on which your project have a dependency"
+            }
+            if ($dependency.Repo -eq ".") {
+                $dependency.Repo = "$ENV:GITHUB_SERVER_URL/$ENV:GITHUB_REPOSITORY"
+            }
+            elseif ($dependency.Repo -notlike "https://*") {
+                $dependency.Repo = "$ENV:GITHUB_SERVER_URL/$($dependency.Repo)"
+            }
+            if (-not ($dependency.PsObject.Properties.name -eq "Version")) {
+                $dependency | Add-Member -name "Version" -MemberType NoteProperty -Value "latest"
+            }
+            if (-not ($dependency.PsObject.Properties.name -eq "projects")) {
+                $dependency | Add-Member -name "projects" -MemberType NoteProperty -Value "*"
+            }
+            elseif ([String]::IsNullOrEmpty($dependency.projects)) {
+                $dependency.projects = '*'
+            }
+            if (-not ($dependency.PsObject.Properties.name -eq "release_status")) {
+                $dependency | Add-Member -name "release_status" -MemberType NoteProperty -Value "release"
+            }
+            if (-not ($dependency.PsObject.Properties.name -eq "branch")) {
+                $dependency | Add-Member -name "branch" -MemberType NoteProperty -Value "main"
+            }
+            Write-Host "Dependency to projects '$($dependency.projects)' in $($dependency.Repo)@$($dependency.branch), version $($dependency.version), release status $($dependency.release_status)"
+            if ($dependency.PsObject.Properties.name -eq "AuthTokenSecret") {
+                Write-Host "Using secret $($dependency.AuthTokenSecret) for access to repository"
+                if ("$env:Secrets" -eq "") {
+                    throw "Internal error. Secrets are not available!"
+                }
+                $secrets = $env:Secrets | ConvertFrom-Json
+                # AuthTokenSecret is specified, use the value of that secret
+                $dependency.AuthTokenSecret = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets."$($dependency.AuthTokenSecret)"))
+            }
+            else {
+                if ($token) {
+                    Write-Host "Using GITHUB_TOKEN for access to repository"
+                }
+                else {
+                    Write-Host "No token available, will attempt to invoke gh auth token for access to repository"
+                }
+                $dependency | Add-Member -name "AuthTokenSecret" -MemberType NoteProperty -Value $token
+            }
+            if (-not ($dependency.PsObject.Properties.name -eq "alwaysIncludeApps")) {
+                $dependency | Add-Member -name "alwaysIncludeApps" -MemberType NoteProperty -Value @()
+            }
+            elseif ($dependency.alwaysIncludeApps -is [string]) {
+                $dependency.alwaysIncludeApps = $dependency.alwaysIncludeApps.Split(' ')
+            }
+            if ($dependency.alwaysIncludeApps) {
+                Write-Host "Always including apps: $($dependency.alwaysIncludeApps -join ", ")"
+            }
+
+            if ($dependency.release_status -eq "include") {
+                if ($dependency.Repo -ne "$ENV:GITHUB_SERVER_URL/$ENV:GITHUB_REPOSITORY") {
+                    OutputWarning "Dependencies with release_status 'include' must be to other projects in the same repository."
+                }
+                else {
+                    $dependency.projects.Split(',') | ForEach-Object {
+                        if ($_ -eq '*') {
+                            OutputWarning "Dependencies to the same repository cannot specify all projects (*)"
+                        }
+                        else {
+                            $depProject = $_
+                            Write-Host "Identified dependency to project $depProject in the same repository"
+
+                            $dependencyIds = @( @($settings.appDependencies + $settings.testDependencies) | ForEach-Object { $_.id })
+                            $depSettings = ReadSettings -baseFolder $baseFolder -project $depProject -workflowName "CI/CD"
+                            $depSettings = AnalyzeRepo -settings $depSettings -token $token -baseFolder $baseFolder -project $project -doNotCheckArtifactSetting -doNotIssueWarnings
+                            $depSettings = CheckAppDependencyProbingPaths -settings $depSettings -token $token -baseFolder $baseFolder -project $depProject
+
+                            Push-Location $projectPath
+                            try {
+                                "appFolders", "testFolders", "bcptTestFolders" | ForEach-Object {
+                                    $propertyName = $_
+                                    Write-Host "Adding folders from $depProject to $_"
+                                    $found = $false
+                                    $depSettings."$propertyName" | ForEach-Object {
+                                        $folder = Resolve-Path -Path (Join-Path $baseFolder "$depProject/$_") -Relative
+                                        if (!$settings."$propertyName".Contains($folder)) {
+                                            $settings."$propertyName" += @($folder)
+                                            $found = $true
+                                            Write-Host "- $folder"
+                                        }
+                                    }
+                                    if (!$found) { Write-Host "- No folders added" }
+                                }
+                            }
+                            finally {
+                                Pop-Location
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+
 function Get-ProjectFolders {
     Param(
         [string] $baseFolder,
         [string] $project,
         [switch] $includeALGoFolder,
-        [string[]] $includeOnlyAppIds,
-        [string] $server_url = $ENV:GITHUB_SERVER_URL,
-        [string] $repository = $ENV:GITHUB_REPOSITORY,
+        [string[]] $includeOnlyAppIds
         $token
     )
 
@@ -1179,7 +1186,7 @@ function Get-ProjectFolders {
 
     $projectFolders = @()
     $settings = ReadSettings -baseFolder $baseFolder -project $project -workflowName "CI/CD"
-    $settings = AnalyzeRepo -settings $settings -token $token -baseFolder $baseFolder -project $project -includeOnlyAppIds $includeOnlyAppIds -doNotIssueWarnings -doNotCheckArtifactSetting -server_url $server_url -repository $repository -doNotCheckAppDependencyProbingPaths
+    $settings = AnalyzeRepo -settings $settings -token $token -baseFolder $baseFolder -project $project -includeOnlyAppIds $includeOnlyAppIds -doNotIssueWarnings -doNotCheckArtifactSetting
     $AlGoFolderArr = @()
     if ($includeALGoFolder) { $AlGoFolderArr = @($ALGoFolderName) }
     Set-Location $baseFolder
@@ -1604,10 +1611,7 @@ function CreateDevEnv {
             }
         }
 
-        $params = @{
-            "settings"   = $settings
-            "baseFolder" = $projectFolder
-        }
+        $params = @{}
         if ($kind -eq "local") {
             $params += @{
                 "insiderSasToken" = $insiderSasToken
@@ -1618,21 +1622,22 @@ function CreateDevEnv {
                 "doNotCheckArtifactSetting" = $true
             }
         }
-        $repo = AnalyzeRepo @params
-        if ((-not $repo.appFolders) -and (-not $repo.testFolders)) {
+        $settings = AnalyzeRepo -settings $settings -baseFolder $baseFolder -project $project @params
+        $settings = CheckAppDependencyProbingPaths -settings $settings -baseFolder $baseFolder -project $project
+        if ((-not $settings.appFolders) -and (-not $settings.testFolders)) {
             Write-Host "Repository is empty"
         }
 
-        if ($kind -eq "local" -and $repo.type -eq "AppSource App" ) {
+        if ($kind -eq "local" -and $settings.type -eq "AppSource App" ) {
             if ($licenseFileUrl -eq "") {
                 OutputWarning -message "When building an AppSource App, you should create a secret called LicenseFileUrl, containing a secure URL to your license file with permission to the objects used in the app."
             }
         }
 
-        $installApps = $repo.installApps
-        $installTestApps = $repo.installTestApps
+        $installApps = $settings.installApps
+        $installTestApps = $settings.installTestApps
 
-        if ($repo.appDependencyProbingPaths) {
+        if ($settings.appDependencyProbingPaths) {
             Write-Host "Downloading dependencies ..."
 
             if (Test-Path $dependenciesFolder) {
@@ -1642,7 +1647,7 @@ function CreateDevEnv {
                 New-Item $dependenciesFolder -ItemType Directory | Out-Null
             }
 
-            $repo.appDependencyProbingPaths = @($repo.appDependencyProbingPaths | ForEach-Object {
+            $settings.appDependencyProbingPaths = @($settings.appDependencyProbingPaths | ForEach-Object {
                     if ($_.GetType().Name -eq "PSCustomObject") {
                         $_
                     }
@@ -1650,7 +1655,7 @@ function CreateDevEnv {
                         New-Object -Type PSObject -Property $_
                     }
                 })
-            Get-Dependencies -probingPathsJson $repo.appDependencyProbingPaths -saveToPath $dependenciesFolder -api_url 'https://api.github.com' | ForEach-Object {
+            Get-Dependencies -probingPathsJson $settings.appDependencyProbingPaths -saveToPath $dependenciesFolder -api_url 'https://api.github.com' | ForEach-Object {
                 if ($_.startswith('(')) {
                     $installTestApps += $_
                 }
@@ -1660,9 +1665,9 @@ function CreateDevEnv {
             }
         }
 
-        if ($repo.versioningStrategy -eq -1) {
+        if ($settings.versioningStrategy -eq -1) {
             if ($kind -eq "cloud") { throw "Versioningstrategy -1 cannot be used on cloud" }
-            $artifactVersion = [Version]$repo.artifact.Split('/')[4]
+            $artifactVersion = [Version]$settings.artifact.Split('/')[4]
             $runAlPipelineParams += @{
                 "appVersion"  = "$($artifactVersion.Major).$($artifactVersion.Minor)"
                 "appBuild"    = $artifactVersion.Build
@@ -1670,14 +1675,14 @@ function CreateDevEnv {
             }
         }
         else {
-            if (($repo.versioningStrategy -band 16) -eq 16) {
+            if (($settings.versioningStrategy -band 16) -eq 16) {
                 $runAlPipelineParams += @{
-                    "appVersion" = $repo.repoVersion
+                    "appVersion" = $settings.repoVersion
                 }
             }
             $appBuild = 0
             $appRevision = 0
-            switch ($repo.versioningStrategy -band 15) {
+            switch ($settings.versioningStrategy -band 15) {
                 2 {
                     # USE DATETIME
                     $appBuild = [Int32]([DateTime]::UtcNow.ToString('yyyyMMdd'))
@@ -1716,7 +1721,7 @@ function CreateDevEnv {
 
         if ($kind -eq "local") {
             $runAlPipelineParams += @{
-                "artifact"   = $repo.artifact.replace('{INSIDERSASTOKEN}', $insiderSasToken)
+                "artifact"   = $settings.artifact.replace('{INSIDERSASTOKEN}', $insiderSasToken)
                 "auth"       = $auth
                 "credential" = $credential
             }
@@ -1759,7 +1764,7 @@ function CreateDevEnv {
                 $baseApp = Get-BcPublishedApps -bcAuthContext $authContext -environment $environmentName | Where-Object { $_.Name -eq "Base Application" }
             }
             else {
-                $countryCode = $repo.country
+                $countryCode = $settings.country
                 New-BcEnvironment -bcAuthContext $authContext -environment $environmentName -countryCode $countryCode -environmentType "Sandbox" | Out-Null
                 do {
                     Start-Sleep -Seconds 10
@@ -1799,7 +1804,7 @@ function CreateDevEnv {
         "enableAppSourceCop",
         "enablePerTenantExtensionCop",
         "enableUICop" | ForEach-Object {
-            if ($repo."$_") { $runAlPipelineParams += @{ "$_" = $true } }
+            if ($settings."$_") { $runAlPipelineParams += @{ "$_" = $true } }
         }
 
         $sharedFolder = ""
@@ -1808,29 +1813,29 @@ function CreateDevEnv {
         }
 
         Run-AlPipeline @runAlPipelineParams `
-            -vsixFile $repo.vsixFile `
+            -vsixFile $settings.vsixFile `
             -pipelinename $workflowName `
             -imageName "" `
-            -memoryLimit $repo.memoryLimit `
+            -memoryLimit $settings.memoryLimit `
             -baseFolder $projectFolder `
             -sharedFolder $sharedFolder `
             -licenseFile $licenseFileUrl `
             -installApps $installApps `
             -installTestApps $installTestApps `
-            -installOnlyReferencedApps:$repo.installOnlyReferencedApps `
-            -appFolders $repo.appFolders `
-            -testFolders $repo.testFolders `
+            -installOnlyReferencedApps:$settings.installOnlyReferencedApps `
+            -appFolders $settings.appFolders `
+            -testFolders $settings.testFolders `
             -testResultsFile $testResultsFile `
             -testResultsFormat 'JUnit' `
-            -customCodeCops $repo.customCodeCops `
+            -customCodeCops $settings.customCodeCops `
             -azureDevOps:($caller -eq 'AzureDevOps') `
             -gitLab:($caller -eq 'GitLab') `
             -gitHubActions:($caller -eq 'GitHubActions') `
-            -failOn $repo.failOn `
-            -treatTestFailuresAsWarnings:$repo.treatTestFailuresAsWarnings `
-            -rulesetFile $repo.rulesetFile `
-            -AppSourceCopMandatoryAffixes $repo.appSourceCopMandatoryAffixes `
-            -obsoleteTagMinAllowedMajorMinor $repo.obsoleteTagMinAllowedMajorMinor `
+            -failOn $settings.failOn `
+            -treatTestFailuresAsWarnings:$settings.treatTestFailuresAsWarnings `
+            -rulesetFile $settings.rulesetFile `
+            -AppSourceCopMandatoryAffixes $settings.appSourceCopMandatoryAffixes `
+            -obsoleteTagMinAllowedMajorMinor $settings.obsoleteTagMinAllowedMajorMinor `
             -doNotRunTests `
             -doNotRunBcptTests `
             -useDevEndpoint `

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1140,12 +1140,12 @@ function CheckAppDependencyProbingPaths {
                             $depSettings = AnalyzeRepo -settings $depSettings -token $token -baseFolder $baseFolder -project $depProject -includeOnlyAppIds $thisIncludeOnlyAppIds -doNotCheckArtifactSetting -doNotIssueWarnings
                             $depSettings = CheckAppDependencyProbingPaths -settings $depSettings -token $token -baseFolder $baseFolder -project $depProject -includeOnlyAppIds $thisIncludeOnlyAppIds
 
-                            $projectPath = Join-Path $baseFolder $depProject -Resolve
+                            $projectPath = Join-Path $baseFolder $project -Resolve
                             Push-Location $projectPath
                             try {
                                 "appFolders", "testFolders", "bcptTestFolders" | ForEach-Object {
                                     $propertyName = $_
-                                    Write-Host "Adding folders from $depProject to $_"
+                                    Write-Host "Adding folders from $depProject to $_ in $project"
                                     $found = $false
                                     $depSettings."$propertyName" | ForEach-Object {
                                         $folder = Resolve-Path -Path (Join-Path $baseFolder "$depProject/$_") -Relative

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1066,7 +1066,7 @@ function CheckAppDependencyProbingPaths {
                     New-Object -Type PSObject -Property $_
                 }
             })
-        foreach($dependency in settings.appDependencyProbingPaths) {
+        foreach($dependency in $settings.appDependencyProbingPaths) {
             if (-not ($dependency.PsObject.Properties.name -eq "repo")) {
                 throw "The Setting AppDependencyProbingPaths needs to contain a repo property, pointing to the repository on which your project have a dependency"
             }

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1137,7 +1137,7 @@ function CheckAppDependencyProbingPaths {
                             $dependencyIds = @( @($settings.appDependencies + $settings.testDependencies) | ForEach-Object { $_.id })
                             $thisIncludeOnlyAppIds = @($dependencyIds + $includeOnlyAppIds + $dependency.alwaysIncludeApps)
                             $depSettings = ReadSettings -baseFolder $baseFolder -project $depProject -workflowName "CI/CD"
-                            $depSettings = AnalyzeRepo -settings $depSettings -token $token -baseFolder $baseFolder -project $project -includeOnlyAppIds $thisIncludeOnlyAppIds -doNotIssueWarnings
+                            $depSettings = AnalyzeRepo -settings $depSettings -token $token -baseFolder $baseFolder -project $project -includeOnlyAppIds $thisIncludeOnlyAppIds -doNotCheckArtifactSetting -doNotIssueWarnings
                             $depSettings = CheckAppDependencyProbingPaths -settings $depSettings -token $token -baseFolder $baseFolder -project $depProject -includeOnlyAppIds $thisIncludeOnlyAppIds
 
                             Push-Location $projectPath

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1164,6 +1164,7 @@ function CheckAppDependencyProbingPaths {
             }
         }
     }
+    $settings
 }
 
 function Get-ProjectFolders {

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1140,6 +1140,7 @@ function CheckAppDependencyProbingPaths {
                             $depSettings = AnalyzeRepo -settings $depSettings -token $token -baseFolder $baseFolder -project $project -includeOnlyAppIds $thisIncludeOnlyAppIds -doNotCheckArtifactSetting -doNotIssueWarnings
                             $depSettings = CheckAppDependencyProbingPaths -settings $depSettings -token $token -baseFolder $baseFolder -project $depProject -includeOnlyAppIds $thisIncludeOnlyAppIds
 
+                            $projectPath = Join-Path $baseFolder $depProject -Resolve
                             Push-Location $projectPath
                             try {
                                 "appFolders", "testFolders", "bcptTestFolders" | ForEach-Object {

--- a/Actions/AddExistingApp/AddExistingApp.ps1
+++ b/Actions/AddExistingApp/AddExistingApp.ps1
@@ -226,7 +226,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/AnalyzeTests/AnalyzeTests.ps1
+++ b/Actions/AnalyzeTests/AnalyzeTests.ps1
@@ -45,7 +45,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
 

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -538,7 +538,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/CreateApp/CreateApp.ps1
+++ b/Actions/CreateApp/CreateApp.ps1
@@ -140,7 +140,7 @@ try {
 
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/CreateApp/CreateApp.ps1
+++ b/Actions/CreateApp/CreateApp.ps1
@@ -63,7 +63,7 @@ try {
     if ($type -eq "Performance Test App") {
         try {
             $settings = ReadSettings -baseFolder $baseFolder -project $project
-            $settings = AnalyzeRepo -settings $settings -token $token -baseFolder $baseFolder -project $project -doNotIssueWarnings -doNotCheckAppDependencyProbingPaths
+            $settings = AnalyzeRepo -settings $settings -token $token -baseFolder $baseFolder -project $project -doNotIssueWarnings
             $folders = Download-Artifacts -artifactUrl $settings.artifact -includePlatform
             $sampleApp = Join-Path $folders[0] "Applications.*\Microsoft_Performance Toolkit Samples_*.app"
             if (Test-Path $sampleApp) {

--- a/Actions/CreateDevelopmentEnvironment/CreateDevelopmentEnvironment.ps1
+++ b/Actions/CreateDevelopmentEnvironment/CreateDevelopmentEnvironment.ps1
@@ -54,7 +54,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
+++ b/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
@@ -68,7 +68,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/Deliver/Deliver.ps1
+++ b/Actions/Deliver/Deliver.ps1
@@ -177,7 +177,7 @@ try {
             Write-Host "Found custom script $customScript for delivery target $deliveryTarget"
             
             $projectSettings = ReadSettings -baseFolder $baseFolder -project $thisProject
-            $projectSettings = AnalyzeRepo -settings $projectSettings -baseFolder $baseFolder -project $thisProject -doNotCheckArtifactSetting -doNotCheckAppDependencyProbingPaths -doNotIssueWarnings
+            $projectSettings = AnalyzeRepo -settings $projectSettings -baseFolder $baseFolder -project $thisProject -doNotCheckArtifactSetting -doNotIssueWarnings
             $parameters = @{
                 "Project" = $thisProject
                 "ProjectName" = $projectName
@@ -398,7 +398,7 @@ try {
         }
         elseif ($deliveryTarget -eq "AppSource") {
             $projectSettings = ReadSettings -baseFolder $baseFolder -project $thisProject
-            $projectSettings = AnalyzeRepo -settings $projectSettings -baseFolder $baseFolder -project $thisProject -doNotCheckArtifactSetting -doNotCheckAppDependencyProbingPaths -doNotIssueWarnings
+            $projectSettings = AnalyzeRepo -settings $projectSettings -baseFolder $baseFolder -project $thisProject -doNotCheckArtifactSetting -doNotIssueWarnings
             # if type is Release, we only get here with the projects that needs to be delivered to AppSource
             # if type is CD, we get here for all projects, but should only deliver to AppSource if AppSourceContinuousDelivery is set to true
             if ($type -eq 'Release' -or ($projectSettings.Keys -contains 'AppSourceContinuousDelivery' -and $projectSettings.AppSourceContinuousDelivery)) {

--- a/Actions/Deliver/Deliver.ps1
+++ b/Actions/Deliver/Deliver.ps1
@@ -467,7 +467,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -238,7 +238,7 @@ try {
 
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
@@ -38,7 +38,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
@@ -19,7 +19,7 @@ try {
     $secrets = $env:Secrets | ConvertFrom-Json | ConvertTo-HashTable
     $insiderSasToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.insiderSasToken))
     $settings = $env:Settings | ConvertFrom-Json | ConvertTo-HashTable
-    $settings = AnalyzeRepo -settings $settings -project $project -doNotCheckArtifactSetting -doNotCheckAppDependencyProbingPaths -doNotIssueWarnings
+    $settings = AnalyzeRepo -settings $settings -project $project -doNotCheckArtifactSetting -doNotIssueWarnings
     $artifactUrl = Determine-ArtifactUrl -projectSettings $settings -insiderSasToken $insiderSasToken
     $artifactCacheKey = ''
     if ($settings.useCompilerFolder) {

--- a/Actions/DetermineDeliveryTargets/DetermineDeliveryTargets.ps1
+++ b/Actions/DetermineDeliveryTargets/DetermineDeliveryTargets.ps1
@@ -21,6 +21,7 @@ function IncludeDeliveryTarget([string] $deliveryTarget) {
     Write-Host "DeliveryTarget $_ - "
     # DeliveryTarget Context Secret needs to be specified for a delivery target to be included
     $contextName = "$($_)Context"
+    $secrets = $env:Secrets | ConvertFrom-Json
     if (-not $secrets."$contextName") {
         Write-Host "- Secret '$contextName' not found"
         return $false
@@ -51,7 +52,6 @@ Get-Item -Path (Join-Path $ENV:GITHUB_WORKSPACE ".github/$($namePrefix)*.ps1") |
 $deliveryTargets = @($deliveryTargets | Select-Object -unique)
 if ($checkContextSecrets) {
     # Check all delivery targets and include only the ones needed
-    $secrets = $env:Secrets | ConvertFrom-Json
     $deliveryTargets = @($deliveryTargets | Where-Object { IncludeDeliveryTarget -deliveryTarget $_ })
 }
 $contextSecrets = @($deliveryTargets | ForEach-Object { "$($_)Context" })

--- a/Actions/DetermineDeliveryTargets/README.md
+++ b/Actions/DetermineDeliveryTargets/README.md
@@ -7,7 +7,7 @@ Determines the delivery targets to use for the build
 | Name | Description |
 | :-- | :-- |
 | Settings | env.Settings must be set by a prior call to the ReadSettings Action |
-| Secrets | env.Secrets with delivery target context secrets must be read by a prior call to the ReadSecrets Action |
+| Secrets | env.Secrets with delivery target context secrets must be read by a prior call to the ReadSecrets Action (if checkContextSecrets is set to Y) |
 
 ### Parameters
 | Name | Required | Description | Default value |

--- a/Actions/DetermineDeploymentEnvironments/README.md
+++ b/Actions/DetermineDeploymentEnvironments/README.md
@@ -7,6 +7,7 @@ Determines the environments to be used for a build or a publish
 | Name | Description |
 | :-- | :-- |
 | Settings | env.Settings must be set by a prior call to the ReadSettings Action |
+| GITHUB_TOKEN | GITHUB_TOKEN must be set as an environment variable when calling this action |
 
 ### Parameters
 | Name | Required | Description | Default value |

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
@@ -45,7 +45,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
+++ b/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
@@ -81,6 +81,7 @@ function DownloadDependenciesFromCurrentBuild($baseFolder, $project, $projectsDe
 }
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
+DownloadAndImportBcContainerHelper -baseFolder $baseFolder
 
 Write-Host "Downloading dependencies for project '$project'. BuildMode: $buildMode, Base Folder: $baseFolder, Destination Path: $destinationPath"
 

--- a/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
+++ b/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
@@ -11,6 +11,7 @@ Param(
 function DownloadDependenciesFromProbingPaths($baseFolder, $project, $destinationPath) {
     $settings = $env:Settings | ConvertFrom-Json | ConvertTo-HashTable -recurse
     $settings = AnalyzeRepo -settings $settings -token $token -baseFolder $baseFolder -project $project -doNotCheckArtifactSetting -doNotIssueWarnings
+    $settings = CheckAppDependencyProbingPaths -settings $settings -token $token -baseFolder $baseFolder -project $project
     if ($settings.ContainsKey('appDependencyProbingPaths') -and $settings.appDependencyProbingPaths) {
         return Get-Dependencies -probingPathsJson $settings.appDependencyProbingPaths -saveToPath $destinationPath | Where-Object { $_ }
     }

--- a/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
+++ b/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
@@ -81,7 +81,6 @@ function DownloadDependenciesFromCurrentBuild($baseFolder, $project, $projectsDe
 }
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
-DownloadAndImportBcContainerHelper -baseFolder $baseFolder
 
 Write-Host "Downloading dependencies for project '$project'. BuildMode: $buildMode, Base Folder: $baseFolder, Destination Path: $destinationPath"
 

--- a/Actions/DownloadProjectDependencies/README.md
+++ b/Actions/DownloadProjectDependencies/README.md
@@ -9,6 +9,7 @@ The action constructs arrays of paths to .app files, that are dependencies of th
 | Name | Description |
 | :-- | :-- |
 | Settings | env.Settings must be set by a prior call to the ReadSettings Action |
+| Secrets | env.Secrets must be read by a prior call to the ReadSecrets Action with appDependencyProbingPathsSecrets in getSecrets |
 
 ### Parameters
 | Name | Required | Description | Default value |

--- a/Actions/IncrementVersionNumber/IncrementVersionNumber.ps1
+++ b/Actions/IncrementVersionNumber/IncrementVersionNumber.ps1
@@ -129,7 +129,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/PipelineCleanup/PipelineCleanup.ps1
+++ b/Actions/PipelineCleanup/PipelineCleanup.ps1
@@ -22,7 +22,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/PullRequestStatusCheck/README.md
+++ b/Actions/PullRequestStatusCheck/README.md
@@ -4,7 +4,9 @@ Check the status of a pull request build and fail the build if any jobs have fai
 ## INPUT
 
 ### ENV variables
-GITHUB_TOKEN
+| Name | Description |
+| :-- | :-- |
+| GITHUB_TOKEN | GITHUB_TOKEN must be set as an environment variable when calling this action |
 
 ### Parameters
 | Name | Required | Description | Default value |

--- a/Actions/ReadSecrets/README.md
+++ b/Actions/ReadSecrets/README.md
@@ -9,7 +9,6 @@ Additionally, the secrets specified by the authToken secret in AppDependencyProb
 | Name | Description |
 | :-- | :-- |
 | Settings | env.Settings must be set by a prior call to the ReadSettings Action |
-| UseGhTokenWorkflowForCommits | Set this ENV variable to true in order to use the GhTokenWorkflow secret for Pull Requests and Commits |
 
 ### Parameters
 | Name | Required | Description | Default value |
@@ -17,6 +16,7 @@ Additionally, the secrets specified by the authToken secret in AppDependencyProb
 | shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
 | parentTelemetryScopeJson | | Specifies the parent telemetry scope for the telemetry signal | {} |
 | getSecrets | Yes | Comma separated list of secrets to get (add appDependencyProbingPathsSecrets to request secrets needed for resolving dependencies in AppDependencyProbingPaths, add TokenForCommits in order to request a token to use for pull requests and commits) | |
+| useGhTokenWorkflowForCommits | false | Set this variable to true if you want to use the GhTokenWorkflow secret for TokenForCommits |
 
 ## OUTPUT
 

--- a/Actions/ReadSecrets/README.md
+++ b/Actions/ReadSecrets/README.md
@@ -15,8 +15,8 @@ Additionally, the secrets specified by the authToken secret in AppDependencyProb
 | :-- | :-: | :-- | :-- |
 | shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
 | parentTelemetryScopeJson | | Specifies the parent telemetry scope for the telemetry signal | {} |
-| getSecrets | Yes | Comma separated list of secrets to get (add appDependencyProbingPathsSecrets to request secrets needed for resolving dependencies in AppDependencyProbingPaths, add TokenForCommits in order to request a token to use for pull requests and commits) | |
-| useGhTokenWorkflowForCommits | false | Set this variable to true if you want to use the GhTokenWorkflow secret for TokenForCommits |
+| getSecrets | Yes | Comma separated list of secrets to get (add appDependencyProbingPathsSecrets to request secrets needed for resolving dependencies in AppDependencyProbingPaths, add TokenForPush in order to request a token to use for pull requests and commits) | |
+| useGhTokenWorkflowForPush | false | Set this variable to true if you want to use the GhTokenWorkflow secret for TokenForPush |
 
 ## OUTPUT
 
@@ -27,5 +27,5 @@ none
 | Name | Description |
 | :-- | :-- |
 | Secrets | A compressed json construct with all requested secrets base64 encoded. The secret value + the base64 value of the secret value are masked in the log |
-| TokenForCommits | The token to use when workflows are creating Pull Requests or Commits. This is either the GITHUB_TOKEN or the GhTokenWorkflow secret (based on the env variable UseGhTokenWorkflowForCommits)  |
+| TokenForPush | The token to use when workflows are pushing changes (either directly, or via pull requests). This is either the GITHUB_TOKEN or the GhTokenWorkflow secret (based on the env variable useGhTokenWorkflowForPush)  |
 

--- a/Actions/ReadSecrets/README.md
+++ b/Actions/ReadSecrets/README.md
@@ -16,7 +16,7 @@ Additionally, the secrets specified by the authToken secret in AppDependencyProb
 | shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
 | parentTelemetryScopeJson | | Specifies the parent telemetry scope for the telemetry signal | {} |
 | getSecrets | Yes | Comma separated list of secrets to get (add appDependencyProbingPathsSecrets to request secrets needed for resolving dependencies in AppDependencyProbingPaths, add TokenForPush in order to request a token to use for pull requests and commits) | |
-| useGhTokenWorkflowForPush | false | Set this variable to true if you want to use the GhTokenWorkflow secret for TokenForPush |
+| useGhTokenWorkflowForPush | false | Determines whether you want to use the GhTokenWorkflow secret for TokenForPush |
 
 ## OUTPUT
 

--- a/Actions/ReadSecrets/README.md
+++ b/Actions/ReadSecrets/README.md
@@ -9,23 +9,23 @@ Additionally, the secrets specified by the authToken secret in AppDependencyProb
 | Name | Description |
 | :-- | :-- |
 | Settings | env.Settings must be set by a prior call to the ReadSettings Action |
+| UseGhTokenWorkflowForCommits | Set this ENV variable to true in order to use the GhTokenWorkflow secret for Pull Requests and Commits |
 
 ### Parameters
 | Name | Required | Description | Default value |
 | :-- | :-: | :-- | :-- |
 | shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
 | parentTelemetryScopeJson | | Specifies the parent telemetry scope for the telemetry signal | {} |
-| getSecrets | Yes | Comma separated list of secrets to get (add appDependencyProbingPathsSecrets to request secrets needed for resolving dependencies in AppDependencyProbingPaths) | |
+| getSecrets | Yes | Comma separated list of secrets to get (add appDependencyProbingPathsSecrets to request secrets needed for resolving dependencies in AppDependencyProbingPaths, add TokenForCommits in order to request a token to use for pull requests and commits) | |
 
 ## OUTPUT
 
 ### ENV variables
-| Name | Description |
-| :-- | :-- |
-| Secrets | A compressed json construct with all requested secrets base64 encoded. The secret value + the base64 value of the secret value are masked in the log |
+none
 
 ### OUTPUT variables
 | Name | Description |
 | :-- | :-- |
 | Secrets | A compressed json construct with all requested secrets base64 encoded. The secret value + the base64 value of the secret value are masked in the log |
+| TokenForCommits | The token to use when workflows are creating Pull Requests or Commits. This is either the GITHUB_TOKEN or the GhTokenWorkflow secret (based on the env variable UseGhTokenWorkflowForCommits)  |
 

--- a/Actions/ReadSecrets/README.md
+++ b/Actions/ReadSecrets/README.md
@@ -22,7 +22,10 @@ Additionally, the secrets specified by the authToken secret in AppDependencyProb
 ### ENV variables
 | Name | Description |
 | :-- | :-- |
-| Secrets | A compressed json construct with all secrets base64 encoded. The secret value + the base64 value of the secret value are masked in the log |
+| Secrets | A compressed json construct with all requested secrets base64 encoded. The secret value + the base64 value of the secret value are masked in the log |
 
 ### OUTPUT variables
-none
+| Name | Description |
+| :-- | :-- |
+| Secrets | A compressed json construct with all requested secrets base64 encoded. The secret value + the base64 value of the secret value are masked in the log |
+

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -130,8 +130,8 @@ try {
             $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($outSecrets.ghTokenWorkflow))
         }
         else {
-            Write-Host "Use GITHUB_TOKEN for Commits"
-            $ghToken = $ENV:GITHUB_TOKEN
+            Write-Host "Use github_token for Commits"
+            $ghToken = GetGithubSecret -SecretName 'github_token'
         }
         Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "TokenForCommits=$ghToken"
     }

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -71,7 +71,7 @@ try {
         }
     }
 
-    foreach($_ in ($secretsCollection)) {
+    foreach($_ in @($secretsCollection)) {
         $secretSplit = $_.Split('=')
         $envVar = $secretSplit[0]
         $secret = $envVar

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -129,7 +129,7 @@ try {
             $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($outSecrets.ghTokenWorkflow))
         }
         else {
-            $ghToken = $env:GITHUB_TOKEN
+            $ghToken = GetGithubSecret -SecretName 'github_token'
         }
         Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "TokenForCommits=$ghToken"
     }

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -126,14 +126,13 @@ try {
 
     if ($getTokenForCommits) {
         if ($env:UseGhTokenWorkflowForCommits -eq 'true' -and $outSecrets.ghTokenWorkflow) {
-            Write-Host "use ghTokenWorkflow"
+            Write-Host "Use ghTokenWorkflow for Commits"
             $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($outSecrets.ghTokenWorkflow))
         }
         else {
-            Write-Host "use github-token"
-            $ghToken = GetGithubSecret -SecretName 'github_token'
+            Write-Host "Use GITHUB_TOKEN for Commits"
+            $ghToken = $ENV:GITHUB_TOKEN
         }
-        Write-Host "add to output"
         Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "TokenForCommits=$ghToken"
     }
 

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -127,7 +127,7 @@ try {
     Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "Secrets=$outSecretsJson"
 
     if ($getTokenForCommits) {
-        if ($env:UseGhTokenWorkflowForCommits -eq 'true' -and $outSecrets.ghTokenWorkflow) {
+        if ($useGhTokenWorkflowForCommits -eq 'true' -and $outSecrets.ghTokenWorkflow) {
             Write-Host "Use ghTokenWorkflow for Commits"
             $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($outSecrets.ghTokenWorkflow))
         }

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -71,7 +71,7 @@ try {
         }
     }
 
-    foreach($_ in $secretsCollection) {
+    foreach($_ in ($secretsCollection)) {
         $secretSplit = $_.Split('=')
         $envVar = $secretSplit[0]
         $secret = $envVar

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -71,6 +71,7 @@ try {
         }
     }
 
+    # Loop through secrets (use @() to allow us to remove items from the collection while looping)
     foreach($_ in @($secretsCollection)) {
         $secretSplit = $_.Split('=')
         $envVar = $secretSplit[0]

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -40,10 +40,10 @@ try {
     $getSecrets.Split(',') | Select-Object -Unique | ForEach-Object {
         $secret = $_
         if ($secret -eq 'TokenForCommits') {
+            $getTokenForCommits = $true
             if ($env:UseGhTokenWorkflowForCommits -ne 'true') { return }
             # If we are using the ghTokenWorkflow for commits, we need to get ghTokenWorkflow secret
             $secret = 'ghTokenWorkflow'
-            $getTokenForCommits = $true
         }
         $secretNameProperty = "$($secret)SecretName"
         if ($secret -eq 'AppDependencyProbingPathsSecrets') {
@@ -126,11 +126,14 @@ try {
 
     if ($getTokenForCommits) {
         if ($env:UseGhTokenWorkflowForCommits -eq 'true' -and $outSecrets.ghTokenWorkflow) {
+            Write-Host "use ghTokenWorkflow"
             $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($outSecrets.ghTokenWorkflow))
         }
         else {
+            Write-Host "use github-token"
             $ghToken = GetGithubSecret -SecretName 'github_token'
         }
+        Write-Host "add to output"
         Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "TokenForCommits=$ghToken"
     }
 

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -40,7 +40,7 @@ try {
     $getSecrets.Split(',') | Select-Object -Unique | ForEach-Object {
         $secret = $_
         if ($secret -eq 'TokenForCommits') {
-            if ($env:useGhTokenWorkflowForCommits -ne 'true') { return }
+            if ($env:UseGhTokenWorkflowForCommits -ne 'true') { return }
             # If we are using the ghTokenWorkflow for commits, we need to get ghTokenWorkflow secret
             $secret = 'ghTokenWorkflow'
             $getTokenForCommits = $true
@@ -125,7 +125,7 @@ try {
     Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "Secrets=$outSecretsJson"
 
     if ($getTokenForCommits) {
-        if ($env:useGhTokenWorkflowForCommits -eq 'true' -and $outSecrets.ghTokenWorkflow) {
+        if ($env:UseGhTokenWorkflowForCommits -eq 'true' -and $outSecrets.ghTokenWorkflow) {
             $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($outSecrets.ghTokenWorkflow))
         }
         else {

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -3,7 +3,7 @@ Param(
     [string] $gitHubSecrets = "",
     [Parameter(HelpMessage = "Comma separated list of Secrets to get", Mandatory = $true)]
     [string] $getSecrets = "",
-    [Parameter(HelpMessage = "Determines wheher you want to use the GhTokenWorkflow secret for TokenForCommits", Mandatory = $false)]
+    [Parameter(HelpMessage = "Determines whether you want to use the GhTokenWorkflow secret for TokenForCommits", Mandatory = $false)]
     [string] $useGhTokenWorkflowForCommits = 'false'
 )
 

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -42,7 +42,7 @@ try {
     foreach($secret in ($getSecrets.Split(',') | Select-Object -Unique)) {
         if ($secret -eq 'TokenForPush') {
             $getTokenForPush = $true
-            if ($useGhTokenWorkflowForPush -ne 'true') { return }
+            if ($useGhTokenWorkflowForPush -ne 'true') { continue }
             # If we are using the ghTokenWorkflow for commits, we need to get ghTokenWorkflow secret
             $secret = 'ghTokenWorkflow'
         }
@@ -129,11 +129,11 @@ try {
 
     if ($getTokenForPush) {
         if ($useGhTokenWorkflowForPush -eq 'true' -and $outSecrets.ghTokenWorkflow) {
-            Write-Host "Use ghTokenWorkflow for Commits"
+            Write-Host "Use ghTokenWorkflow for Push"
             $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($outSecrets.ghTokenWorkflow))
         }
         else {
-            Write-Host "Use github_token for Commits"
+            Write-Host "Use github_token for Push"
             $ghToken = GetGithubSecret -SecretName 'github_token'
         }
         Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "TokenForPush=$ghToken"

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -116,7 +116,7 @@ try {
             else {
                 "$($secretSplit[0]) (Secret $($secretSplit[1]))"
             }
-            $outSecrets += @{ ""$($secretSplit[0])"" = """" }
+            $outSecrets += @{ $($secretSplit[0]) = "" }
         }) -join ', '
         Write-Host "The following secrets was not found: $unresolvedSecrets"
     }

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -117,7 +117,7 @@ try {
             else {
                 "$($secretSplit[0]) (Secret $($secretSplit[1]))"
             }
-            $outSecrets += @{ $($secretSplit[0]) = "" }
+            $outSecrets += @{ "$($secretSplit[0])" = "" }
         }) -join ', '
         Write-Host "The following secrets was not found: $unresolvedSecrets"
     }

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(HelpMessage = "All GitHub Secrets in compressed JSON format", Mandatory = $true)]
     [string] $gitHubSecrets = "",
     [Parameter(HelpMessage = "Comma separated list of Secrets to get", Mandatory = $true)]
-    [string] $getSecrets = ""
+    [string] $getSecrets = "",
+    [Parameter(HelpMessage = "Determines wheher you want to use the GhTokenWorkflow secret for TokenForCommits", Mandatory = $false)]
+    [string] $useGhTokenWorkflowForCommits = 'false'
 )
 
 $buildMutexName = "AL-Go-ReadSecrets"
@@ -41,7 +43,7 @@ try {
         $secret = $_
         if ($secret -eq 'TokenForCommits') {
             $getTokenForCommits = $true
-            if ($env:UseGhTokenWorkflowForCommits -ne 'true') { return }
+            if ($useGhTokenWorkflowForCommits -ne 'true') { return }
             # If we are using the ghTokenWorkflow for commits, we need to get ghTokenWorkflow secret
             $secret = 'ghTokenWorkflow'
         }

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -108,7 +108,7 @@ try {
     }
 
     if ($secretsCollection) {
-        $unresolvedSecrets = ($secretsCollection | ForEach-Object { 
+        $unresolvedSecrets = ($secretsCollection | ForEach-Object {
             $secretSplit = @($_.Split('='))
             if ($secretSplit.Count -eq 1) {
                 $secretSplit[0]

--- a/Actions/ReadSecrets/ReadSecretsHelper.psm1
+++ b/Actions/ReadSecrets/ReadSecretsHelper.psm1
@@ -42,11 +42,17 @@ function GetGithubSecret {
     param (
         [string] $secretName
     )
+    $secretSplit = $secretName.Split('=')
+    $envVar = $secretSplit[0]
+    $secret = $envVar
+    if ($secretSplit.Count -gt 1) {
+        $secret = $secretSplit[1]
+    }
 
-    if ($script:gitHubSecrets.PSObject.Properties.Name -eq $secretName) {
-        $value = $script:githubSecrets."$secretName"
+    if ($script:gitHubSecrets.PSObject.Properties.Name -eq $secret) {
+        $value = $script:githubSecrets."$secret"
         if ($value) {
-            MaskValue -key $secretName -value $value
+            MaskValue -key $secret -value $value
             return $value
         }
     }

--- a/Actions/ReadSecrets/ReadSecretsHelper.psm1
+++ b/Actions/ReadSecrets/ReadSecretsHelper.psm1
@@ -42,17 +42,11 @@ function GetGithubSecret {
     param (
         [string] $secretName
     )
-    $secretSplit = $secretName.Split('=')
-    $envVar = $secretSplit[0]
-    $secret = $envVar
-    if ($secretSplit.Count -gt 1) {
-        $secret = $secretSplit[1]
-    }
-    
-    if ($script:gitHubSecrets.PSObject.Properties.Name -eq $secret) {
-        $value = $script:githubSecrets."$secret"
+
+    if ($script:gitHubSecrets.PSObject.Properties.Name -eq $secretName) {
+        $value = $script:githubSecrets."$secretName"
         if ($value) {
-            MaskValue -key $secret -value $value
+            MaskValue -key $secretName -value $value
             return $value
         }
     }

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -15,6 +15,9 @@ outputs:
   Secrets:
     description: All requested secrets in compressed JSON format
     value: ${{ steps.ReadSecrets.outputs.Secrets }}
+  TokenForCommits:
+    description: The token to use when workflows are creating Pull Requests or Commits.
+    value: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
 runs:
   using: composite
   steps:

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -14,13 +14,13 @@ inputs:
 outputs:
   Secrets:
     description: All requested secrets in compressed JSON format
-    value: ${{ steps.readSecrets.outputs.Secrets }}
+    value: ${{ steps.ReadSecrets.outputs.Secrets }}
 runs:
   using: composite
   steps:
     - name: run
-      id: readSecrets
       shell: ${{ inputs.shell }}
+      id: ReadSecrets
       env:
         _getSecrets: ${{ inputs.getSecrets }}
       run: |

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -12,7 +12,7 @@ inputs:
     description: Comma separated list of Secrets to get
     required: true
   useGhTokenWorkflowForPush:
-    description: Determines wheher you want to use the GhTokenWorkflow secret for TokenForPush
+    description: Determines whether you want to use the GhTokenWorkflow secret for TokenForPush
     required: false
     default: 'false'
 outputs:

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -11,17 +11,17 @@ inputs:
   getSecrets:
     description: Comma separated list of Secrets to get
     required: true
-  useGhTokenWorkflowForCommits:
-    description: Determines wheher you want to use the GhTokenWorkflow secret for TokenForCommits
+  useGhTokenWorkflowForPush:
+    description: Determines wheher you want to use the GhTokenWorkflow secret for TokenForPush
     required: false
     default: 'false'
 outputs:
   Secrets:
     description: All requested secrets in compressed JSON format
     value: ${{ steps.ReadSecrets.outputs.Secrets }}
-  TokenForCommits:
-    description: The token to use when workflows are creating Pull Requests or Commits.
-    value: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+  TokenForPush:
+    description: The token to use when workflows are pushing changes (either directly, or via pull requests).
+    value: ${{ steps.ReadSecrets.outputs.TokenForPush }}
 runs:
   using: composite
   steps:
@@ -30,11 +30,11 @@ runs:
       id: ReadSecrets
       env:
         _getSecrets: ${{ inputs.getSecrets }}
-        _useGhTokenWorkflowForCommits: ${{ inputs.useGhTokenWorkflowForCommits }}
+        _useGhTokenWorkflowForPush: ${{ inputs.useGhTokenWorkflowForPush }}
       run: |
         $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
         try {
-          ${{ github.action_path }}/ReadSecrets.ps1 -gitHubSecrets '${{ inputs.gitHubSecrets }}' -getSecrets $ENV:_getSecrets -useGhTokenWorkflowForCommits $ENV:_useGhTokenWorkflowForCommits
+          ${{ github.action_path }}/ReadSecrets.ps1 -gitHubSecrets '${{ inputs.gitHubSecrets }}' -getSecrets $ENV:_getSecrets -useGhTokenWorkflowForPush $ENV:_useGhTokenWorkflowForPush
         }
         catch {
           Write-Host "::ERROR::Unexpected error when running action. Error Message: $($_.Exception.Message.Replace("`r",'').Replace("`n",' ')), StackTrace: $($_.ScriptStackTrace.Replace("`r",'').Replace("`n",' <- '))";

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -11,6 +11,10 @@ inputs:
   getSecrets:
     description: Comma separated list of Secrets to get
     required: true
+  useGhTokenWorkflowForCommits:
+    description: Determines wheher you want to use the GhTokenWorkflow secret for TokenForCommits
+    required: false
+    default: 'false'
 outputs:
   Secrets:
     description: All requested secrets in compressed JSON format
@@ -26,10 +30,11 @@ runs:
       id: ReadSecrets
       env:
         _getSecrets: ${{ inputs.getSecrets }}
+        _useGhTokenWorkflowForCommits: ${{ inputs.useGhTokenWorkflowForCommits }}
       run: |
         $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
         try {
-          ${{ github.action_path }}/ReadSecrets.ps1 -gitHubSecrets '${{ inputs.gitHubSecrets }}' -getSecrets $ENV:_getSecrets
+          ${{ github.action_path }}/ReadSecrets.ps1 -gitHubSecrets '${{ inputs.gitHubSecrets }}' -getSecrets $ENV:_getSecrets -useGhTokenWorkflowForCommits $ENV:_useGhTokenWorkflowForCommits
         }
         catch {
           Write-Host "::ERROR::Unexpected error when running action. Error Message: $($_.Exception.Message.Replace("`r",'').Replace("`n",' ')), StackTrace: $($_.ScriptStackTrace.Replace("`r",'').Replace("`n",' <- '))";

--- a/Actions/ReadSecrets/action.yaml
+++ b/Actions/ReadSecrets/action.yaml
@@ -11,22 +11,22 @@ inputs:
   getSecrets:
     description: Comma separated list of Secrets to get
     required: true
-  parentTelemetryScopeJson:
-    description: Specifies the parent telemetry scope for the telemetry signal
-    required: false
-    default: '7b7d'
+outputs:
+  Secrets:
+    description: All requested secrets in compressed JSON format
+    value: ${{ steps.readSecrets.outputs.Secrets }}
 runs:
   using: composite
   steps:
     - name: run
+      id: readSecrets
       shell: ${{ inputs.shell }}
       env:
         _getSecrets: ${{ inputs.getSecrets }}
-        _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
       run: |
         $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
         try {
-          ${{ github.action_path }}/ReadSecrets.ps1 -gitHubSecrets '${{ inputs.gitHubSecrets }}' -getSecrets $ENV:_getSecrets -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson
+          ${{ github.action_path }}/ReadSecrets.ps1 -gitHubSecrets '${{ inputs.gitHubSecrets }}' -getSecrets $ENV:_getSecrets
         }
         catch {
           Write-Host "::ERROR::Unexpected error when running action. Error Message: $($_.Exception.Message.Replace("`r",'').Replace("`n",' ')), StackTrace: $($_.ScriptStackTrace.Replace("`r",'').Replace("`n",' <- '))";

--- a/Actions/ReadSettings/README.md
+++ b/Actions/ReadSettings/README.md
@@ -12,7 +12,6 @@ none
 | shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
 | actor | | The GitHub actor running the action | github.actor |
 | token | | The GitHub token running the action | github.token |
-| parentTelemetryScopeJson | | Specifies the parent telemetry scope for the telemetry signal | {} |
 | project | | Project name if the repository is setup for multiple projects | . |
 | get | | Specifies which properties to get from the settings file, default is all | |
 

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -3,99 +3,81 @@ Param(
     [string] $actor,
     [Parameter(HelpMessage = "The GitHub token running the action", Mandatory = $false)]
     [string] $token,
-    [Parameter(HelpMessage = "Specifies the parent telemetry scope for the telemetry signal", Mandatory = $false)]
-    [string] $parentTelemetryScopeJson = '7b7d',
     [Parameter(HelpMessage = "Project folder", Mandatory = $false)]
     [string] $project = ".",
     [Parameter(HelpMessage = "Specifies which properties to get from the settings file, default is all", Mandatory = $false)]
     [string] $get = ""
 )
 
-$telemetryScope = $null
+. (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
 
-try {
-    . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
-    DownloadAndImportBcContainerHelper
+$settings = ReadSettings -project $project
+if ($get) {
+    $getSettings = $get.Split(',').Trim()
+}
+else {
+    $getSettings = @()
+}
 
-    import-module (Join-Path -Path $PSScriptRoot -ChildPath "..\TelemetryHelper.psm1" -Resolve)
-    $telemetryScope = CreateScope -eventId 'DO0079' -parentTelemetryScopeJson $parentTelemetryScopeJson
+if ($ENV:GITHUB_EVENT_NAME -in @("pull_request_target", "pull_request")) {
+    $settings.doNotSignApps = $true
+    $settings.versioningStrategy = 15
+}
 
-    $settings = ReadSettings -project $project
-    if ($get) {
-        $getSettings = $get.Split(',').Trim()
-    }
-    else {
-        $getSettings = @()
-    }
+if ($settings.appBuild -eq [int32]::MaxValue) {
+    $settings.versioningStrategy = 15
+}
 
-    if ($ENV:GITHUB_EVENT_NAME -in @("pull_request_target", "pull_request")) {
-        $settings.doNotSignApps = $true
-        $settings.versioningStrategy = 15
-    }
-
-    if ($settings.appBuild -eq [int32]::MaxValue) {
-        $settings.versioningStrategy = 15
-    }
-
-    if ($settings.versioningstrategy -ne -1) {
-        switch ($settings.versioningStrategy -band 15) {
-            0 { # Use RUN_NUMBER and RUN_ATTEMPT
-                $settings.appBuild = $settings.runNumberOffset + [Int32]($ENV:GITHUB_RUN_NUMBER)
-                $settings.appRevision = [Int32]($ENV:GITHUB_RUN_ATTEMPT) - 1
-            }
-            1 { # Use RUN_ID and RUN_ATTEMPT
-                OutputError -message "Versioning strategy 1 is no longer supported"
-            }
-            2 { # USE DATETIME
-                $settings.appBuild = [Int32]([DateTime]::UtcNow.ToString('yyyyMMdd'))
-                $settings.appRevision = [Int32]([DateTime]::UtcNow.ToString('HHmmss'))
-            }
-            15 { # Use maxValue
-                $settings.appBuild = [Int32]::MaxValue
-                $settings.appRevision = 0
-            }
-            default {
-                OutputError -message "Unknown version strategy $versionStrategy"
-                exit
-            }
+if ($settings.versioningstrategy -ne -1) {
+    switch ($settings.versioningStrategy -band 15) {
+        0 { # Use RUN_NUMBER and RUN_ATTEMPT
+            $settings.appBuild = $settings.runNumberOffset + [Int32]($ENV:GITHUB_RUN_NUMBER)
+            $settings.appRevision = [Int32]($ENV:GITHUB_RUN_ATTEMPT) - 1
+        }
+        1 { # Use RUN_ID and RUN_ATTEMPT
+            OutputError -message "Versioning strategy 1 is no longer supported"
+        }
+        2 { # USE DATETIME
+            $settings.appBuild = [Int32]([DateTime]::UtcNow.ToString('yyyyMMdd'))
+            $settings.appRevision = [Int32]([DateTime]::UtcNow.ToString('HHmmss'))
+        }
+        15 { # Use maxValue
+            $settings.appBuild = [Int32]::MaxValue
+            $settings.appRevision = 0
+        }
+        default {
+            OutputError -message "Unknown version strategy $versionStrategy"
+            exit
         }
     }
+}
 
-    $outSettings = @{}
-    $settings.Keys | ForEach-Object {
-        $setting = $_
-        $settingValue = $settings."$setting"
-        $outSettings += @{ "$setting" = $settingValue }
-        if ($getSettings -contains $setting) {
-            if ($settingValue -is [System.Collections.Specialized.OrderedDictionary] -or $settingValue -is [hashtable]) {
-                Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$setting=$(ConvertTo-Json $settingValue -Depth 99 -Compress)"
-            }
-            elseif ($settingValue -is [String] -and ($settingValue.contains("`n") -or $settingValue.contains("`r"))) {
-                throw "Setting $setting contains line breaks, which is not supported"
-            }
-            else {
-                Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$setting=$settingValue"
-            }
+$outSettings = @{}
+$settings.Keys | ForEach-Object {
+    $setting = $_
+    $settingValue = $settings."$setting"
+    $outSettings += @{ "$setting" = $settingValue }
+    if ($getSettings -contains $setting) {
+        if ($settingValue -is [System.Collections.Specialized.OrderedDictionary] -or $settingValue -is [hashtable]) {
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$setting=$(ConvertTo-Json $settingValue -Depth 99 -Compress)"
+        }
+        elseif ($settingValue -is [String] -and ($settingValue.contains("`n") -or $settingValue.contains("`r"))) {
+            throw "Setting $setting contains line breaks, which is not supported"
+        }
+        else {
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$setting=$settingValue"
         }
     }
-
-    Write-Host "SETTINGS:"
-    $outSettings | ConvertTo-Json -Depth 99 | Out-Host
-    Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "Settings=$($outSettings | ConvertTo-Json -Depth 99 -Compress)"
-
-    $gitHubRunner = $settings.githubRunner.Split(',').Trim() | ConvertTo-Json -compress
-    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerJson=$githubRunner"
-    Write-Host "GitHubRunnerJson=$githubRunner"
-
-    $gitHubRunnerShell = $settings.githubRunnerShell
-    Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerShell=$githubRunnerShell"
-    Write-Host "GitHubRunnerShell=$githubRunnerShell"
-
-    TrackTrace -telemetryScope $telemetryScope
 }
-catch {
-    if ($env:BcContainerHelperPath) {
-        TrackException -telemetryScope $telemetryScope -errorRecord $_
-    }
-    throw
-}
+
+Write-Host "SETTINGS:"
+$outSettings | ConvertTo-Json -Depth 99 | Out-Host
+Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "Settings=$($outSettings | ConvertTo-Json -Depth 99 -Compress)"
+
+$gitHubRunner = $settings.githubRunner.Split(',').Trim() | ConvertTo-Json -compress
+Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerJson=$githubRunner"
+Write-Host "GitHubRunnerJson=$githubRunner"
+
+$gitHubRunnerShell = $settings.githubRunnerShell
+Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "GitHubRunnerShell=$githubRunnerShell"
+Write-Host "GitHubRunnerShell=$githubRunnerShell"

--- a/Actions/ReadSettings/action.yaml
+++ b/Actions/ReadSettings/action.yaml
@@ -13,10 +13,6 @@ inputs:
     description: The GitHub token running the action
     required: false
     default: ${{ github.token }}
-  parentTelemetryScopeJson:
-    description: Specifies the parent telemetry scope for the telemetry signal
-    required: false
-    default: '7b7d'
   project:
     description: Project folder
     required: false
@@ -41,13 +37,12 @@ runs:
       env:
         _actor: ${{ inputs.actor }}
         _token: ${{ inputs.token }}
-        _parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
         _project: ${{ inputs.project }}
         _get: ${{ inputs.get }}
       run: |
         $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
         try {
-          ${{ github.action_path }}/ReadSettings.ps1 -actor $ENV:_actor -token $ENV:_token -parentTelemetryScopeJson $ENV:_parentTelemetryScopeJson -project $ENV:_project -get $ENV:_get
+          ${{ github.action_path }}/ReadSettings.ps1 -actor $ENV:_actor -token $ENV:_token -project $ENV:_project -get $ENV:_get
         }
         catch {
           Write-Host "::ERROR::Unexpected error when running action. Error Message: $($_.Exception.Message.Replace("`r",'').Replace("`n",' ')), StackTrace: $($_.ScriptStackTrace.Replace("`r",'').Replace("`n",' <- '))";

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -414,7 +414,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -115,21 +115,22 @@ try {
         }
     }
 
-    $repo = AnalyzeRepo -settings $settings -token $token -baseFolder $baseFolder -project $project -insiderSasToken $insiderSasToken @analyzeRepoParams
+    $settings = AnalyzeRepo -settings $settings -token $token -baseFolder $baseFolder -project $project -insiderSasToken $insiderSasToken @analyzeRepoParams
+    $settings = CheckAppDependencyProbingPaths -settings $settings -token $token -baseFolder $baseFolder -project $project
 
-    if ((-not $repo.appFolders) -and (-not $repo.testFolders) -and (-not $repo.bcptTestFolders)) {
+    if ((-not $settings.appFolders) -and (-not $settings.testFolders) -and (-not $settings.bcptTestFolders)) {
         Write-Host "Repository is empty, exiting"
         exit
     }
 
-    if ($repo.type -eq "AppSource App" ) {
+    if ($settings.type -eq "AppSource App" ) {
         if ($licenseFileUrl -eq "") {
             OutputWarning -message "When building an AppSource App, you should create a secret called LicenseFileUrl, containing a secure URL to your license file with permission to the objects used in the app."
         }
     }
 
-    $installApps = $repo.installApps
-    $installTestApps = $repo.installTestApps
+    $installApps = $settings.installApps
+    $installTestApps = $settings.installTestApps
 
     $installApps += $installAppsJson | ConvertFrom-Json
     $installTestApps += $installTestAppsJson | ConvertFrom-Json
@@ -139,7 +140,7 @@ try {
     # Analyze InstallApps and InstallTestApps before launching pipeline 
 
     # Check if codeSignCertificateUrl+Password is used (and defined)
-    if (!$repo.doNotSignApps -and $codeSignCertificateUrl -and $codeSignCertificatePassword -and !$repo.keyVaultCodesignCertificateName) {
+    if (!$settings.doNotSignApps -and $codeSignCertificateUrl -and $codeSignCertificatePassword -and !$settings.keyVaultCodesignCertificateName) {
         OutputWarning -message "Using the legacy CodeSignCertificateUrl and CodeSignCertificatePassword parameters. Consider using the new Azure Keyvault signing instead. Go to https://aka.ms/ALGoSettings#keyVaultCodesignCertificateName to find out more"
         $runAlPipelineParams += @{ 
             "CodeSignCertPfxFile" = $codeSignCertificateUrl
@@ -161,7 +162,7 @@ try {
     }
 
     $previousApps = @()
-    if (!$repo.skipUpgrade) {
+    if (!$settings.skipUpgrade) {
         Write-Host "::group::Locating previous release"
         try {
             $latestRelease = GetLatestRelease -token $token -api_url $ENV:GITHUB_API_URL -repository $ENV:GITHUB_REPOSITORY -ref $ENV:GITHUB_REF_NAME
@@ -183,14 +184,14 @@ try {
         Write-Host "::endgroup::"
     }
 
-    $additionalCountries = $repo.additionalCountries
+    $additionalCountries = $settings.additionalCountries
 
     $imageName = ""
     if (-not $gitHubHostedRunner) {
-        $imageName = $repo.cacheImageName
+        $imageName = $settings.cacheImageName
         if ($imageName) {
             Write-Host "::group::Flush ContainerHelper Cache"
-            Flush-ContainerHelperCache -cache 'all,exitedcontainers' -keepdays $repo.cacheKeepDays
+            Flush-ContainerHelperCache -cache 'all,exitedcontainers' -keepdays $settings.cacheKeepDays
             Write-Host "::endgroup::"
         }
     }
@@ -198,17 +199,17 @@ try {
     $environmentName = ""
     $CreateRuntimePackages = $false
 
-    if ($repo.versioningStrategy -eq -1) {
-        $artifactVersion = [Version]$repo.artifact.Split('/')[4]
+    if ($settings.versioningStrategy -eq -1) {
+        $artifactVersion = [Version]$settings.artifact.Split('/')[4]
         $runAlPipelineParams += @{
             "appVersion" = "$($artifactVersion.Major).$($artifactVersion.Minor)"
         }
         $appBuild = $artifactVersion.Build
         $appRevision = $artifactVersion.Revision
     }
-    elseif (($repo.versioningStrategy -band 16) -eq 16) {
+    elseif (($settings.versioningStrategy -band 16) -eq 16) {
         $runAlPipelineParams += @{
-            "appVersion" = $repo.repoVersion
+            "appVersion" = $settings.repoVersion
         }
     }
     
@@ -250,12 +251,12 @@ try {
     }
 
     if ($runAlPipelineParams.Keys -notcontains 'ImportTestDataInBcContainer') {
-        if (($repo.configPackages) -or ($repo.Keys | Where-Object { $_ -like 'configPackages.*' })) {
+        if (($settings.configPackages) -or ($settings.Keys | Where-Object { $_ -like 'configPackages.*' })) {
             Write-Host "Adding Import Test Data override"
             Write-Host "Configured config packages:"
-            $repo.Keys | Where-Object { $_ -like 'configPackages*' } | ForEach-Object {
+            $settings.Keys | Where-Object { $_ -like 'configPackages*' } | ForEach-Object {
                 Write-Host "- $($_):"
-                $repo."$_" | ForEach-Object {
+                $settings."$_" | ForEach-Object {
                     Write-Host "  - $_"
                 }
             }
@@ -264,12 +265,12 @@ try {
                     Param([Hashtable]$parameters)
                     $country = Get-BcContainerCountry -containerOrImageName $parameters.containerName
                     $prop = "configPackages.$country"
-                    if ($repo.Keys -notcontains $prop) {
+                    if ($settings.Keys -notcontains $prop) {
                         $prop = "configPackages"
                     }
-                    if ($repo."$prop") {
+                    if ($settings."$prop") {
                         Write-Host "Importing config packages from $prop"
-                        $repo."$prop" | ForEach-Object {
+                        $settings."$prop" | ForEach-Object {
                             $configPackage = $_.Split(',')[0].Replace('{COUNTRY}',$country)
                             $packageId = $_.Split(',')[1]
                             UploadImportAndApply-ConfigPackageInBcContainer `
@@ -332,12 +333,12 @@ try {
     "enableAppSourceCop",
     "enablePerTenantExtensionCop",
     "enableUICop" | ForEach-Object {
-        if ($repo."$_") { $runAlPipelineParams += @{ "$_" = $true } }
+        if ($settings."$_") { $runAlPipelineParams += @{ "$_" = $true } }
     }
 
     switch($buildMode){
         'Clean' {
-            $preprocessorsymbols = $repo.cleanModePreprocessorSymbols
+            $preprocessorsymbols = $settings.cleanModePreprocessorSymbols
 
             if (!$preprocessorsymbols) {
                 throw "No cleanModePreprocessorSymbols defined in settings.json for this project. Please add the preprocessor symbols to use when building in clean mode or disable CLEAN mode."
@@ -365,34 +366,34 @@ try {
         -imageName $imageName `
         -bcAuthContext $authContext `
         -environment $environmentName `
-        -artifact $repo.artifact.replace('{INSIDERSASTOKEN}',$insiderSasToken) `
-        -vsixFile $repo.vsixFile `
-        -companyName $repo.companyName `
-        -memoryLimit $repo.memoryLimit `
+        -artifact $settings.artifact.replace('{INSIDERSASTOKEN}',$insiderSasToken) `
+        -vsixFile $settings.vsixFile `
+        -companyName $settings.companyName `
+        -memoryLimit $settings.memoryLimit `
         -baseFolder $projectPath `
         -sharedFolder $sharedFolder `
         -licenseFile $licenseFileUrl `
         -installApps $installApps `
         -installTestApps $installTestApps `
-        -installOnlyReferencedApps:$repo.installOnlyReferencedApps `
-        -generateDependencyArtifact:$repo.generateDependencyArtifact `
-        -updateDependencies:$repo.updateDependencies `
+        -installOnlyReferencedApps:$settings.installOnlyReferencedApps `
+        -generateDependencyArtifact:$settings.generateDependencyArtifact `
+        -updateDependencies:$settings.updateDependencies `
         -previousApps $previousApps `
-        -appFolders $repo.appFolders `
-        -testFolders $repo.testFolders `
-        -bcptTestFolders $repo.bcptTestFolders `
+        -appFolders $settings.appFolders `
+        -testFolders $settings.testFolders `
+        -bcptTestFolders $settings.bcptTestFolders `
         -buildOutputFile $buildOutputFile `
         -containerEventLogFile $containerEventLogFile `
         -testResultsFile $testResultsFile `
         -testResultsFormat 'JUnit' `
-        -customCodeCops $repo.customCodeCops `
+        -customCodeCops $settings.customCodeCops `
         -gitHubActions `
-        -failOn $repo.failOn `
-        -treatTestFailuresAsWarnings:$repo.treatTestFailuresAsWarnings `
-        -rulesetFile $repo.rulesetFile `
-        -appSourceCopMandatoryAffixes $repo.appSourceCopMandatoryAffixes `
+        -failOn $settings.failOn `
+        -treatTestFailuresAsWarnings:$settings.treatTestFailuresAsWarnings `
+        -rulesetFile $settings.rulesetFile `
+        -appSourceCopMandatoryAffixes $settings.appSourceCopMandatoryAffixes `
         -additionalCountries $additionalCountries `
-        -obsoleteTagMinAllowedMajorMinor $repo.obsoleteTagMinAllowedMajorMinor `
+        -obsoleteTagMinAllowedMajorMinor $settings.obsoleteTagMinAllowedMajorMinor `
         -buildArtifactFolder $buildArtifactFolder `
         -CreateRuntimePackages:$CreateRuntimePackages `
         -appBuild $appBuild -appRevision $appRevision `

--- a/Actions/Sign/Sign.ps1
+++ b/Actions/Sign/Sign.ps1
@@ -59,7 +59,7 @@ try {
     TrackTrace -telemetryScope $telemetryScope
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -70,7 +70,7 @@ try {
     Write-Host "correlationId=$correlationId"
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/Actions/WorkflowPostProcess/WorkflowPostProcess.ps1
+++ b/Actions/WorkflowPostProcess/WorkflowPostProcess.ps1
@@ -18,7 +18,7 @@ try {
     }
 }
 catch {
-    if ($env:BcContainerHelperPath) {
+    if (Get-Module BcContainerHelper) {
         TrackException -telemetryScope $telemetryScope -errorRecord $_
     }
     throw

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,7 @@ Note that when using the preview version of AL-Go for GitHub, you need to Update
 - Issue 592 Internal Server Error when publishing
 - Issue 557 Deployment step fails when retried
 - After configuring deployment branches for an environment in GitHub and setting Deployment Branch Policy to **Protected Branches**, AL-Go for GitHub would fail during initialization (trying to get environments for deployment)
+- The DetermineDeploymentEnvironments doesn't work in private repositories (needs the GITHUB_TOKEN)
 
 ### Breaking changes
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -50,6 +50,10 @@ By specifying a custom EnvironmentType in the DeployTo structure for an environm
 ### Status Checks in Pull Requests
 AL-Go for GitHub now adds status checks to Pull Requests Builds. In your GitHub branch protection rules, you can set up "Pull Request Status Check" to be a required status check to ensure Pull Request Builds succeed before merging.
 
+### Secrets in AL-Go for GitHub
+In v3.2 of AL-Go for GitHub, all secrets requested by AL-Go for GitHub were available to all steps in a job one compressed JSON structure in env:Secrets.
+With this update, only the steps that actually requires secrets will have the secrets available.
+
 ## v3.2
 
 ### Issues

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,6 +3,7 @@
 Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.
 
 ### Issues 
+
 - Issue 227 Feature request: Allow deployments with "Schema Sync Mode" = Force
 - Issue 519 Deploying to onprem environment
 - Issue 520 Automatic deployment to environment with annotation
@@ -11,8 +12,11 @@ Note that when using the preview version of AL-Go for GitHub, you need to Update
 - After configuring deployment branches for an environment in GitHub and setting Deployment Branch Policy to **Protected Branches**, AL-Go for GitHub would fail during initialization (trying to get environments for deployment)
 
 ### Breaking changes
+
 Earlier, you could specify a mapping to an environment name in an environment secret called `<environmentname>_EnvironmentName`, `<environmentname>-EnvironmentName` or just `EnvironmentName`. You could also specify the projects you want to deploy to an environment as an environment secret called `Projects`.
+
 This mechanism is no longer supported and you will get an error if your repository has these secrets. Instead you should use the `DeployTo<environmentName>` setting described below.
+
 Earlier, you could also specify the projects you want to deploy to an environment in a setting called `<environmentName>_Projects` or `<environmentName>-Projects`. This is also no longer supported. Instead use the `DeployTo<environmentName>` and remove the old settings.
 
 ### New Actions
@@ -32,6 +36,7 @@ Earlier, you could also specify the projects you want to deploy to an environmen
   - **runs-on** = specifies which GitHub runner to use when deploying to this environment. (Default is settings.runs-on)
 
 ### Custom Deployment
+
 By specifying a custom EnvironmentType in the DeployTo structure for an environment, you can now add a script in the .github folder called `DeployTo<environmentType>.ps1`. This script will be executed instead of the standard deployment mechanism with the following parameters in a HashTable:
 
 | Parameter | Description | Example |
@@ -48,6 +53,7 @@ By specifying a custom EnvironmentType in the DeployTo structure for an environm
 | `$parameters."runs-on"` | GitHub runner to be used to run the deployment script | windows-latest |
 
 ### Status Checks in Pull Requests
+
 AL-Go for GitHub now adds status checks to Pull Requests Builds. In your GitHub branch protection rules, you can set up "Pull Request Status Check" to be a required status check to ensure Pull Request Builds succeed before merging.
 
 ### Secrets in AL-Go for GitHub

--- a/Scenarios/settings.md
+++ b/Scenarios/settings.md
@@ -1,20 +1,25 @@
 # Settings
-The behavior of AL-Go for GitHub is very much controlled by the settings in the settings file.
+The behavior of AL-Go for GitHub is very much controlled by settings.
 
-## Where is the settings file located
-An AL-Go repository can consist of a single project (with multiple apps) or multiple projects (each with multiple apps). Multiple projects in a single repository are comparable to multiple repositories; they are built, deployed, and tested separately. All apps in each project (single or multiple) are built together in the same pipeline, published and tested together. If a repository is multiple projects, each project is stored in a separate folder in the root of the repository.
+## Where are the settings located
 
-When running a workflow or a local script, the settings are applied by reading one or more settings files. Last applied settings file wins. The following lists the settings files and their location:
+Settings can be defined in GitHub variables or in various settings file. An AL-Go repository can consist of a single project (with multiple apps) or multiple projects (each with multiple apps). Settings can be applied on the project level or on the repository level. Multiple projects in a single repository are comparable to multiple repositories; they are built, deployed, and tested separately. All apps in each project (single or multiple) are built together in the same pipeline, published and tested together. If a repository is multiple projects, each project is stored in a separate folder in the root of the repository.
 
-**.github\\AL-Go-settings.json** is the repository settings file. This settings file contains settings that are relevant for all projects in the repository. If a settings in the repository settings file is found in a subsequent settings file, it will be overridden by the new value.
+When running a workflow or a local script, the settings are applied by reading settings from GitHub variables and one or more settings files. Last applied settings file wins. The following lists the order of locations to search for settings:
 
-**Special note:** The repository settings file can also contains `BcContainerHelper` settings, which will be applied when loading `BcContainerHelper` in a workflow (see expert section).
+1.  `ALGoOrgSettings` is a **GitHub variable**, which can be defined on an **organizational level** and will apply to **all AL-Go repositories** in this organization.
 
-**.AL-Go\\settings.json** is the project settings file. If the repository is a single project, the .AL-Go folder is in the root folder of the repository. If the repository contains multiple projects, there will be a .AL-Go folder in each project folder.
+1.  `.github/AL-Go-settings.json` is the **repository settings file**. This settings file contains settings that are relevant for all projects in the repository. **Special note:** The repository settings file can also contains `BcContainerHelper` settings, which will be applied when loading `BcContainerHelper` in a workflow - the GitHub variables are not considered for BcContainerHelper settings. (see expert section).
 
-**.AL-Go\\\<workflow\>.settings.json** is the workflow-specific settings file. This option is used for the Current, NextMinor and NextMajor workflows to determine artifacts and build numbers when running these workflows.
+1.  `ALGoRepoSettings` is a **GitHub variable**, which can be defined on an **repository level** and can contain settings that are relevant for **all projects** in the repository.
 
-**.AL-Go\\\<username\>.settings.json** is the user-specific settings file. This option is rarely used, but if you have special settings, which should only be used for one specific user (potentially in the local scripts), these settings can be added to a settings file with the name of the user followed by `.settings.json`.
+1.  `.AL-Go/settings.json` is the **project settings file**. If the repository is a single project, the .AL-Go folder is in the root folder of the repository. If the repository contains multiple projects, there will be a .AL-Go folder in each project folder (like `project/.AL-Go/settings.json`)
+
+1.  `.github/<workflow>.settings.json` is the **workflow-specific settings file** for **all projects**. This option is used for the Current, NextMinor and NextMajor workflows to determine artifacts and build numbers when running these workflows.
+
+1.  `.AL-Go/<workflow>.settings.json` is the **workflow-specific settings file** for a **specific project**.
+
+1.  `.AL-Go/<username>.settings.json` is the **user-specific settings file**. This option is rarely used, but if you have special settings, which should only be used for one specific user (potentially in the local scripts), these settings can be added to a settings file with the name of the user followed by `.settings.json`.
 
 ## Basic settings
 
@@ -26,8 +31,6 @@ When running a workflow or a local script, the settings are applied by reading o
 | <a id="testFolders"></a>testFolders | testFolders should be an array of folders (relative to project root), which contains test apps for this project. Apps in these folders are sorted based on dependencies and built, published and tests are run in that order.<br />If testFolders are not specified, AL-Go for GitHub will try to locate testFolders in the root of the project. | [ ] |
 | <a id="bcptTestFolders"></a>bcptTestFolders | bcptTestFolders should be an array of folders (relative to project root), which contains performance test apps for this project. Apps in these folders are sorted based on dependencies and built, published and bcpt tests are run in that order.<br />If bcptTestFolders are not specified, AL-Go for GitHub will try to locate bcptTestFolders in the root of the project. | [ ] |
 | <a id="appDependencyProbingPaths"></a>appDependencyProbingPaths | Array of dependency specifications, from which apps will be downloaded when the CI/CD workflow is starting. Every dependency specification consists of the following properties:<br />**repo** = repository<br />**version** = version (default latest)<br />**release_status** = latestBuild/release/prerelease/draft (default release)<br />**projects** = projects (default * = all)<br />**AuthTokenSecret** = Name of secret containing auth token (default none)<br /> | [ ] |
-| <a id="environments"></a>environments | Array of logical environment names. You can specify environments in GitHub environments or in the repo settings file. If you specify environments in the settings file, you can create your AUTHCONTEXT secret using **&lt;environmentname&gt;_AUTHCONTEXT**. You can specify additional information about environments in a setting called **DeployTo&lt;environmentname&gt;** | [ ] |
-| <a id="deployto"></a>DeployTo&lt;environmentname&gt; | Structure with additional properties for the environment specified. The structure can contain the following properties:<br />**EnvironmentType** = specifies the type of environment. The environment type can be used to invoke a custom deployment. (Default SaaS)<br />**EnvironmentName** = specifies the "real" name of the environment if it differs from the GitHub environment.<br />**Branches** = an array of branch patterns, which are allowed to deploy to this environment. (Default main)<br />**Projects** = In multi-project repositories, this property can be a comma separated list of project patterns to deploy to this environment. (Default *)<br />**SyncMode** = ForceSync if deployment to this environment should happen with ForceSync, else Add. If deploying to the development endpoint you can also specify Development or Clean. (Default Add)<br />**ContinuousDeployment** = true if this environment should be used for continuous deployment, else false. (Default: AL-Go will continuously deploy to sandbox environments or environments, which doesn't end in (PROD) or (FAT)<br />**runs-on** = specifies which runner to use when deploying to this environment. (Default is settings.runs-on)<br /> | { } |
 | <a id="cleanModePreprocessorSymbols"></a>cleanModePreprocessorSymbols | List of clean tags to be used in _Clean_ build mode | [ ] |
 
 ## AppSource specific basic settings
@@ -51,6 +54,8 @@ The repository settings are only read from the repository settings file (.github
 | <a id="shell"></a>shell | Specifies which shell will be used as the default in all jobs. **powershell** is the default, which results in using _PowerShell 5.1_ (unless you selected _ubuntu-latest_, then **pwsh** is used, which results in using _PowerShell 7_) |
 | <a id="githubRunner"></a>githubRunner | Specifies which github runner will be used for the build jobs in workflows including a build job. This is the most time consuming task. By default this job uses the _Windows-latest_ github runner (unless overridden by the runs-on setting). This settings takes precedence over runs-on so that you can use different runners for the build job and the housekeeping jobs. See **runs-on** setting. |
 | <a id="githubRunnerShell"></a>githubRunnerShell | Specifies which shell is used for build jobs in workflows including a build job. The default is to use the same as defined in **shell**. If the shell setting isn't defined, **powershell** is the default, which results in using _PowerShell 5.1_. Use **pwsh** for _PowerShell 7_. |
+| <a id="environments"></a>environments | Array of logical environment names. You can specify environments in GitHub environments or in the repo settings file. If you specify environments in the settings file, you can create your AUTHCONTEXT secret using **&lt;environmentname&gt;_AUTHCONTEXT**. You can specify additional information about environments in a setting called **DeployTo&lt;environmentname&gt;** | [ ] |
+| <a id="deployto"></a>DeployTo&lt;environmentname&gt; | Structure with additional properties for the environment specified. The structure can contain the following properties:<br />**EnvironmentType** = specifies the type of environment. The environment type can be used to invoke a custom deployment. (Default SaaS)<br />**EnvironmentName** = specifies the "real" name of the environment if it differs from the GitHub environment.<br />**Branches** = an array of branch patterns, which are allowed to deploy to this environment. (Default main)<br />**Projects** = In multi-project repositories, this property can be a comma separated list of project patterns to deploy to this environment. (Default *)<br />**SyncMode** = ForceSync if deployment to this environment should happen with ForceSync, else Add. If deploying to the development endpoint you can also specify Development or Clean. (Default Add)<br />**ContinuousDeployment** = true if this environment should be used for continuous deployment, else false. (Default: AL-Go will continuously deploy to sandbox environments or environments, which doesn't end in (PROD) or (FAT)<br />**runs-on** = specifies which runner to use when deploying to this environment. (Default is settings.runs-on)<br /> | { } |
 | <a id="useProjectDependencies"></a>useProjectDependencies | Determines whether your projects are built using a multi-stage built workflow or single stage. After setting useProjectDependencies to true, you need to run Update AL-Go System Files and your workflows including a build job will change to have multiple build jobs, depending on each other. The number of build jobs will be determined by the dependency depth in your projects.<br />You can change dependencies between your projects, but if the dependency **depth** changes, AL-Go will warn you that updates for your AL-Go System Files are available and you will need to run the workflow. |
 | <a id="CICDPushBranches"></a>CICDPushBranches | CICDPushBranches can be specified as an array of branches, which triggers a CI/CD workflow on commit.<br />Default is [ "main", "release/\*", "feature/\*" ] |
 | <a id="CICDPullrequestBranches"></a>CICDPullRequestBranches | CICDPullRequestBranches can be specified as an array of branches, which triggers a CI/CD workflow on a PR.<br />Default is [ "main" ] |
@@ -105,6 +110,52 @@ The repository settings are only read from the repository settings file (.github
 | :-- | :-- | :-- |
 | <a id=""></a>appSourceContextSecretName | This setting specifies the name (**NOT the secret**) of a secret containing a json string with ClientID, TenantID and ClientSecret or RefreshToken. If this secret exists, AL-Go will can upload builds to AppSource validation. | AppSourceContext |
 | <a id=""></a>keyVaultCertificateUrlSecretName<br />keyVaultCertificatePasswordSecretName<br />keyVaultClientIdSecretName | If you want to enable KeyVault access for your AppSource App, you need to provide 3 secrets as GitHub Secrets or in the Azure KeyVault. The names of those secrets (**NOT the secrets**) should be specified in the settings file with these 3 settings. Default is to not have KeyVault access from your AppSource App. Read [this](EnableKeyVaultForAppSourceApp.md) for more information. | |
+
+## Conditional Settings
+In any of the settings files, you can add conditional settings by using the ConditionalSettings setting.
+
+Example, adding this:
+```json
+    "ConditionalSettings": [
+        {
+            "branches": [ 
+                "feature/*"
+            ],
+            "settings": {
+                "doNotPublishApps": true,
+                "doNotSignApps": true
+            }
+        }
+    ]
+```
+to your project settings file (.AL-Go/settings.json) will ensure that all branches matching the patterns in branches will use doNotPublishApps=true and doNotSignApps=true during CI/CD. Conditions can be:
+- **repositories** settings will be applied to repositories matching the patterns
+- **projects** settings will be applied to projects matching the patterns
+- **branches** settings will be applied to branches matching the patterns
+- **workflows** settings will be applied to workflows matching the patterns
+- **users** settings will be applied for users matching the patterns
+
+You could imagine that you could have and organizational settings variable containing:
+
+```json
+    "ConditionalSettings": [
+        {
+            "repositories": [ 
+                "bcsamples-*"
+            ],
+            "branches": [ 
+                "features/*"
+            ],
+            "settings": {
+                "doNotSignApps": true
+            }
+        }
+    ]
+```
+
+Which will ensure that for all repositories named `bcsamples-*` in this organization, the branches matching `features/*` will not sign apps.
+
+**Note:** that you can have conditional settings on any level and all conditional settings which has all conditions met will be applied in the order of settings file + appearance.
 
 ## Expert settings (rarely used)
 

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -31,7 +31,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   AddExistingAppOrTestApp:
@@ -59,6 +58,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
         uses: microsoft/AL-Go-Actions/AddExistingApp@main

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -51,7 +51,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -31,7 +31,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   AddExistingAppOrTestApp:

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -57,14 +57,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
         uses: microsoft/AL-Go-Actions/AddExistingApp@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           url: ${{ github.event.inputs.url }}

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -31,6 +31,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   AddExistingAppOrTestApp:
@@ -54,36 +55,18 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Add existing app
         uses: microsoft/AL-Go-Actions/AddExistingApp@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           url: ${{ github.event.inputs.url }}

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -98,6 +98,8 @@ jobs:
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
         uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           shell: powershell
           getEnvironments: '*'

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -55,7 +55,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: type
 
       - name: Determine Workflow Depth
@@ -115,7 +114,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           get: templateUrl
 
       - name: Check for updates to AL-Go system files

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -79,6 +79,7 @@ jobs:
           checkContextSecrets: 'N'
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
@@ -88,6 +89,8 @@ jobs:
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
         uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@main
+        env:
+          Secrets: ${{ steps.ReadSecrets.outputs.Secrets }}
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -175,6 +178,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
@@ -183,6 +187,8 @@ jobs:
 
       - name: Deploy
         uses: microsoft/AL-Go-Actions/Deploy@main
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           environmentName: ${{ matrix.environment }}
@@ -214,6 +220,7 @@ jobs:
           shell: powershell
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
@@ -222,6 +229,8 @@ jobs:
 
       - name: Deliver
         uses: microsoft/AL-Go-Actions/Deliver@main
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           type: 'CD'

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -41,6 +41,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateApp:
@@ -64,36 +65,18 @@ jobs:
           get: type
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Creating a new app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: ${{ env.type }}

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -41,7 +41,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateApp:

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -61,7 +61,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: type
 
       - name: Read secrets

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -68,14 +68,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: ${{ env.type }}

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -41,7 +41,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateApp:
@@ -70,6 +69,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -35,6 +35,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   Initialization:
@@ -63,10 +64,10 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'adminCenterApiCredentials'
 
@@ -74,10 +75,8 @@ jobs:
         id: authenticate
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $secrets = $env:Secrets | ConvertFrom-Json
           $settings = $env:Settings | ConvertFrom-Json
-          if ($secrets.adminCenterApiCredentials) {
-            $adminCenterApiCredentials = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.adminCenterApiCredentials))
+          if ('${{ fromJson(steps.ReadSecrets.outputs.Secrets).adminCenterApiCredentials }}') {
             Write-Host "AdminCenterApiCredentials provided in secret $($settings.adminCenterApiCredentialsSecretName)!"
             Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "Admin Center Api Credentials was provided in a secret called $($settings.adminCenterApiCredentialsSecretName). Using this information for authentication."
           }
@@ -113,48 +112,35 @@ jobs:
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'adminCenterApiCredentials,ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'adminCenterApiCredentials,TokenForCommits'
 
       - name: Set AdminCenterApiCredentials
+        id: SetAdminCenterApiCredentials
         run: |
           if ($env:deviceCode) {
             $adminCenterApiCredentials = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("{""deviceCode"":""$($env:deviceCode)""}"))
-            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -value "adminCenterApiCredentials=$adminCenterApiCredentials"
           }
+          else {
+            $adminCenterApiCredentials = '${{ fromJson(steps.ReadSecrets.outputs.Secrets).adminCenterApiCredentials }}'
+          }
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -value "adminCenterApiCredentials=$adminCenterApiCredentials"
 
       - name: Create Development Environment
         uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
           project: ${{ github.event.inputs.project }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}
           directCommit: ${{ github.event.inputs.directCommit }}
-          adminCenterApiCredentials: ${{ fromJson(env.Secrets).adminCenterApiCredentials }}
+          adminCenterApiCredentials: ${{ steps.SetAdminCenterApiCredentials.outputs.adminCenterApiCredentials }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -61,7 +61,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets
@@ -109,7 +108,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -35,7 +35,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   Initialization:
@@ -116,6 +115,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'adminCenterApiCredentials,TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Set AdminCenterApiCredentials
         id: SetAdminCenterApiCredentials

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -114,8 +114,8 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'adminCenterApiCredentials,TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'adminCenterApiCredentials,TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Set AdminCenterApiCredentials
         id: SetAdminCenterApiCredentials
@@ -132,7 +132,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
           project: ${{ github.event.inputs.project }}

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -35,7 +35,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   Initialization:

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -47,6 +47,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreatePerformanceTestApp:
@@ -70,36 +71,18 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Performance Test App'

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -73,14 +73,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Performance Test App'

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -65,7 +65,6 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -47,7 +47,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreatePerformanceTestApp:
@@ -75,6 +74,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -67,7 +67,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -47,7 +47,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreatePerformanceTestApp:

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -53,7 +53,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateRelease:

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -319,14 +319,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
           versionNumber: ${{ github.event.inputs.updateVersionNumber }}
           directCommit: ${{ github.event.inputs.directCommit }}

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -53,7 +53,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateRelease:
@@ -321,6 +320,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -80,7 +80,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: templateUrl,repoName
 
       - name: Determine Projects
@@ -221,7 +220,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets
@@ -315,7 +313,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -313,7 +313,6 @@ jobs:
     steps:
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -53,6 +53,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateRelease:
@@ -223,10 +224,10 @@ jobs:
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'nuGetContext,storageContext'
 
@@ -260,22 +261,11 @@ jobs:
               data: fs.readFileSync(assetPath)
             });
 
-      - name: nuGetContext
-        id: nuGetContext
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $nuGetContext = ''
-          $secrets = $env:Secrets | ConvertFrom-Json
-          if ('${{ matrix.atype }}' -eq 'Apps' -and $secrets.nuGetContext) {
-            $nuGetContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.nuGetContext))
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "nuGetContext=$nuGetContext"
-
       - name: Deliver to NuGet
         uses: microsoft/AL-Go-Actions/Deliver@main
-        if: ${{ steps.nuGetContext.outputs.nuGetContext }}
+        if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).nuGetContext != '' }}
         env:
-          deliveryContext: ${{ steps.nuGetContext.outputs.nuGetContext }}
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           type: 'Release'
@@ -284,22 +274,11 @@ jobs:
           artifacts: ${{ github.event.inputs.appVersion }}
           atypes: 'Apps,TestApps'
 
-      - name: storageContext
-        id: storageContext
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $storageContext = ''
-          $secrets = $env:Secrets | ConvertFrom-Json
-          if ('${{ matrix.atype }}' -eq 'Apps' -and $secrets.storageContext) {
-            $storageContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.storageContext))
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "storageContext=$storageContext"
-
       - name: Deliver to Storage
         uses: microsoft/AL-Go-Actions/Deliver@main
-        if: ${{ steps.storageContext.outputs.storageContext }}
+        if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).storageContext != '' }}
         env:
-          deliveryContext: ${{ steps.storageContext.outputs.storageContext }}
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           type: 'Release'
@@ -340,36 +319,18 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Update Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
           versionNumber: ${{ github.event.inputs.updateVersionNumber }}
           directCommit: ${{ github.event.inputs.directCommit }}

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -43,6 +43,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateTestApp:
@@ -66,36 +67,18 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Test App'

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -43,7 +43,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateTestApp:
@@ -71,6 +70,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -63,7 +63,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -69,14 +69,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Test App'

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -43,7 +43,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateTestApp:

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/Templates/AppSource App/.github/workflows/Current.yaml
+++ b/Templates/AppSource App/.github/workflows/Current.yaml
@@ -44,7 +44,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -51,7 +51,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -31,7 +31,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   IncrementVersionNumber:

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -57,14 +57,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           versionNumber: ${{ github.event.inputs.versionNumber }}

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -31,6 +31,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   IncrementVersionNumber:
@@ -54,36 +55,18 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Increment Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           versionNumber: ${{ github.event.inputs.versionNumber }}

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -31,7 +31,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   IncrementVersionNumber:
@@ -59,6 +58,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main

--- a/Templates/AppSource App/.github/workflows/NextMajor.yaml
+++ b/Templates/AppSource App/.github/workflows/NextMajor.yaml
@@ -44,7 +44,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/AppSource App/.github/workflows/NextMinor.yaml
+++ b/Templates/AppSource App/.github/workflows/NextMinor.yaml
@@ -44,7 +44,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/AppSource App/.github/workflows/PublishToAppSource.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToAppSource.yaml
@@ -56,7 +56,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/AppSource App/.github/workflows/PublishToAppSource.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToAppSource.yaml
@@ -59,6 +59,7 @@ jobs:
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
@@ -67,6 +68,8 @@ jobs:
 
       - name: Deliver
         uses: microsoft/AL-Go-Actions/Deliver@main
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -67,11 +67,11 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount == 1
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext'
 
@@ -81,7 +81,7 @@ jobs:
         run: |
           $envName = '${{ steps.envName.outputs.envName }}'
           $secretName = ''
-          $secrets = $env:Secrets | ConvertFrom-Json
+          $secrets = '${{ steps.ReadSecrets.outputs.Secrets }}' | ConvertFrom-Json
           $authContext = $null
           "$($envName)-AuthContext", "$($envName)_AuthContext", "AuthContext" | ForEach-Object {
             if (!($authContext)) {
@@ -135,6 +135,7 @@ jobs:
           shell: powershell
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
@@ -143,6 +144,8 @@ jobs:
 
       - name: Deploy
         uses: microsoft/AL-Go-Actions/Deploy@main
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           environmentName: ${{ matrix.environment }}

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -48,7 +48,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -52,6 +52,8 @@ jobs:
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
         uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           shell: powershell
           getEnvironments: ${{ github.event.inputs.environmentName }}

--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -62,7 +62,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -45,10 +45,10 @@ jobs:
           get: templateUrl
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'ghTokenWorkflow'
 
@@ -82,7 +82,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          token: ${{ fromJson(env.Secrets).ghTokenWorkflow }}
+          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
           Update: Y
           templateUrl: ${{ env.templateUrl }}
           directCommit: ${{ env.directCommit }}

--- a/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -41,7 +41,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: templateUrl
 
       - name: Read secrets

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -81,7 +81,6 @@ jobs:
           uses: microsoft/AL-Go-Actions/ReadSettings@main
           with:
             shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
             get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,artifact
 

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -86,17 +86,19 @@ jobs:
             get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,artifact
 
         - name: Read secrets
+          id: ReadSecrets
           if: github.event_name != 'pull_request'
           uses: microsoft/AL-Go-Actions/ReadSecrets@main
           with:
             shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             gitHubSecrets: ${{ toJson(secrets) }}
             getSecrets: '${{ inputs.secrets }},appDependencyProbingPathsSecrets'
 
         - name: Determine ArtifactUrl
           uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@main
           id: determineArtifactUrl
+          env:
+            Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           with:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
@@ -112,6 +114,8 @@ jobs:
         - name: Download Project Dependencies
           id: DownloadProjectDependencies
           uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@main
+          env:
+            Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           with:
             shell: ${{ inputs.shell }}
             project: ${{ inputs.project }}
@@ -122,6 +126,7 @@ jobs:
           id: RunPipeline
           uses: microsoft/AL-Go-Actions/RunPipeline@main
           env:
+            Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
             BuildMode: ${{ inputs.buildMode }}
           with:
             shell: ${{ inputs.shell }}

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -31,7 +31,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   AddExistingAppOrTestApp:
@@ -59,6 +58,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
         uses: microsoft/AL-Go-Actions/AddExistingApp@main

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -51,7 +51,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -31,7 +31,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   AddExistingAppOrTestApp:

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -57,14 +57,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
         uses: microsoft/AL-Go-Actions/AddExistingApp@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           url: ${{ github.event.inputs.url }}

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -31,6 +31,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   AddExistingAppOrTestApp:
@@ -54,36 +55,18 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Add existing app
         uses: microsoft/AL-Go-Actions/AddExistingApp@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           url: ${{ github.event.inputs.url }}

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -98,6 +98,8 @@ jobs:
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
         uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           shell: powershell
           getEnvironments: '*'

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -55,7 +55,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: type
 
       - name: Determine Workflow Depth
@@ -115,7 +114,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           get: templateUrl
 
       - name: Check for updates to AL-Go system files

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -79,6 +79,7 @@ jobs:
           checkContextSecrets: 'N'
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
@@ -88,6 +89,8 @@ jobs:
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
         uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@main
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -175,6 +178,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
@@ -183,6 +187,8 @@ jobs:
 
       - name: Deploy
         uses: microsoft/AL-Go-Actions/Deploy@main
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           environmentName: ${{ matrix.environment }}
@@ -214,6 +220,7 @@ jobs:
           shell: powershell
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
@@ -222,6 +229,8 @@ jobs:
 
       - name: Deliver
         uses: microsoft/AL-Go-Actions/Deliver@main
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           type: 'CD'

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -41,6 +41,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateApp:
@@ -64,36 +65,18 @@ jobs:
           get: type
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Creating a new app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: ${{ env.type }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -41,7 +41,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateApp:

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -61,7 +61,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: type
 
       - name: Read secrets

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -68,14 +68,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: ${{ env.type }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -41,7 +41,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateApp:
@@ -70,6 +69,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -35,6 +35,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   Initialization:
@@ -63,10 +64,10 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'adminCenterApiCredentials'
 
@@ -74,10 +75,8 @@ jobs:
         id: authenticate
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $secrets = $env:Secrets | ConvertFrom-Json
           $settings = $env:Settings | ConvertFrom-Json
-          if ($secrets.adminCenterApiCredentials) {
-            $adminCenterApiCredentials = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.adminCenterApiCredentials))
+          if ('${{ fromJson(steps.ReadSecrets.outputs.Secrets).adminCenterApiCredentials }}') {
             Write-Host "AdminCenterApiCredentials provided in secret $($settings.adminCenterApiCredentialsSecretName)!"
             Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "Admin Center Api Credentials was provided in a secret called $($settings.adminCenterApiCredentialsSecretName). Using this information for authentication."
           }
@@ -113,48 +112,35 @@ jobs:
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'adminCenterApiCredentials,ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'adminCenterApiCredentials,TokenForCommits'
 
       - name: Set AdminCenterApiCredentials
+        id: SetAdminCenterApiCredentials
         run: |
           if ($env:deviceCode) {
             $adminCenterApiCredentials = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("{""deviceCode"":""$($env:deviceCode)""}"))
-            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -value "adminCenterApiCredentials=$adminCenterApiCredentials"
           }
+          else {
+            $adminCenterApiCredentials = '${{ fromJson(steps.ReadSecrets.outputs.Secrets).adminCenterApiCredentials }}'
+          }
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -value "adminCenterApiCredentials=$adminCenterApiCredentials"
 
       - name: Create Development Environment
         uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
           project: ${{ github.event.inputs.project }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}
           directCommit: ${{ github.event.inputs.directCommit }}
-          adminCenterApiCredentials: ${{ fromJson(env.Secrets).adminCenterApiCredentials }}
+          adminCenterApiCredentials: ${{ steps.SetAdminCenterApiCredentials.outputs.adminCenterApiCredentials }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -61,7 +61,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets
@@ -109,7 +108,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -35,7 +35,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   Initialization:
@@ -116,6 +115,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'adminCenterApiCredentials,TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Set AdminCenterApiCredentials
         id: SetAdminCenterApiCredentials

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -114,8 +114,8 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'adminCenterApiCredentials,TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'adminCenterApiCredentials,TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Set AdminCenterApiCredentials
         id: SetAdminCenterApiCredentials
@@ -132,7 +132,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
           project: ${{ github.event.inputs.project }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -35,7 +35,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   Initialization:

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -47,6 +47,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreatePerformanceTestApp:
@@ -70,36 +71,18 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Performance Test App'

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -73,14 +73,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Performance Test App'

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -65,7 +65,6 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -47,7 +47,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreatePerformanceTestApp:
@@ -75,6 +74,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -67,7 +67,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -47,7 +47,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreatePerformanceTestApp:

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -53,7 +53,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateRelease:

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -319,14 +319,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
           versionNumber: ${{ github.event.inputs.updateVersionNumber }}
           directCommit: ${{ github.event.inputs.directCommit }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -53,7 +53,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateRelease:
@@ -321,6 +320,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -80,7 +80,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: templateUrl,repoName
 
       - name: Determine Projects
@@ -221,7 +220,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets
@@ -315,7 +313,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -313,7 +313,6 @@ jobs:
     steps:
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -53,6 +53,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateRelease:
@@ -223,10 +224,10 @@ jobs:
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'nuGetContext,storageContext'
 
@@ -260,22 +261,11 @@ jobs:
               data: fs.readFileSync(assetPath)
             });
 
-      - name: nuGetContext
-        id: nuGetContext
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $nuGetContext = ''
-          $secrets = $env:Secrets | ConvertFrom-Json
-          if ('${{ matrix.atype }}' -eq 'Apps' -and $secrets.nuGetContext) {
-            $nuGetContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.nuGetContext))
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "nuGetContext=$nuGetContext"
-
       - name: Deliver to NuGet
         uses: microsoft/AL-Go-Actions/Deliver@main
-        if: ${{ steps.nuGetContext.outputs.nuGetContext }}
+        if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).nuGetContext != '' }}
         env:
-          deliveryContext: ${{ steps.nuGetContext.outputs.nuGetContext }}
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           type: 'Release'
@@ -284,22 +274,11 @@ jobs:
           artifacts: ${{ github.event.inputs.appVersion }}
           atypes: 'Apps,TestApps'
 
-      - name: storageContext
-        id: storageContext
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $storageContext = ''
-          $secrets = $env:Secrets | ConvertFrom-Json
-          if ('${{ matrix.atype }}' -eq 'Apps' -and $secrets.storageContext) {
-            $storageContext = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.storageContext))
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "storageContext=$storageContext"
-
       - name: Deliver to Storage
         uses: microsoft/AL-Go-Actions/Deliver@main
-        if: ${{ steps.storageContext.outputs.storageContext }}
+        if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).storageContext != '' }}
         env:
-          deliveryContext: ${{ steps.storageContext.outputs.storageContext }}
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           type: 'Release'
@@ -340,36 +319,18 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Update Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
           versionNumber: ${{ github.event.inputs.updateVersionNumber }}
           directCommit: ${{ github.event.inputs.directCommit }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -43,6 +43,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateTestApp:
@@ -66,36 +67,18 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Test App'

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -43,7 +43,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateTestApp:
@@ -71,6 +70,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -63,7 +63,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -69,14 +69,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
         uses: microsoft/AL-Go-Actions/CreateApp@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           type: 'Test App'

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -43,7 +43,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   CreateTestApp:

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/Templates/Per Tenant Extension/.github/workflows/Current.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/Current.yaml
@@ -44,7 +44,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -51,7 +51,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -31,7 +31,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
+  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   IncrementVersionNumber:

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -57,14 +57,14 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForCommits'
-          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
-          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           versionNumber: ${{ github.event.inputs.versionNumber }}

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -31,6 +31,7 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+  useGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   IncrementVersionNumber:
@@ -54,36 +55,18 @@ jobs:
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: github.event.inputs.useGhTokenWorkflow == 'true'
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'ghTokenWorkflow'
-
-      - name: CalculateToken
-        id: CalculateToken
-        env:
-          useGhTokenWorkflow: ${{ github.event.inputs.useGhTokenWorkflow }}
-        run: |
-          $ghToken = '${{ secrets.GITHUB_TOKEN }}'
-          if ($env:useGhTokenWorkflow -eq 'true') {
-            $secrets = $env:Secrets | ConvertFrom-Json
-            if ($secrets.GHTOKENWORKFLOW) {
-              $ghToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.GHTOKENWORKFLOW))
-            }
-            else {
-              Write-Host "::Warning::GHTOKENWORKFLOW secret not found. Using GITHUB_TOKEN."
-            }
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ghToken=$ghToken"
+          getSecrets: 'TokenForCommits'
 
       - name: Increment Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
-          token: ${{ steps.CalculateToken.outputs.ghToken }}
+          token: ${{ steps.ReadSecrets.outputs.TokenForCommits }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           project: ${{ github.event.inputs.project }}
           versionNumber: ${{ github.event.inputs.versionNumber }}

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -31,7 +31,6 @@ defaults:
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
-  UseGhTokenWorkflowForCommits: ${{ github.event.inputs.useGhTokenWorkflow }}
 
 jobs:
   IncrementVersionNumber:
@@ -59,6 +58,7 @@ jobs:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'TokenForCommits'
+          useGhTokenWorkflowForCommits: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
         uses: microsoft/AL-Go-Actions/IncrementVersionNumber@main

--- a/Templates/Per Tenant Extension/.github/workflows/NextMajor.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/NextMajor.yaml
@@ -44,7 +44,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/Per Tenant Extension/.github/workflows/NextMinor.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/NextMinor.yaml
@@ -44,7 +44,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -67,11 +67,11 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         if: steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount == 1
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext'
 
@@ -81,7 +81,7 @@ jobs:
         run: |
           $envName = '${{ steps.envName.outputs.envName }}'
           $secretName = ''
-          $secrets = $env:Secrets | ConvertFrom-Json
+          $secrets = '${{ steps.ReadSecrets.outputs.Secrets }}' | ConvertFrom-Json
           $authContext = $null
           "$($envName)-AuthContext", "$($envName)_AuthContext", "AuthContext" | ForEach-Object {
             if (!($authContext)) {
@@ -135,6 +135,7 @@ jobs:
           shell: powershell
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
@@ -143,6 +144,8 @@ jobs:
 
       - name: Deploy
         uses: microsoft/AL-Go-Actions/Deploy@main
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           environmentName: ${{ matrix.environment }}

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -48,7 +48,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -52,6 +52,8 @@ jobs:
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
         uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           shell: powershell
           getEnvironments: ${{ github.event.inputs.environmentName }}

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -62,7 +62,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -45,10 +45,10 @@ jobs:
           get: templateUrl
 
       - name: Read secrets
+        id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'ghTokenWorkflow'
 
@@ -82,7 +82,7 @@ jobs:
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          token: ${{ fromJson(env.Secrets).ghTokenWorkflow }}
+          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
           Update: Y
           templateUrl: ${{ env.templateUrl }}
           directCommit: ${{ env.directCommit }}

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -41,7 +41,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: templateUrl
 
       - name: Read secrets

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -81,7 +81,6 @@ jobs:
           uses: microsoft/AL-Go-Actions/ReadSettings@main
           with:
             shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             project: ${{ inputs.project }}
             get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,artifact
 

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -86,17 +86,19 @@ jobs:
             get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,artifact
 
         - name: Read secrets
+          id: ReadSecrets
           if: github.event_name != 'pull_request'
           uses: microsoft/AL-Go-Actions/ReadSecrets@main
           with:
             shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
             gitHubSecrets: ${{ toJson(secrets) }}
             getSecrets: '${{ inputs.secrets }},appDependencyProbingPathsSecrets'
 
         - name: Determine ArtifactUrl
           uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@main
           id: determineArtifactUrl
+          env:
+            Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           with:
             shell: ${{ inputs.shell }}
             parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
@@ -112,6 +114,8 @@ jobs:
         - name: Download Project Dependencies
           id: DownloadProjectDependencies
           uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@main
+          env:
+            Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           with:
             shell: ${{ inputs.shell }}
             project: ${{ inputs.project }}
@@ -122,6 +126,7 @@ jobs:
           id: RunPipeline
           uses: microsoft/AL-Go-Actions/RunPipeline@main
           env:
+            Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
             BuildMode: ${{ inputs.buildMode }}
           with:
             shell: ${{ inputs.shell }}

--- a/Tests/ReadSecrets.Action.Test.ps1
+++ b/Tests/ReadSecrets.Action.Test.ps1
@@ -19,7 +19,7 @@ Describe "ReadSecrets Action Tests" {
         }
         $outputs = [ordered]@{
             "Secrets" = "All requested secrets in compressed JSON format"
-            "TokenForCommits" = "The token to use when workflows are creating Pull Requests or Commits."
+            "TokenForPush" = "The token to use when workflows are pushing changes (either directly, or via pull requests)."
         }
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
     }

--- a/Tests/ReadSecrets.Action.Test.ps1
+++ b/Tests/ReadSecrets.Action.Test.ps1
@@ -19,6 +19,8 @@ Describe "ReadSecrets Action Tests" {
         }
         $outputs = [ordered]@{
             "Secrets" = "All requested secrets in compressed JSON format"
+            "TokenForCommits" = "The token to use when workflows are creating Pull Requests or Commits."
+        
         }
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
     }

--- a/Tests/ReadSecrets.Action.Test.ps1
+++ b/Tests/ReadSecrets.Action.Test.ps1
@@ -20,7 +20,6 @@ Describe "ReadSecrets Action Tests" {
         $outputs = [ordered]@{
             "Secrets" = "All requested secrets in compressed JSON format"
             "TokenForCommits" = "The token to use when workflows are creating Pull Requests or Commits."
-        
         }
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
     }

--- a/Tests/ReadSecrets.Action.Test.ps1
+++ b/Tests/ReadSecrets.Action.Test.ps1
@@ -18,6 +18,7 @@ Describe "ReadSecrets Action Tests" {
         $permissions = [ordered]@{
         }
         $outputs = [ordered]@{
+            "Secrets" = "All requested secrets in compressed JSON format"
         }
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
     }

--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -235,7 +235,7 @@ function WaitWorkflow {
     Write-Host
     Write-Host $run.conclusion
     if ($run.conclusion -ne "Success") {
-        throw "Workflow $name failed, url = $($run.html_url)"
+        throw "Workflow $($run.name), conclusion $($run.conclusion), url = $($run.html_url)"
     }
 }
 


### PR DESCRIPTION
This PR includes:
- Fix for BUG: The DetermineDeploymentEnvironments doesn't work in private repositories (needs the GITHUB_TOKEN)
- Only transfer Secrets to the Actions which actually needs them. Do not have ENV:Secrets available in all steps.
- Move CheckAppDependencyProbingPaths out of AnalyzeRepo and call where needed (remove doNotCheckAppDependencyProbingPaths switch)
- Remove BcContainerHelper usage from ReadSecrets
- Remove BcContainerHelper usage from ReadSettings
- Move functionality for getting a token to use for commits into ReadSecrets (remove PS code from workflows)
  - Set UseGhTokenWorkflowForCommits as ENV variable based on the input
  - Add TokenForCommits in the getSecrets and you will not have an output variable to use as token for actions needing that