### PR TITLE
Added missing space to make :white_check_mark: visible as a pic

### DIFF
--- a/Actions/AnalyzeTests/TestResultAnalyzer.ps1
+++ b/Actions/AnalyzeTests/TestResultAnalyzer.ps1
@@ -44,11 +44,11 @@
             }
             $summarySb.Append("|") | Out-Null
             if ($appFailed -gt 0) {
-                $summarySb.Append("$($appFailed):x:") | Out-Null
+                $summarySb.Append("$($appFailed) :x:") | Out-Null
             }
             $summarySb.Append("|") | Out-Null
             if ($appSkipped -gt 0) {
-                $summarySb.Append("$($appSkipped):white_circle:") | Out-Null
+                $summarySb.Append("$($appSkipped) :white_circle:") | Out-Null
             }
             $summarySb.Append("|$($appTime)s|\n") | Out-Null
             if ($appFailed -gt 0) {

--- a/Actions/AnalyzeTests/TestResultAnalyzer.ps1
+++ b/Actions/AnalyzeTests/TestResultAnalyzer.ps1
@@ -40,7 +40,7 @@
             Write-Host "- $appName, $appTests tests, $appPassed passed, $appFailed failed, $appSkipped skipped, $appTime seconds"
             $summarySb.Append("|$appName|$appTests|") | Out-Null
             if ($appPassed -gt 0) {
-                $summarySb.Append("$($appPassed):white_check_mark:") | Out-Null
+                $summarySb.Append("$($appPassed) :white_check_mark:") | Out-Null
             }
             $summarySb.Append("|") | Out-Null
             if ($appFailed -gt 0) {


### PR DESCRIPTION
### Problem
In the **Build . - Default / . - Default summary** section of an action results I see `:white_check_mark:` instead of :white_check_mark::
<img width="502" alt="image" src="https://github.com/microsoft/AL-Go/assets/16445780/2c49b04f-4b96-4fa0-a381-d73899afadf9">
### Solution 
separate a number and the smile by a space:
- "$($appPassed) :white_check_mark:"
- "$($appFailed) :x:"  
- "$($appSkipped) :white_circle:"