### PR TITLE
fix array cast

### DIFF
--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -507,7 +507,7 @@ function GetReleases {
     )
 
     Write-Host "Analyzing releases $api_url/repos/$repository/releases"
-    $releases = @(InvokeWebRequest -Headers (GetHeader -token $token) -Uri "$api_url/repos/$repository/releases" | ConvertFrom-Json)
+    $releases = InvokeWebRequest -Headers (GetHeader -token $token) -Uri "$api_url/repos/$repository/releases" | ConvertFrom-Json
     if ($releases.Count -gt 1) {
         # Sort by SemVer tag
         try {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -12,6 +12,7 @@ Note that when using the preview version of AL-Go for GitHub, we recommend you U
 - Support release branches that start with releases/
 - Issue 870 Improve Error Handling when CLI is missing
 - Issue 889 CreateRelease and IncrementVersionNumber workflow did not handle wild characters in `appFolders`, `testFolders` or `bcptTestFolders` settings.
+- Issue 973 Prerelease is not used for deployment
 
 ### Build modes
 AL-Go ships with Default, Translated and Clean mode out of the box. Now you can also define custom build modes in addition to the ones shipped with AL-Go. This allows you to define your own build modes, which can be used to build your apps in different ways. By default, a custom build mode will build the apps similarly to the Default mode but this behavior can be overridden in e.g. script overrides in your repository.

--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -66,7 +66,7 @@ function Add-PropertiesToJsonFile {
         $headers = GetHeader -token $token
         Write-Host "Get Previous runs"
         $url = "https://api.github.com/repos/$repository/actions/runs"
-        $previousrunids = @(InvokeWebRequest -Method Get -Headers $headers -Uri $url -retry | ConvertFrom-Json).workflow_runs | Where-Object { $_.event -eq 'push' } | Select-Object -ExpandProperty id
+        $previousrunids = (InvokeWebRequest -Method Get -Headers $headers -Uri $url -retry | ConvertFrom-Json).workflow_runs | Where-Object { $_.event -eq 'push' } | Select-Object -ExpandProperty id
         if ($previousrunids) {
             Write-Host "Previous runs: $($previousrunids -join ', ')"
         }
@@ -517,7 +517,7 @@ function MergePRandPull {
     Write-Host "Get Previous runs"
     $headers = GetHeader -token $token
     $url = "https://api.github.com/repos/$repository/actions/runs"
-    $previousrunids = @(InvokeWebRequest -Method Get -Headers $headers -Uri $url -retry | ConvertFrom-Json).workflow_runs | Where-Object { $_.event -eq 'push' } | Select-Object -ExpandProperty id
+    $previousrunids = (InvokeWebRequest -Method Get -Headers $headers -Uri $url -retry | ConvertFrom-Json).workflow_runs | Where-Object { $_.event -eq 'push' } | Select-Object -ExpandProperty id
     if ($previousrunids) {
         Write-Host "Previous runs: $($previousrunids -join ', ')"
     }


### PR DESCRIPTION
Fixes #973

The fix can best be illustrated by running this code:

```powershell
@('[]' | ConvertFrom-Json).Count
@('[{"a":"1"}]' | ConvertFrom-Json).Count
@('[{"a":"1"},{"b":"2"}]' | ConvertFrom-Json).Count
```

Returns: 1, 1, 1
Expected: 0,1,2

Where this:

```powershell
('[]' | ConvertFrom-Json).Count
('[{"a":"1"}]' | ConvertFrom-Json).Count
('[{"a":"1"},{"b":"2"}]' | ConvertFrom-Json).Count
```

Returns: 0,1,2 as expected
