### PR TITLE
Fix getting version from a release branch name

### DIFF
--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -538,7 +538,8 @@ function GetLatestRelease {
     if ($isReleaseBranch) {
         # If release branch, get the latest release from that the release branch
         # This is given by the latest release with the same major.minor as the release branch
-        $semVerObj = SemVerStrToSemVerObj -semVerStr $ref.SubString($releaseBranchPrefix.Length) -allowMajorMinorOnly
+        $releaseVersion = $ref -split '/' | Select-Object -Last 1 # Get the version from the release branch
+        $semVerObj = SemVerStrToSemVerObj -semVerStr $releaseVersion -allowMajorMinorOnly
         $latestRelease = $releases | Where-Object {
             $releaseSemVerObj = SemVerStrToSemVerObj -semVerStr $_.tag_name
             $semVerObj.Major -eq $releaseSemVerObj.Major -and $semVerObj.Minor -eq $releaseSemVerObj.Minor


### PR DESCRIPTION
After https://github.com/microsoft/AL-Go/commit/bf1e8f35935cb9a2361a40e47b6bf3a2ec0dad9c#diff-8b3bc43d627973d00981a6cb79e54160281d51f7a4a7aee41e856160e9841b24 getting the release branch version from the branch name was broken.

Fix for failing E2E test: https://github.com/microsoft/AL-Go/actions/runs/7637020651/job/20805106171