### PR TITLE
Dependencies from prior build jobs are not included when using useProjectDependencies

### DIFF
--- a/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
+++ b/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
@@ -49,7 +49,7 @@ else {
 }
 
 # Set this build artifacts name
-'Apps', 'TestApps' | ForEach-Object {
+'Apps', 'Dependencies', 'TestApps' | ForEach-Object {
     $name = "ThisBuild$($_)ArtifactsName"
     $value = "thisbuild-$($projectName)-$($buildMode)$($_)"
     Set-OutputVariable -name $name -value $value

--- a/Actions/CalculateArtifactNames/README.md
+++ b/Actions/CalculateArtifactNames/README.md
@@ -22,6 +22,7 @@ Calculate Artifact Names for AL-Go workflows
 | Name | Description |
 | :-- | :-- |
 | ThisBuildAppsArtifactsName | Artifact name for apps being built in the current workflow run |
+| ThisBuildDependenciesArtifactsName | Artifact name for dependencies of apps being built in the current workflow run |
 | ThisBuildTestAppsArtifactsName | Artifact name for test apps being built in the current workflow run |
 | AppsArtifactsName | Artifacts name for Apps |
 | DependenciesArtifactsName | Artifacts name for Dependencies |
@@ -36,6 +37,7 @@ Calculate Artifact Names for AL-Go workflows
 | Name | Description |
 | :-- | :-- |
 | ThisBuildAppsArtifactsName | Artifact name for apps being built in the current workflow run |
+| ThisBuildDependenciesArtifactsName | Artifact name for dependencies of apps being built in the current workflow run |
 | ThisBuildTestAppsArtifactsName | Artifact name for test apps being built in the current workflow run |
 | AppsArtifactsName | Artifacts name for Apps |
 | DependenciesArtifactsName | Artifacts name for Dependencies |

--- a/Actions/CalculateArtifactNames/action.yaml
+++ b/Actions/CalculateArtifactNames/action.yaml
@@ -19,6 +19,9 @@ outputs:
   ThisBuildAppsArtifactsName:
     description: Artifact name for apps being built in the current workflow run
     value: ${{ steps.calculateartifactnames.outputs.ThisBuildAppsArtifactsName }}
+  ThisBuildDependenciesArtifactsName:
+    description: Artifact name for dependencies of apps being built in the current workflow run
+    value: ${{ steps.calculateartifactnames.outputs.ThisBuildDependenciesArtifactsName }}
   ThisBuildTestAppsArtifactsName:
     description: Artifact name for test apps being built in the current workflow run
     value: ${{ steps.calculateartifactnames.outputs.ThisBuildTestAppsArtifactsName }}

--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -131,7 +131,7 @@ function GetDependencies {
     }
 
     $downloadedList = @()
-    foreach($mask in 'Apps','TestApps') {
+    foreach($mask in 'Apps','Dependencies','TestApps') {
         foreach($dependency in $probingPathsJson) {
             $projects = $dependency.projects
             $buildMode = $dependency.buildMode

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -385,7 +385,7 @@ try {
         -installApps $installApps `
         -installTestApps $installTestApps `
         -installOnlyReferencedApps:$settings.installOnlyReferencedApps `
-        -generateDependencyArtifact:$settings.generateDependencyArtifact `
+        -generateDependencyArtifact `
         -updateDependencies:$settings.updateDependencies `
         -previousApps $previousApps `
         -appFolders $settings.appFolders `

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,7 @@ Note that when using the preview version of AL-Go for GitHub, we recommend you U
 
 ### Issues
 - Issue 782 Exclude '.altestrunner/' from template .gitignore
+- Issue 823 Dependencies from prior build jobs are not included when using useProjectDependencies
 
 ## v4.0
 

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -91,7 +91,7 @@ jobs:
           with:
             shell: ${{ inputs.shell }}
             project: ${{ inputs.project }}
-            get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact
+            get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact,generateDependencyArtifact
 
         - name: Read secrets
           id: ReadSecrets
@@ -172,6 +172,15 @@ jobs:
             if-no-files-found: ignore
             retention-days: 1
 
+        - name: Upload thisbuild artifacts - dependencies
+          if: inputs.publishThisBuildArtifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildDependenciesArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
+            if-no-files-found: ignore
+            retention-days: 1
+
         - name: Upload thisbuild artifacts - test apps
           if: inputs.publishThisBuildArtifacts
           uses: actions/upload-artifact@v3
@@ -191,7 +200,7 @@ jobs:
 
         - name: Publish artifacts - dependencies
           uses: actions/upload-artifact@v3
-          if: inputs.publishArtifacts
+          if: inputs.publishArtifacts && env.generateDependencyArtifact == 'True'
           with:
             name: ${{ steps.calculateArtifactsNames.outputs.DependenciesArtifactsName }}
             path: '${{ inputs.project }}/.buildartifacts/Dependencies/'

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -91,7 +91,7 @@ jobs:
           with:
             shell: ${{ inputs.shell }}
             project: ${{ inputs.project }}
-            get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact
+            get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact,generateDependencyArtifact
 
         - name: Read secrets
           id: ReadSecrets
@@ -172,6 +172,15 @@ jobs:
             if-no-files-found: ignore
             retention-days: 1
 
+        - name: Upload thisbuild artifacts - dependencies
+          if: inputs.publishThisBuildArtifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildDependenciesArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
+            if-no-files-found: ignore
+            retention-days: 1
+
         - name: Upload thisbuild artifacts - test apps
           if: inputs.publishThisBuildArtifacts
           uses: actions/upload-artifact@v3
@@ -191,7 +200,7 @@ jobs:
 
         - name: Publish artifacts - dependencies
           uses: actions/upload-artifact@v3
-          if: inputs.publishArtifacts
+          if: inputs.publishArtifacts && env.generateDependencyArtifact == 'True'
           with:
             name: ${{ steps.calculateArtifactsNames.outputs.DependenciesArtifactsName }}
             path: '${{ inputs.project }}/.buildartifacts/Dependencies/'

--- a/Tests/CalculateArtifactNames.Test.ps1
+++ b/Tests/CalculateArtifactNames.Test.ps1
@@ -145,6 +145,7 @@ Describe 'CalculateArtifactNames Action Tests' {
         }
         $outputs = [ordered]@{
             "ThisBuildAppsArtifactsName" = "Artifact name for apps being built in the current workflow run"
+            "ThisBuildDependenciesArtifactsName" = "Artifact name for dependencies of apps being built in the current workflow run"
             "ThisBuildTestAppsArtifactsName" = "Artifact name for test apps being built in the current workflow run"
             "AppsArtifactsName" = "Artifacts name for Apps"
             "DependenciesArtifactsName" = "Artifacts name for Dependencies"


### PR DESCRIPTION
Fixes #823 

This pull request includes changes related to the handling of dependencies artifacts in several files. The most important changes include adding a new step to upload dependencies artifacts, modifying the `if` condition for uploading dependency artifacts, and updating the `GetDependencies` function to include the dependencies folder in its search for dependencies.

Dependency handling changes:

* `Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml`: Added a new step to upload dependencies artifacts and added the `generateDependencyArtifact` input to the `get` parameter in two jobs. (F1a2b3c4R1)
* `Actions/Github-Helper.psm1`: Updated the `GetDependencies` function to include the dependencies folder in its search for dependencies. (F2d3e4f5R1)
* `Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml`: Modified the `if` condition for uploading dependency artifacts to check if the `generateDependencyArtifact` environment variable is true before uploading. (F3g4h5i6R1)

Other changes:

* `Actions/CalculateArtifactNames/action.yaml`: Added a new output variable for dependencies artifacts name to the `CalculateArtifactNames` action. (F4j5k6l7R1)
* `RELEASENOTES.md`: Added a new issue to the release notes. (F7m8n9o1R1)
* `Actions/CalculateArtifactNames/README.md`: Added a new output variable called `ThisBuildDependenciesArtifactsName` to the table in the `Actions/CalculateArtifactNames/README.md` file. (F0p1q2r3R1)
* `Actions/CalculateArtifactNames/CalculateArtifactNames.ps1`: Updated the `Set-OutputVariable` command to include the dependencies folder in the search for dependencies. (F4s5t6u7R1)
* `Actions/RunPipeline/RunPipeline.ps1`: Updated the `generateDependencyArtifact` parameter to be a boolean value. (F8v9w1x2R1)