### PR TITLE
Fix containerhelperversion in deploy

### DIFF
--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -19,7 +19,7 @@ on:
         required: false
         default: false
       defaultBcContainerHelperVersion:
-        description: 'Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/freddydk/navcontainerhelper/archive/master.zip - leave empty to use latest)'
+        description: 'Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/freddydk/navcontainerhelper/archive/master.zip). Leave empty to use latest (or preview for preview branches)'
         required: false
         default: ''
 
@@ -68,6 +68,13 @@ jobs:
               throw "In order to run the Deploy workflow, you need a Secret called OrgPAT containing a valid Personal Access Token"
             }
             $githubOwner = "$ENV:GITHUB_REPOSITORY_OWNER"
+            if ("$env:defaultBcContainerHelperVersion" -eq "") {
+              if ($env:branch -eq 'preview') {
+                $env:defaultBcContainerHelperVersion = 'preview'
+              } else {
+                $env:defaultBcContainerHelperVersion = 'latest'
+              }
+            }
             $config = @{
                   "githubOwner" = $githubOwner
                   "actionsRepo" = "AL-Go-Actions"

--- a/Internal/Deploy.ps1
+++ b/Internal/Deploy.ps1
@@ -232,6 +232,7 @@ try {
                     if ($lines[$idx] -match '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)" # (.*)$') {
                         $lines[$idx] = "$($Matches[1])`$defaultBcContainerHelperVersion$($Matches[2])=$($Matches[3])""$($config.defaultBcContainerHelperVersion)"" # $($Matches[5])"
                         $found = $true
+                        break
                     }
                 }
                 if (-not $found) {

--- a/Internal/Deploy.ps1
+++ b/Internal/Deploy.ps1
@@ -226,8 +226,17 @@ try {
                 $lines = $lines | ForEach-Object { $_ -replace $regex, $replace }
             }
             if ($_.Name -eq "AL-Go-Helper.ps1" -and ($config.ContainsKey("defaultBcContainerHelperVersion") -and $config.defaultBcContainerHelperVersion)) {
-                # replace defaultBcContainerHelperVersion (even if a version is set)
-                $lines = $lines | ForEach-Object { $_ -replace '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)" # (.*)$', "`${1}`$defaultBcContainerHelperVersion`${2}=`${3}""$($config.defaultBcContainerHelperVersion)"" # `${5}" }
+                # replace defaultBcContainerHelperVersion
+                $found = $false
+                for($idx=0; $idx -lt $lines.count; $idx++) {
+                    if ($lines[$idx] -match '^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)" # (.*)$') {
+                        $lines[$idx] = "$($Matches[1])`$defaultBcContainerHelperVersion$($Matches[2])=$($Matches[3])""$($config.defaultBcContainerHelperVersion)"" # $($Matches[5])"
+                        $found = $true
+                    }
+                }
+                if (-not $found) {
+                    throw 'Could not find defaultBcContainerHelperVersion line in AL-Go-Helpers.ps1 matching "^(\s*)\$defaultBcContainerHelperVersion(\s*)=(\s*)"(.*)" # (.*)$"'
+                }
             }
             [System.IO.File]::WriteAllText($dstFile, "$($lines -join "`n")`n")
         }


### PR DESCRIPTION
After finding out that v3.3 was shipped with containerHelper preview as the selected version, I investigated and found that:
If a defaultContainerHelperVersion wasn't specified when running deploy, the default containerHelperVersion used was taken from AL-Go-Helper.ps1 (which normally is "preview")
This PR defaults defaultContainerHelperVersion to preview for preview branches and latest for other branches.
Also it makes sure that the line in AL-Go-Helper.ps1 can be found and patched - else it will throw an error.