### PR TITLE
Check if GITHUB_ENV exists before writing to it

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -367,7 +367,9 @@ function GetBcContainerHelperPath([string] $bcContainerHelperVersion) {
         }
     }
     $env:BcContainerHelperPath = $bcContainerHelperPath
-    Add-Content -Encoding UTF8 -Path $ENV:GITHUB_ENV "BcContainerHelperPath=$bcContainerHelperPath"
+    if ($ENV:GITHUB_ENV) {
+        Add-Content -Encoding UTF8 -Path $ENV:GITHUB_ENV "BcContainerHelperPath=$bcContainerHelperPath"
+    }
     return $bcContainerHelperPath
 }
 


### PR DESCRIPTION
When running localdevenv.ps1 I'm getting the following error:
`
Using BcContainerHelper preview version
Downloading BcContainerHelper preview version from Blob Storage
Using Expand-Archive
Error: Cannot bind argument to parameter 'Path' because it is null.
Stacktrace: at GetBcContainerHelperPath, C:\Users\aholstrup\AppData\Local\Temp\tmpC451.tmp.ps1: line 370
at DownloadAndImportBcContainerHelper, C:\Users\aholstrup\AppData\Local\Temp\tmpC451.tmp.ps1: line 410
at CreateDevEnv, C:\Users\aholstrup\AppData\Local\Temp\tmpC451.tmp.ps1: line 1516
at <ScriptBlock>, C:\Users\aholstrup\Documents\Github\Microsoft\BCApps\Projects\System Application\.AL-Go\localDevEnv.ps1: line 125
at <ScriptBlock>, <No file>: line 1
`

It appears to happen when we try to write BcContainerHelperPath to $ENV:GITHUB_ENV.