### PR TITLE
Allow PullRequestHandler to use ubuntu-latest

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -244,7 +244,7 @@ function GetWorkflowContentWithChangesFromSettings {
         ModifyPullRequestHandlerWorkflow -yaml $yaml -repoSettings $repoSettings
     }
 
-    if ($baseName -ne "UpdateGitHubGoSystemFiles" -and $baseName -ne "PullRequestHandler" -and $baseName -ne 'Troubleshooting') {
+    if ($baseName -ne "UpdateGitHubGoSystemFiles" -and $baseName -ne 'Troubleshooting') {
         ModifyRunsOnAndShell -yaml $yaml -repoSettings $repoSettings
     }
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -13,6 +13,7 @@ Note that when using the preview version of AL-Go for GitHub, we recommend you U
 - Issue 997 'Deliver to AppSource' action fails for projects containing a space
 - Issue 987 Resource not accessible by integration when creating release from specific version
 - Issue 979 Publish to AppSource Documentation
+- Issue 1008 Allow PullRequestHandler to use ubuntu or self hosted runners for all jobs except for pregateCheck
 
 ### New Settings
 - `deliverToAppSource`: a JSON object containing the following properties

--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
   PregateCheck:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
-    runs-on: [ windows-latest ]
+    runs-on: windows-latest
     steps:
       - uses: microsoft/AL-Go-Actions/VerifyPRChanges@main
 

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
   PregateCheck:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
-    runs-on: [ windows-latest ]
+    runs-on: windows-latest
     steps:
       - uses: microsoft/AL-Go-Actions/VerifyPRChanges@main
 

--- a/Tests/WorkflowSanitation/WorkflowFileContent.Test.ps1
+++ b/Tests/WorkflowSanitation/WorkflowFileContent.Test.ps1
@@ -13,3 +13,15 @@ Describe "All AL-GO workflows should have similar content" {
         }
     }
 }
+
+Describe "PreGateCheck in PullRequestHandler should use runs-on: windows-latest" {
+    It 'Check PullRequestHandler.yaml for runs-on: windows-latest' {
+        # Check that PullRequestHandler.yaml in both templates uses runs-on: windows-latest, which doesn't get updated by the Update AL-Go System Files action
+        $ScriptRoot = $PSScriptRoot
+        . (Join-Path $ScriptRoot "../../Actions/CheckForUpdates/yamlclass.ps1")
+        foreach($template in @('Per Tenant Extension','AppSource App')) {
+            $yaml = [Yaml]::load((Join-Path $ScriptRoot "..\..\Templates\$template\.github\workflows\PullRequestHandler.yaml" -Resolve))
+            $yaml.Get('jobs:/PregateCheck:/runs-on').content | Should -Be 'runs-on: windows-latest' -Because "PreGateCheck in $template/PullRequestHandler.yaml should use runs-on: windows-latest"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1008

Allow Update AL-Go System Files to update runs-on in PullRequestHandler.yaml, except for PregateCheck.
PregateCheck is set to use runs-on: windows-latest which will not be updated.
Update AL-Go System Files will update occurances of "runs-on: [ windows-latest ]" with "runs-on: [ (runs-on setting) ]"