### PR TITLE
Propagate PreCompileApp and PostCompileApp arguments from BCContainerHelper

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -36,6 +36,8 @@ $runAlPipelineOverrides = @(
     "GetBcContainerAppRuntimePackage"
     "RemoveBcContainer"
     "InstallMissingDependencies"
+    "PreCompileApp"
+    "PostCompileApp"
 )
 
 # Well known AppIds


### PR DESCRIPTION
`PreCompileApp` and `PostCompileApp` are arguments of [Run-AlPipeline](https://github.com/microsoft/navcontainerhelper/blob/master/AppHandling/Run-AlPipeline.ps1) in BCContainerHelper.