### PR TITLE
Update permissions for Deploy Reference Documentation and add permissions for _BuildALGoProject

### DIFF
--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -164,7 +164,7 @@ jobs:
     runs-on: windows-latest
     name: Deploy Reference Documentation
     permissions:
-      contents: write
+      contents: read
       actions: read
       pages: write
       id-token: write

--- a/Templates/AppSource App/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/Templates/AppSource App/.github/workflows/DeployReferenceDocumentation.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   actions: read
   pages: write
   id-token: write

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -72,6 +72,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -164,7 +164,7 @@ jobs:
     runs-on: windows-latest
     name: Deploy Reference Documentation
     permissions:
-      contents: write
+      contents: read
       actions: read
       pages: write
       id-token: write

--- a/Templates/Per Tenant Extension/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/DeployReferenceDocumentation.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   actions: read
   pages: write
   id-token: write

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -72,6 +72,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}


### PR DESCRIPTION
Deploy Reference Documentation is currently given `contents: write` permission but it doesn't seem to need it. These workflows succeeded with `contents: read` permission
https://github.com/aholstrup1/BCApps/actions/runs/8538607739
https://github.com/aholstrup1/BCApps/actions/runs/8535969767

This PR would lower that permission and explicitly add top-level permissions for the _BuildALGoProject reusable workflow 

See also results on https://github.com/microsoft/BCApps/security/code-scanning for more info on why we'd like to lower these permissions of possible :)