### PR TITLE
Fix issue with getting dependencies in incremental build

### DIFF
--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -153,7 +153,7 @@ function GetDependencies {
                     if (Test-Path $downloadName -PathType Container) {
                         $folder = Get-Item $downloadName
                         Get-ChildItem -Path $folder | ForEach-Object {
-                            if ($mask -eq 'TestApps') {
+                            if ($mask -like '*TestApps') {
                                 $downloadedList += @("($($_.FullName))")
                             }
                             else {
@@ -163,8 +163,8 @@ function GetDependencies {
                         }
                     }
                     elseif ($mask -notlike '*TestApps') {
-                        Write-Host "$_ not built, downloading from artifacts"
-                        $missingProjects += @($_)
+                        Write-Host "$project not built, downloading from artifacts"
+                        $missingProjects += @($project)
                     }
                 }
                 if ($missingProjects) {
@@ -181,7 +181,7 @@ function GetDependencies {
                     $artifacts | ForEach-Object {
                         $download = DownloadArtifact -path $saveToPath -token $dependency.authTokenSecret -artifact $_
                         if ($download) {
-                            if ($mask -eq 'TestApps') {
+                            if ($mask -like '*TestApps') {
                                 $downloadedList += @("($download)")
                             }
                             else {
@@ -216,7 +216,7 @@ function GetDependencies {
 
                 $download = DownloadRelease -token $dependency.authTokenSecret -projects $projects -api_url $api_url -repository $repository -path $saveToPath -release $release -mask $mask
                 if ($download) {
-                    if ($mask -eq 'TestApps') {
+                    if ($mask -like '*TestApps') {
                         $downloadedList += @("($download)")
                     }
                     else {


### PR DESCRIPTION
Issue 1: after https://github.com/microsoft/AL-Go/commit/7e245d8413b88c59b7d0a05bb4582ac107f99b84#diff-8b3bc43d627973d00981a6cb79e54160281d51f7a4a7aee41e856160e9841b24 there was an issue with `$_` not being defined.

Issue 2: `TestApp` mask is transformed to `<buildMode>TestApps` in non-default mode. There are a few lines that needed fixing.

Note: The issue was not caught in E2E tests as there's no test to cover the PR incremental build (where some projects are not built, but instead fetched from a previous build).