### PR TITLE
Invokegh

### DIFF
--- a/Actions/AL-Go-TestRepoHelper.ps1
+++ b/Actions/AL-Go-TestRepoHelper.ps1
@@ -116,7 +116,7 @@ function Test-JsonFile {
     Test-JsonStr -org -jsonStr (Get-Content -Path $jsonFile -Raw -Encoding UTF8) -settingsDescription $settingsFile -type $type
 }
 
-function Test-RunnerPrerequisites {
+function TestRunnerPrerequisites {
     try {
         invoke-gh version
     }
@@ -131,7 +131,7 @@ function Test-RunnerPrerequisites {
     }
 }
 
-function Test-ALGoRepository {
+function TestALGoRepository {
     Param(
         [string] $baseFolder = $ENV:GITHUB_WORKSPACE
     )

--- a/Actions/AL-Go-TestRepoHelper.ps1
+++ b/Actions/AL-Go-TestRepoHelper.ps1
@@ -116,6 +116,21 @@ function Test-JsonFile {
     Test-JsonStr -org -jsonStr (Get-Content -Path $jsonFile -Raw -Encoding UTF8) -settingsDescription $settingsFile -type $type
 }
 
+function Test-RunnerPrerequisites {
+    try {
+        invoke-gh version
+    }
+    catch {
+        Write-Host "::Warning::GitHub CLI is not installed"
+    }
+    try {
+        invoke-git version
+    }
+    catch {
+        Write-Host "::Warning::Git is not installed"
+    }
+}
+
 function Test-ALGoRepository {
     Param(
         [string] $baseFolder = $ENV:GITHUB_WORKSPACE

--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -310,7 +310,7 @@ function invoke-gh {
         foreach($parameter in $remaining) {
             if ("$parameter".IndexOf(" ") -ge 0 -or "$parameter".IndexOf('"') -ge 0) {
                 if ($parameter.length -gt 15000) {
-                    $parameter = "$($parameter.Substring(0,15000))`n`n**Truncated due to size limits!**"
+                    $parameter = "$($parameter.Substring(0,15000))...`n`n**Truncated due to size limits!**"
                 }
                 $arguments += """$($parameter.Replace('"','\"'))"" "
             }

--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -309,18 +309,16 @@ function invoke-gh {
         $arguments = "$command "
         foreach($parameter in $remaining) {
             if ("$parameter".IndexOf(" ") -ge 0 -or "$parameter".IndexOf('"') -ge 0) {
+                if ($parameter.length -gt 15000) {
+                    $parameter = "$($parameter.Substring(0,15000))`n`n**Truncated due to size limits!**"
+                }
                 $arguments += """$($parameter.Replace('"','\"'))"" "
             }
             else {
                 $arguments += "$parameter "
             }
         }
-        try {
-            cmdDo -command gh -arguments $arguments -silent:$silent -returnValue:$returnValue -inputStr $inputStr
-        }
-        catch [System.Management.Automation.MethodInvocationException] {
-            throw "It looks like GitHub CLI is not installed. Please install GitHub CLI from https://cli.github.com/"
-        }
+        cmdDo -command gh -arguments $arguments -silent:$silent -returnValue:$returnValue -inputStr $inputStr
     }
 }
 
@@ -344,12 +342,7 @@ function invoke-git {
                 $arguments += "$parameter "
             }
         }
-        try {
-            cmdDo -command git -arguments $arguments -silent:$silent -returnValue:$returnValue -inputStr $inputStr
-        }
-        catch [System.Management.Automation.MethodInvocationException] {
-            throw "It looks like Git is not installed. Please install Git from https://git-scm.com/download"
-        }
+        cmdDo -command git -arguments $arguments -silent:$silent -returnValue:$returnValue -inputStr $inputStr
     }
 }
 

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -25,11 +25,11 @@ try {
 
     Write-Big -str "a$verstr"
 
-    Test-ALGoRepository
+    TestALGoRepository
 
     DownloadAndImportBcContainerHelper
 
-    Test-RunnerPrerequisites
+    TestRunnerPrerequisites
 
     import-module (Join-Path -path $PSScriptRoot -ChildPath "..\TelemetryHelper.psm1" -Resolve)
     $telemetryScope = CreateScope -eventId $eventId

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -27,9 +27,9 @@ try {
 
     Test-ALGoRepository
 
-    Test-RunnerPrerequisites
-
     DownloadAndImportBcContainerHelper
+
+    Test-RunnerPrerequisites
 
     import-module (Join-Path -path $PSScriptRoot -ChildPath "..\TelemetryHelper.psm1" -Resolve)
     $telemetryScope = CreateScope -eventId $eventId

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -27,6 +27,8 @@ try {
 
     Test-ALGoRepository
 
+    Test-RunnerPrerequisites
+
     DownloadAndImportBcContainerHelper
 
     import-module (Join-Path -path $PSScriptRoot -ChildPath "..\TelemetryHelper.psm1" -Resolve)

--- a/Tests/WorkflowInitialize.Test.ps1
+++ b/Tests/WorkflowInitialize.Test.ps1
@@ -51,7 +51,7 @@ Describe "WorkflowInitialize Action Tests" {
                 Set-Content -Path (Join-Path $githubFolder 'AL-Go-Settings.json') -Value $repoSettings -Encoding UTF8
                 Set-Content -Path (Join-Path $ALGoFolder 'settings.json') -Value $projectSettings -Encoding UTF8
                 Set-Content -Path (Join-Path $Project1ALGoFolder 'settings.json') -Value $project1Settings -Encoding UTF8
-                Test-ALGoRepository -baseFolder $tempDir
+                TestALGoRepository -baseFolder $tempDir
             }
             finally {
                 Remove-Item -Path $tempDir -Recurse -Force


### PR DESCRIPTION
Test pre-requisites in WorkflowInitialize and give warnings if git or GH isn't installed, by attempting to display version numbers.
Also remove the mechanism of hiding the real exception in invoke-gh and invoke-git to display this error in that function