### PR TITLE
Publish to environment problem in preview

### DIFF
--- a/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
+++ b/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
@@ -51,7 +51,7 @@ $ghEnvironments = @(GetGitHubEnvironments)
 
 Write-Host "Reading environments from settings"
 $settings.excludeEnvironments += @('github-pages')
-$environments = @($ghEnvironments | ForEach-Object { $_.name }) + @($settings.environments) | Select-Object -unique | Where-Object { $settings.excludeEnvironments -notcontains $_ -and $_ -like $getEnvironments }
+$environments = @($ghEnvironments | ForEach-Object { $_.name }) + @($settings.environments) | Select-Object -unique | Where-Object { $settings.excludeEnvironments -notcontains $_.Split(' ')[0] -and $_.Split(' ')[0] -like $getEnvironments }
 
 Write-Host "Environments found: $($environments -join ', ')"
 
@@ -64,6 +64,7 @@ if (!($environments)) {
         $envName = $getEnvironments.Split(' ')[0]
         $deploymentEnvironments += @{
             "$getEnvironments" = @{
+                "EnvironmentType" = "SaaS"
                 "EnvironmentName" = $envName
                 "Branches" = $null
                 "BranchesFromPolicy" = @()

--- a/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
+++ b/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
@@ -56,6 +56,7 @@ $environments = @($ghEnvironments | ForEach-Object { $_.name }) + @($settings.en
 Write-Host "Environments found: $($environments -join ', ')"
 
 $deploymentEnvironments = @{}
+$unknownEnvironment = 0
 
 if (!($environments)) {
     # If no environments are defined and the user specified a single environment, use that environment
@@ -74,6 +75,7 @@ if (!($environments)) {
                 "runs-on" = @($settings."runs-on".Split(',').Trim())
             }
         }
+        $unknownEnvironment = 1
     }
 }
 else {
@@ -179,3 +181,6 @@ Write-Host "DeploymentEnvironmentsJson=$deploymentEnvironmentsJson"
 
 Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "EnvironmentCount=$($deploymentEnvironments.Keys.Count)"
 Write-Host "EnvironmentCount=$($deploymentEnvironments.Keys.Count)"
+
+Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "UnknownEnvironment=$unknownEnvironment"
+Write-Host "UnknownEnvironment=$unknownEnvironment"

--- a/Actions/DetermineDeploymentEnvironments/README.md
+++ b/Actions/DetermineDeploymentEnvironments/README.md
@@ -20,5 +20,6 @@ Determines the environments to be used for a build or a publish
 | EnvironmentsMatrixJson | The Environment matrix to use for the Deploy step in compressed JSON format |
 | DeploymentEnvironmentsJson | Deployment Environments with settings in compressed JSON format |
 | EnvironmentCount | Number of Deployment Environments |
+| UnknownEnvironment | Flag determining whether we try to publish to an unknown environment (invoke device code flow) |
 
 ### ENV variables

--- a/Actions/DetermineDeploymentEnvironments/action.yaml
+++ b/Actions/DetermineDeploymentEnvironments/action.yaml
@@ -21,6 +21,9 @@ outputs:
   EnvironmentCount:
     description: Number of Deployment Environments
     value: ${{ steps.determineDeploymentEnvironments.outputs.EnvironmentCount }}
+  UnknownEnvironment:
+    description: Flag determining whether the environment is unknown
+    value: ${{ steps.determineDeploymentEnvironments.outputs.UnknownEnvironment }}
 runs:
   using: composite
   steps:

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: EnvName
         id: envName
-        if: steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount == 1
+        if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $envName = '${{ fromJson(steps.DetermineDeploymentEnvironments.outputs.environmentsMatrixJson).matrix.include[0].environment }}'.split(' ')[0]
@@ -70,7 +70,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount == 1
+        if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Authenticate
         id: Authenticate
-        if: steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount == 1
+        if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         run: |
           $envName = '${{ steps.envName.outputs.envName }}'
           $secretName = ''

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: EnvName
         id: envName
-        if: steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount == 1
+        if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $envName = '${{ fromJson(steps.DetermineDeploymentEnvironments.outputs.environmentsMatrixJson).matrix.include[0].environment }}'.split(' ')[0]
@@ -70,7 +70,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         uses: microsoft/AL-Go-Actions/ReadSecrets@main
-        if: steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount == 1
+        if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Authenticate
         id: Authenticate
-        if: steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount == 1
+        if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         run: |
           $envName = '${{ steps.envName.outputs.envName }}'
           $secretName = ''

--- a/Tests/DetermineDeploymentEnvironments.Test.ps1
+++ b/Tests/DetermineDeploymentEnvironments.Test.ps1
@@ -203,7 +203,7 @@ Describe "DetermineDeploymentEnvironments Action Test" {
         . (Join-Path $scriptRoot $scriptName) -getEnvironments 'test' -type 'Publish'
         PassGeneratedOutput
         $EnvironmentCount | Should -Be 1
-        ($EnvironmentsMatrixJson | ConvertFrom-Json | ConvertTo-HashTable -recurse).matrix.include.environment | Should -Contain "test"
+        ($EnvironmentsMatrixJson | ConvertFrom-Json | ConvertTo-HashTable -recurse).matrix.include.environment | Should -Contain "test (PROD)"
     }
 
     # 2 environments defined in Settings - one PROD and one non-PROD (settings based)
@@ -235,6 +235,6 @@ Describe "DetermineDeploymentEnvironments Action Test" {
         . (Join-Path $scriptRoot $scriptName) -getEnvironments 'test' -type 'Publish'
         PassGeneratedOutput
         $EnvironmentCount | Should -Be 1
-        ($EnvironmentsMatrixJson | ConvertFrom-Json | ConvertTo-HashTable -recurse).matrix.include.environment | Should -Contain "test"
+        ($EnvironmentsMatrixJson | ConvertFrom-Json | ConvertTo-HashTable -recurse).matrix.include.environment | Should -Contain "test (PROD)"
     }
 }

--- a/Tests/DetermineDeploymentEnvironments.Test.ps1
+++ b/Tests/DetermineDeploymentEnvironments.Test.ps1
@@ -43,6 +43,7 @@ Describe "DetermineDeploymentEnvironments Action Test" {
             "EnvironmentsMatrixJson" = "The Environment matrix to use for the Deploy step in compressed JSON format"
             "DeploymentEnvironmentsJson" = "Deployment Environments with settings in compressed JSON format"
             "EnvironmentCount" = "Number of Deployment Environments"
+            "UnknownEnvironment" = "Flag determining whether the environment is unknown"
         }
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
     }


### PR DESCRIPTION
Fix for issue #697

Problem was:
- GitHub Environments with a suffix (PROD (PROD)) was not found, leading to publish trying to publish to an unknown environment (because count was 1)
- The autogenerated DeploySettings was missing the EnvironmentType.

But the publish to unknown environment should never be invoked in the first place - only if the environment actually isn't in GitHub - this has also been fixed.