### PR TITLE
Add defensive checks for env Secrets 

### DIFF
--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
@@ -18,6 +18,7 @@ try {
     $telemetryScope = CreateScope -eventId 'DO0084' -parentTelemetryScopeJson $parentTelemetryScopeJson
 
     $insiderSasToken = ""
+    # ENV:Secrets is not set when running Pull_Request trigger
     if ($env:Secrets) {
         $secrets = $env:Secrets | ConvertFrom-Json | ConvertTo-HashTable
         $insiderSasToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.insiderSasToken))

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
@@ -22,7 +22,7 @@ try {
         $secrets = $env:Secrets | ConvertFrom-Json | ConvertTo-HashTable
         $insiderSasToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.insiderSasToken))
     }
-    
+
     $settings = $env:Settings | ConvertFrom-Json | ConvertTo-HashTable
     $settings = AnalyzeRepo -settings $settings -project $project -doNotCheckArtifactSetting -doNotIssueWarnings
     $artifactUrl = DetermineArtifactUrl -projectSettings $settings -insiderSasToken $insiderSasToken

--- a/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
+++ b/Actions/DetermineArtifactUrl/DetermineArtifactUrl.ps1
@@ -16,8 +16,13 @@ try {
 
     #region Action: Determine artifacts to use
     $telemetryScope = CreateScope -eventId 'DO0084' -parentTelemetryScopeJson $parentTelemetryScopeJson
-    $secrets = $env:Secrets | ConvertFrom-Json | ConvertTo-HashTable
-    $insiderSasToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.insiderSasToken))
+
+    $insiderSasToken = ""
+    if ($env:Secrets) {
+        $secrets = $env:Secrets | ConvertFrom-Json | ConvertTo-HashTable
+        $insiderSasToken = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets.insiderSasToken))
+    }
+    
     $settings = $env:Settings | ConvertFrom-Json | ConvertTo-HashTable
     $settings = AnalyzeRepo -settings $settings -project $project -doNotCheckArtifactSetting -doNotIssueWarnings
     $artifactUrl = DetermineArtifactUrl -projectSettings $settings -insiderSasToken $insiderSasToken

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -77,7 +77,14 @@ try {
 
     Write-Host "use settings and secrets"
     $settings = $env:Settings | ConvertFrom-Json | ConvertTo-HashTable
-    $secrets = $env:Secrets | ConvertFrom-Json | ConvertTo-HashTable
+    Write-Host "secrets: $env:Secrets"
+    if ($env:Secrets) {
+        $secrets = $env:Secrets | ConvertFrom-Json | ConvertTo-HashTable
+    }
+    else {
+        $secrets = @{}
+    }
+
     $appBuild = $settings.appBuild
     $appRevision = $settings.appRevision
     'licenseFileUrl','insiderSasToken','codeSignCertificateUrl','*codeSignCertificatePassword','keyVaultCertificateUrl','*keyVaultCertificatePassword','keyVaultClientId','gitHubPackagesContext','applicationInsightsConnectionString' | ForEach-Object {

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -77,7 +77,6 @@ try {
 
     Write-Host "use settings and secrets"
     $settings = $env:Settings | ConvertFrom-Json | ConvertTo-HashTable
-    Write-Host "secrets: $env:Secrets"
     if ($env:Secrets) {
         $secrets = $env:Secrets | ConvertFrom-Json | ConvertTo-HashTable
     }

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -77,6 +77,7 @@ try {
 
     Write-Host "use settings and secrets"
     $settings = $env:Settings | ConvertFrom-Json | ConvertTo-HashTable
+    # ENV:Secrets is not set when running Pull_Request trigger
     if ($env:Secrets) {
         $secrets = $env:Secrets | ConvertFrom-Json | ConvertTo-HashTable
     }


### PR DESCRIPTION

```
BC.HelperFunctions emits usage statistics telemetry to Microsoft
AL-Go action ran: DetermineArtifactUrl Telemetry Correlation Id: 76ecbed3-aa21-4f63-8558-278d39cae9f2
Error: Unexpected error when running action. Error Message: Cannot bind argument to parameter 'InputObject' because it is null., StackTrace: at <ScriptBlock>, D:\a\_actions\microsoft\AL-Go\ce6a36367580e96a[44](https://github.com/microsoft/ALAppExtensions/actions/runs/6244972353/job/16952777632?pr=24858#step:5:46)bbc3b5dd31238d945cf8fe\Actions\DetermineArtifactUrl\DetermineArtifactUrl.ps1: line 19 <- at <ScriptBlock>, D:\a\_temp\b7850c6d-56c1-4fb7-a6cc-ee9b1ce4f5f6.ps1: line 4 <- at <ScriptBlock>, <No file>: line 1
Error: Process completed with exit code 1.
```