### PR TITLE
Bump github/codeql-action/upload-sarif to v3

### DIFF
--- a/.github/workflows/powershell.yaml
+++ b/.github/workflows/powershell.yaml
@@ -31,6 +31,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Fixes #928

See: https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/