### PR TITLE
Applying conditional settings for PR Builds

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -680,6 +680,12 @@ function ReadSettings {
             $settingsObjects += @($projectWorkflowSettingsObject, $userSettingsObject)
         }
     }
+
+    # If the build is triggered by a pull request the refname will be the merge branch. To apply conditional settings we need to use the base branch
+    if (($env:GITHUB_EVENT_NAME -eq "pull_request") -or ($env:GITHUB_EVENT_NAME -eq "pull_request_target")) {
+        $branchName = $env:GITHUB_BASE_REF
+    }
+    
     foreach($settingsJson in $settingsObjects) {
         if ($settingsJson) {
             MergeCustomObjectIntoOrderedDictionary -dst $settings -src $settingsJson

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -685,7 +685,6 @@ function ReadSettings {
             $settingsObjects += @($projectWorkflowSettingsObject, $userSettingsObject)
         }
     }
-    
     foreach($settingsJson in $settingsObjects) {
         if ($settingsJson) {
             MergeCustomObjectIntoOrderedDictionary -dst $settings -src $settingsJson

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -521,6 +521,11 @@ function ReadSettings {
         [string] $repoSettingsVariableValue = "$ENV:ALGoRepoSettings"
     )
 
+    # If the build is triggered by a pull request the refname will be the merge branch. To apply conditional settings we need to use the base branch
+    if (($env:GITHUB_EVENT_NAME -eq "pull_request") -and ($branchName -eq $ENV:GITHUB_REF_NAME)) {
+        $branchName = $env:GITHUB_BASE_REF
+    }
+
     function GetSettingsObject {
         Param(
             [string] $path
@@ -679,11 +684,6 @@ function ReadSettings {
             $userSettingsObject = GetSettingsObject -Path (Join-Path $projectFolder "$ALGoFolderName/$userName.settings.json")
             $settingsObjects += @($projectWorkflowSettingsObject, $userSettingsObject)
         }
-    }
-
-    # If the build is triggered by a pull request the refname will be the merge branch. To apply conditional settings we need to use the base branch
-    if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
-        $branchName = $env:GITHUB_BASE_REF
     }
     
     foreach($settingsJson in $settingsObjects) {

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -682,7 +682,7 @@ function ReadSettings {
     }
 
     # If the build is triggered by a pull request the refname will be the merge branch. To apply conditional settings we need to use the base branch
-    if (($env:GITHUB_EVENT_NAME -eq "pull_request") -or ($env:GITHUB_EVENT_NAME -eq "pull_request_target")) {
+    if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
         $branchName = $env:GITHUB_BASE_REF
     }
     


### PR DESCRIPTION
AL-GO doesn't apply conditional settings on PR Builds. In BCApps we have the following conditional setting in the project settings 

```
"buildModes": [ "Translated" ],
"ConditionalSettings": [
        {
            "branches": [
                "releases/*.[0-5]"
            ],
            "settings": {
                "buildModes": [ "Translated", "Strict"]
            }
        }
    ]
```

Yet when you see the PR builds, it doesn't build in StrictMode: 
https://github.com/microsoft/BCApps/actions/runs/8044365490

In ReadSettings we only apply conditional settings if the branchname matches the pattern in the setting. The problem is that the branchName is set to GITHUB_BASE_REF which for PR builds triggered by the pull_request trigger is the merge branch (e.g. refs/heads/merge/123). The branch pattern for the conditional setting will therefore never match on PR Builds. 

