### PR TITLE
use companyName setting on UploadImportAndApplyConfigPackageInBc

### DIFF
--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -282,6 +282,7 @@ try {
                             $packageId = $_.Split(',')[1]
                             UploadImportAndApply-ConfigPackageInBcContainer `
                                 -containerName $parameters.containerName `
+                                -companyName $settings.companyName `
                                 -Credential $parameters.credential `
                                 -Tenant $parameters.tenant `
                                 -ConfigPackage $configPackage `


### PR DESCRIPTION
CompanyName parameter defines the company where tests should be run, but it does not affect test data import.
I suggest adding this modification so companyName setup works for both steps.
