### PR TITLE
Always set repoVersion on project-level settings

### DIFF
--- a/Actions/IncrementVersionNumber/IncrementVersionNumber.ps1
+++ b/Actions/IncrementVersionNumber/IncrementVersionNumber.ps1
@@ -30,20 +30,18 @@ try {
 
     $settings = $env:Settings | ConvertFrom-Json
 
-    # Ensure the repoVersion setting exists in the repository settings. Defaults to 1.0 if it doesn't exist.
-    Set-VersionInSettingsFile -settingsFilePath (Join-Path $baseFolder $RepoSettingsFile) -settingName 'repoVersion' -newValue $settings.repoVersion -Force # $RepoSettingsFile is defined in AL-Go-Helper.ps1
-
-    # Change repoVersion in repository settings
-    Set-VersionInSettingsFile -settingsFilePath (Join-Path $baseFolder $RepoSettingsFile) -settingName 'repoVersion' -newValue $versionNumber
-
     $projectList = @(GetProjectsFromRepository -baseFolder $baseFolder -projectsFromSettings $settings.projects -selectProjects $projects)
 
     $allAppFolders = @()
     foreach($project in $projectList) {
         $projectPath = Join-Path $baseFolder $project
 
-        # Set repoVersion in project settings (if it exists)
         $projectSettingsPath = Join-Path $projectPath $ALGoSettingsFile # $ALGoSettingsFile is defined in AL-Go-Helper.ps1
+
+        # Ensure the repoVersion setting exists in the project settings. Defaults to 1.0 if it doesn't exist.
+        Set-VersionInSettingsFile -settingsFilePath $projectSettingsPath -settingName 'repoVersion' -newValue $settings.repoVersion -Force
+
+        # Set repoVersion in project settings according to the versionNumber parameter
         Set-VersionInSettingsFile -settingsFilePath $projectSettingsPath -settingName 'repoVersion' -newValue $versionNumber
 
         # Resolve project folders to get all app folders that contain an app.json file

--- a/Actions/IncrementVersionNumber/IncrementVersionNumber.psm1
+++ b/Actions/IncrementVersionNumber/IncrementVersionNumber.psm1
@@ -104,6 +104,10 @@ function Set-VersionInSettingsFile {
     # Construct the new version number. Cast to System.Version to validate if the version number is valid.
     $newValue = [System.Version] "$($versionNumbers -join '.')"
 
+    if($newValue -lt $oldValue) {
+        throw "The new version number ($newValue) is less than the old version number ($oldValue). The version number must be incremented."
+    }
+
     if($newValue -eq $oldValue) {
         Write-Host "The setting $settingName is already set to $newValue in $settingsFilePath"
         return

--- a/Tests/IncrementVersionNumber.Action.Test.ps1
+++ b/Tests/IncrementVersionNumber.Action.Test.ps1
@@ -210,6 +210,20 @@ Describe "Set-VersionInSettingsFile tests" {
         $newSettingsContent.otherSetting | Should -Be "otherSettingValue"
     }
 
+    It 'Set-VersionInSettingsFile -newValue 2.0 throws an error because it''s not incremented' {
+        $settingsFile = New-TestSettingsFilePath -repoVersion '2.0'
+        $settingName = 'repoVersion'
+        $newValue = '1.0'
+
+        { Set-VersionInSettingsFile -settingsFilePath $settingsFile -settingName $settingName -newValue $newValue } | Should -Throw "The new version number ($newValue) is less than the old version number (2.0). The version number must be incremented."
+
+        $newSettingsContent = Get-Content $settingsFile -Encoding UTF8 | ConvertFrom-Json
+        $newSettingsContent.$settingName | Should -Be "2.0"
+
+        # Check that the other setting are not changed
+        $newSettingsContent.otherSetting | Should -Be "otherSettingValue"
+    }
+
     It 'Set-VersionInSettingsFile -newValue +1 increments the major version number and sets the minor version number to 0' {
         $settingsFile = New-TestSettingsFilePath
         $settingName = 'repoVersion'
@@ -238,7 +252,7 @@ Describe "Set-VersionInSettingsFile tests" {
         $newSettingsContent.otherSetting | Should -Be "otherSettingValue"
     }
 
-    It 'Set-VersionInSettingsFile -newValue is set and bnFileuild and revision are kept from the old value'{
+    It 'Set-VersionInSettingsFile -newValue is set and build and revision are kept from the old value'{
         $settingsFile = New-TestSettingsFilePath -repoVersion '1.2.0.0'
         $settingName = 'repoVersion'
         $newValue = '2.1'


### PR DESCRIPTION
- `repoVersion` should always be set on project-level settings as `InrecrementVersionNumber` can be called on a project.
- Disallow lowering the `repoVersion` value.