### PR TITLE
Bug fix for using self-hosted runners while having an Azure KeyVault connection

### DIFF
--- a/Actions/ReadSecrets/ReadSecretsHelper.psm1
+++ b/Actions/ReadSecrets/ReadSecretsHelper.psm1
@@ -109,7 +109,7 @@ function GetKeyVaultCredentials {
 }
 
 function InstallKeyVaultModuleIfNeeded {
-    if ($isWindows) {
+    if ($isWindows -and (Test-Path 'C:\Modules\az_*')) {
         $azModulesPath = Get-ChildItem 'C:\Modules\az_*' | Where-Object { $_.PSIsContainer }
         if ($azModulesPath) {
           Write-Host $azModulesPath.FullName

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,7 @@ AL-Go for GitHub allows you to build and test using insider builds without any e
 
 ### Issues
 - Issue 730 Support for external rulesets.
+- Using self-hosted runners while using Azure KeyVault for secrets or signing might fail with C:\Modules doesn't exist
 
 ### New Settings
 - `enableExternalRulesets`: set this setting to true if you want to allow AL-Go to automatically download external references in rulesets.


### PR DESCRIPTION
Check that C:\Modules (exists on GitHub hosted windows runners) exists before enumerating it.