### PR TITLE
Add support for UpdateALGoSystemFilesEnvironment setting

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -212,6 +212,8 @@ function ModifyUpdateALGoSystemFiles{
         # If the environment: section does not exist, add it
         $updateALGoSystemFilesJob.Insert(1, "environment: $updateALGoSystemFilesEnvironment")
     }
+
+    $yaml.Replace('jobs:/UpdateALGoSystemFiles:/', $updateALGoSystemFilesJob.content)
 }
 
 function GetWorkflowContentWithChangesFromSettings {

--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -193,6 +193,7 @@ function ModifyUpdateALGoSystemFiles{
     }
 
     $updateALGoSystemFilesEnvironment = $repoSettings.UpdateALGoSystemFilesEnvironment
+    Write-Host "Setting 'Update AL-Go System Files' environment to $updateALGoSystemFilesEnvironment"
 
     # Add or replace the environment: section in the UpdateALGoSystemFiles job
     $updateALGoSystemFilesJob = $yaml.Get('jobs:/UpdateALGoSystemFiles:/')

--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -181,6 +181,38 @@ function ModifyBuildWorkflows {
     $yaml.Replace('jobs:/Build:', $newBuild)
 }
 
+function ModifyUpdateALGoSystemFiles{
+    Param(
+        [Yaml] $yaml,
+        [hashtable] $repoSettings
+    )
+
+    if($repoSettings.Keys -notcontains 'UpdateALGoSystemFilesEnvironment') {
+        # If UpdateALGoSystemFilesEnvironment is not set, we don't need to do anything
+        return
+    }
+
+    $updateALGoSystemFilesEnvironment = $repoSettings.UpdateALGoSystemFilesEnvironment
+
+    # Add or replace the environment: section in the UpdateALGoSystemFiles job
+    $updateALGoSystemFilesJob = $yaml.Get('jobs:/UpdateALGoSystemFiles:/')
+
+    if(-not $updateALGoSystemFilesJob) {
+        # Defensively check that the UpdateALGoSystemFiles job exists
+        throw "No UpdateALGoSystemFiles job found in the workflow"
+    }
+
+    $environmentSection = $updateALGoSystemFilesJob.Get('environment:')
+    if($environmentSection) {
+        # If the environment: section already exists, replace it with the new environment
+        $updateALGoSystemFilesJob.Replace($environmentSection, "environment: $updateALGoSystemFilesEnvironment")
+    }
+    else {
+        # If the environment: section does not exist, add it
+        $updateALGoSystemFilesJob.Insert(1, "environment: $updateALGoSystemFilesEnvironment")
+    }
+}
+
 function GetWorkflowContentWithChangesFromSettings {
     Param(
         [string] $srcFile,
@@ -217,6 +249,10 @@ function GetWorkflowContentWithChangesFromSettings {
     # If the dependency depth is higher than 1, we need to add multiple dependent build jobs to the workflow
     if ($depth -gt 1 -and ($baseName -eq 'PullRequestHandler' -or $baseName -eq 'CICD' -or $baseName -eq 'Current' -or $baseName -eq 'NextMinor' -or $baseName -eq 'NextMajor')) {
         ModifyBuildWorkflows -yaml $yaml -depth $depth
+    }
+
+    if($baseName -eq 'UpdateGitHubGoSystemFiles') {
+        ModifyUpdateALGoSystemFiles -yaml $yaml -repoSettings $repoSettings
     }
 
     # combine all the yaml file lines into a single string with LF line endings

--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -181,7 +181,7 @@ function ModifyBuildWorkflows {
     $yaml.Replace('jobs:/Build:', $newBuild)
 }
 
-function ModifyUpdateALGoSystemFiles{
+function ModifyUpdateALGoSystemFiles {
     Param(
         [Yaml] $yaml,
         [hashtable] $repoSettings

--- a/Actions/CheckForUpdates/yamlclass.ps1
+++ b/Actions/CheckForUpdates/yamlclass.ps1
@@ -162,6 +162,9 @@ class Yaml {
         if ($start -eq 0) {
             $this.content = $this.content[$count..($this.content.Count-1)]
         }
+        elseif($start + $count -ge $this.content.Count) {
+            $this.content = $this.content[0..($start-1)]
+        }
         else {
             $this.content = $this.content[0..($start-1)] + $this.content[($start+$count)..($this.content.Count-1)]
         }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,7 @@ Note that when using the preview version of AL-Go for GitHub, we recommend you U
 
 ### New Settings
 - `templateSha`: The SHA of the version of AL-Go currently used
+- `UpdateALGoSystemFilesEnvironment`: The name of the environment that is referenced in job `UpdateALGoSystemFiles` in the _Update AL-Go System Files_ workflow. See [jobs.<job_id>.environment](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenvironment) for more information. Currently, only setting the environment name is supported.
 
 ### New Actions
 - `DumpWorkflowInfo`: Dump information about running workflow
@@ -33,7 +34,7 @@ If false, the templateSha repository setting is used to download specific AL-Go 
   - **footer** = Footer for the documentation site. (Default: Made with...)
   - **defaultIndexMD** = Markdown for the landing page of the documentation site. (Default: Reference documentation...)
   - **defaultReleaseMD** = Markdown for the landing page of the release sites. (Default: Release reference documentation...)
-  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}* 
+  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}*
 
 ### New Workflows
 - **Deploy Reference Documentation** is a workflow, which you can invoke manually or on a schedule to generate and deploy reference documentation using the aldoc tool, using the ALDoc setting properties described above.

--- a/Tests/CheckForUpdates.Action.Test.ps1
+++ b/Tests/CheckForUpdates.Action.Test.ps1
@@ -76,5 +76,49 @@ Describe "CheckForUpdates Action Tests" {
         ($jobsYaml.Get('Initialization:/steps:/- name: Read settings/with:/shell:').content -join '') | Should -be "shell: pwsh"
     }
 
+    It 'Test YamlClass Remove' {
+        . (Join-Path $scriptRoot "yamlclass.ps1")
+
+        $yamlSnippet = @(
+            "permissions:",
+            "  contents: read",
+            "  actions: read",
+            "  pull-requests: write",
+            "  checks: write"
+        )
+
+        $permissionsYaml = [Yaml]::new($yamlSnippet)
+
+        $permissionsContent = $permissionsYaml.Get('permissions:/')
+        $permissionsContent.content.Count | Should -be 4
+        $permissionsContent.Remove(1, 0) # Remove nothing
+        $permissionsContent.content.Count | Should -be 4
+        $permissionsContent.content[0].Trim() | Should -be 'contents: read'
+        $permissionsContent.content[1].Trim() | Should -be 'actions: read'
+        $permissionsContent.content[2].Trim() | Should -be 'pull-requests: write'
+        $permissionsContent.content[3].Trim() | Should -be 'checks: write'
+
+        $permissionsContent = $permissionsYaml.Get('permissions:/')
+        $permissionsContent.content.Count | Should -be 4
+        $permissionsContent.Remove(0, 3) # Remove first 3 lines
+        $permissionsContent.content.Count | Should -be 1
+        $permissionsContent.content[0].Trim() | Should -be 'checks: write'
+
+        $permissionsContent = $permissionsYaml.Get('permissions:/')
+        $permissionsContent.content.Count | Should -be 4
+        $permissionsContent.Remove(2, 1) # Remove only the 3rd line
+        $permissionsContent.content.Count | Should -be 3
+        $permissionsContent.content[0].Trim() | Should -be 'contents: read'
+        $permissionsContent.content[1].Trim() | Should -be 'actions: read'
+        $permissionsContent.content[2].Trim() | Should -be 'checks: write'
+
+        $permissionsContent = $permissionsYaml.Get('permissions:/')
+        $permissionsContent.content.Count | Should -be 4
+        $permissionsContent.Remove(2, 4) # Remove more than the number of lines
+        $permissionsContent.content.Count | Should -be 2 # Only the first two lines should remain
+        $permissionsContent.content[0].Trim() | Should -be 'contents: read'
+        $permissionsContent.content[1].Trim() | Should -be 'actions: read'
+    }
+
     # Call action
 }


### PR DESCRIPTION
Add support for `UpdateALGoSystemFilesEnvironment` setting in order to set the [environment](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenvironment) property of the `UpdateALGoSystemFiles` job.  