### PR TITLE
Update SelfHostedGitHubRunner.md

### DIFF
--- a/Scenarios/SelfHostedGitHubRunner.md
+++ b/Scenarios/SelfHostedGitHubRunner.md
@@ -21,6 +21,10 @@ GitHub runners can be registered for an organization (accessible for all reposit
 1. Go to [Allow your repository access to your runners](#allow-your-repository-access-to-your-runners) to continue the configuration.
 
 ## Create your self-hosted runner manually
+
+> [!NOTE]
+> If the runner is running under a service account, the following should be run using the account, as this will ensure that any of the per-user installation steps are completed.  Failure to do so will result in commands not being recognized when the runner performs steps.
+
 1. To create a self-hosted runner manually, choose Windows under Runner Image and x64 in architecture and follow the description on how to create a self-hosted runner manually
 1. Make sure that the following software is installed on the computer (the suggestion in parentheses explains the mechanism used in https://aka.ms/getbuildagent)
    - Docker (getbuildagent use [this script](https://github.com/microsoft/nav-arm-templates/blob/master/InstallOrUpdateDockerEngine.ps1) to install or update Docker Engine on the Azure VM)


### PR DESCRIPTION
A vital note about the CONTEXT of running these installation steps.

I was trying to setup my first GH Runner to do Signing on a private Windows device.  The sign step kept failing over and over.  Turned out, the AzureSignTool was installed in the context of the user account if the instructions were followed as-is, which my GH Runner was running under a local user account.

I lost a day, so I leave this here for folks to not suffer as I suffered.  