### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: ".github/workflows/"
+  schedule:
+    interval: weekly
+- package-ecosystem: github-actions
+  directory: "/Templates/Per Tenant Extension/.github/workflows/"
+  schedule:
+    interval: weekly
+  ignore:
+    - dependency-name: "microsoft/AL-Go-Actions/*"
+- package-ecosystem: github-actions
+  directory: "/Templates/AppSource App/.github/workflows/"
+  schedule:
+    interval: weekly
+  ignore:
+    - dependency-name: "microsoft/AL-Go-Actions/*"


### PR DESCRIPTION
This PR adds configuration for dependabot so we automatically get PRs generated when never versions of GitHub actions become available.

Dependabot will ignore updates to Al-Go-Actions but will create PRs to update e.g. actions/checkout, actions/upload-pages-artifact or actions/download-artifact if applicable. 