### PR TITLE
Get artifact from settings during localdevenv

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1644,7 +1644,7 @@ function CreateDevEnv {
         $settings = AnalyzeRepo -settings $settings -baseFolder $baseFolder -project $project @params
         $settings = CheckAppDependencyProbingPaths -settings $settings -baseFolder $baseFolder -project $project
 
-        if (!$accept_insiderEula -and ($repo.artifact -like 'https://bcinsider.blob.core.windows.net/*' -or $repo.artifact -like 'https://bcinsider.azureedge.net/*')) {
+        if (!$accept_insiderEula -and ($settings.artifact -like 'https://bcinsider.blob.core.windows.net/*' -or $settings.artifact -like 'https://bcinsider.azureedge.net/*')) {
             Read-Host 'Press ENTER to accept the Business Central insider EULA (https://go.microsoft.com/fwlink/?linkid=2245051) or break the script to cancel'
             $accept_insiderEula = $true
         }

--- a/Templates/AppSource App/.AL-Go/localDevEnv.ps1
+++ b/Templates/AppSource App/.AL-Go/localDevEnv.ps1
@@ -8,7 +8,8 @@ Param(
     [string] $auth = "",
     [pscredential] $credential = $null,
     [string] $licenseFileUrl = "",
-    [switch] $fromVSCode
+    [switch] $fromVSCode,
+    [switch] $accept_insiderEula
 )
 
 $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
@@ -129,7 +130,8 @@ CreateDevEnv `
     -project $project `
     -auth $auth `
     -credential $credential `
-    -licenseFileUrl $licenseFileUrl
+    -licenseFileUrl $licenseFileUrl `
+    -accept_insiderEula:$accept_insiderEula
 }
 catch {
     Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"

--- a/Templates/Per Tenant Extension/.AL-Go/localDevEnv.ps1
+++ b/Templates/Per Tenant Extension/.AL-Go/localDevEnv.ps1
@@ -8,7 +8,8 @@ Param(
     [string] $auth = "",
     [pscredential] $credential = $null,
     [string] $licenseFileUrl = "",
-    [switch] $fromVSCode
+    [switch] $fromVSCode,
+    [switch] $accept_insiderEula
 )
 
 $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
@@ -129,7 +130,8 @@ CreateDevEnv `
     -project $project `
     -auth $auth `
     -credential $credential `
-    -licenseFileUrl $licenseFileUrl
+    -licenseFileUrl $licenseFileUrl `
+    -accept_insiderEula:$accept_insiderEula
 }
 catch {
     Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"


### PR DESCRIPTION
When I run localdevenv from latest preview I get the following:

_No performance test apps found in bcptTestFolders in .AL-Go\settings.json
Checking appDependencyProbingPaths
Error: The variable '$repo' cannot be retrieved because it has not been set.
Stacktrace: at CreateDevEnv, C:\Users\UserName\AppData\Local\Temp\tmp71A1.tmp.ps1: line 1647_

**Suggested fix**
Getting artifact from $settings.artifact rather than $repo.artifact 

Additionally, add an option to accept insider eula when invoking localdevenv