### PR TITLE
Only display test result summary when there is something to display 

### DIFF
--- a/Actions/AnalyzeTests/AnalyzeTests.ps1
+++ b/Actions/AnalyzeTests/AnalyzeTests.ps1
@@ -27,7 +27,7 @@ try {
         Add-Content -path $ENV:GITHUB_STEP_SUMMARY -value "$($testResultSummary.Replace("\n","`n"))`n"
     }
     else {
-        Add-Content -path $ENV:GITHUB_STEP_SUMMARY -value "*Test results not found*`n`n"
+        Write-Host "Test results not found"
     }
 
     $bcptTestResultsFile = Join-Path $ENV:GITHUB_WORKSPACE "$project\BCPTTestResults.json"

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -91,7 +91,7 @@ jobs:
           with:
             shell: ${{ inputs.shell }}
             project: ${{ inputs.project }}
-            get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,artifact
+            get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact
 
         - name: Read secrets
           id: ReadSecrets
@@ -240,7 +240,7 @@ jobs:
 
         - name: Analyze Test Results
           id: analyzeTestResults
-          if: success() || failure()
+          if: (success() || failure()) && env.doNotRunTests == 'False'
           uses: microsoft/AL-Go-Actions/AnalyzeTests@main
           with:
             shell: ${{ inputs.shell }}

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -91,7 +91,7 @@ jobs:
           with:
             shell: ${{ inputs.shell }}
             project: ${{ inputs.project }}
-            get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,artifact
+            get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact
 
         - name: Read secrets
           id: ReadSecrets
@@ -240,7 +240,7 @@ jobs:
 
         - name: Analyze Test Results
           id: analyzeTestResults
-          if: success() || failure()
+          if: (success() || failure()) && env.doNotRunTests == 'False'
           uses: microsoft/AL-Go-Actions/AnalyzeTests@main
           with:
             shell: ${{ inputs.shell }}


### PR DESCRIPTION
GitHub will only show the first three build summaries and showing "Test Results Not Found" three times doesn't provide much value IMO. 

Only display test result summary when there is something to display

<img width="1235" alt="image" src="https://github.com/microsoft/AL-Go/assets/117829001/5d15a3b3-ab3d-43bd-a568-2856ff240d3c">
