### PR TITLE
Run "Update AL-Go System Files" on multiple branches

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -554,6 +554,7 @@ function ReadSettings {
     $settings = [ordered]@{
         "type"                                          = "PTE"
         "unusedALGoSystemFiles"                         = @()
+        "updateALGoBranches"                            = @("main")
         "projects"                                      = @()
         "country"                                       = "us"
         "artifact"                                      = ""

--- a/Actions/GetGitBranches/GetGitBranches.ps1
+++ b/Actions/GetGitBranches/GetGitBranches.ps1
@@ -2,8 +2,8 @@
     $includeBranches = @()
 )
 
-git fetch
-$allBranches = @(git for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })
+invoke-git fetch
+$allBranches = @(invoke-git for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })
 
 if ($includeBranches) {
     $branches = @()

--- a/Actions/GetGitBranches/GetGitBranches.ps1
+++ b/Actions/GetGitBranches/GetGitBranches.ps1
@@ -1,9 +1,12 @@
 ﻿param(
-    $includeBranches = @()
+    [Parameter(Mandatory = $false, HelpMessage = "JSON-formatted array of branches to include if they exist. If not specified, all branches are returned. Wildcards are supported.")]
+    [string] $includeBranches = '[]'
 )
 
 invoke-git fetch
 $allBranches = @(invoke-git for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })
+
+$includeBranches = ConvertFrom-Json $includeBranches
 
 if ($includeBranches) {
     $branches = @()
@@ -16,4 +19,4 @@ else {
 }
 
 # Add the branches to the output
-Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "branches=$(ConvertTo-Json $branches -Depth 99 -Compress)"
+Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "Branches=$(ConvertTo-Json $branches -Depth 99 -Compress)"

--- a/Actions/GetGitBranches/GetGitBranches.ps1
+++ b/Actions/GetGitBranches/GetGitBranches.ps1
@@ -3,6 +3,8 @@
     [string] $includeBranches = '[]'
 )
 
+Import-Module '..\Github-Helper.psm1' -DisableNameChecking
+
 invoke-git fetch
 $allBranches = @(invoke-git for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })
 

--- a/Actions/GetGitBranches/GetGitBranches.ps1
+++ b/Actions/GetGitBranches/GetGitBranches.ps1
@@ -1,0 +1,19 @@
+﻿param(
+    $includeBranches = @()
+)
+
+git fetch
+$allBranches = @(git for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })
+
+if ($includeBranches) {
+    $branches = @()
+    foreach ($branchFilter in $includeBranches) {
+        $branches += $allBranches | Where-Object { $_ -like $branchFilter }
+    }
+}
+else {
+    $branches = $allBranches
+}
+
+# Add the branches to the output
+Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "branches=$(ConvertTo-Json $branches -Depth 99 -Compress)"

--- a/Actions/GetGitBranches/GetGitBranches.ps1
+++ b/Actions/GetGitBranches/GetGitBranches.ps1
@@ -9,7 +9,12 @@ Import-Module $gitHubHelperPath -DisableNameChecking
 invoke-git fetch
 $allBranches = @(invoke-git for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })
 
+Write-Host "Including branches: $includeBranches"
+
 $includeBranches = ConvertFrom-Json $includeBranches
+
+Write-Host "Including branches: $includeBranches"
+
 
 if ($includeBranches) {
     Write-Host "Filtering branches by: $($includeBranches -join ', ')"

--- a/Actions/GetGitBranches/GetGitBranches.ps1
+++ b/Actions/GetGitBranches/GetGitBranches.ps1
@@ -7,7 +7,7 @@ $gitHubHelperPath = Join-Path $PSScriptRoot '../Github-Helper.psm1' -Resolve
 Import-Module $gitHubHelperPath -DisableNameChecking
 
 invoke-git fetch
-$allBranches = @(invoke-git for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })
+$allBranches = @(invoke-git -returnValue for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })
 
 $includeBranches = ConvertFrom-Json $includeBranchesJson
 if ($includeBranches) {

--- a/Actions/GetGitBranches/GetGitBranches.ps1
+++ b/Actions/GetGitBranches/GetGitBranches.ps1
@@ -12,6 +12,7 @@ $allBranches = @(invoke-git for-each-ref --format="%(refname:short)" refs/remote
 $includeBranches = ConvertFrom-Json $includeBranches
 
 if ($includeBranches) {
+    Write-Host "Filtering branches by: $($includeBranches -join ', ')"
     $branches = @()
     foreach ($branchFilter in $includeBranches) {
         $branches += $allBranches | Where-Object { $_ -like $branchFilter }
@@ -20,6 +21,8 @@ if ($includeBranches) {
 else {
     $branches = $allBranches
 }
+
+Write-Host "Found git branches: $($branches -join ', ')"
 
 # Add the branches to the output
 Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "Branches=$(ConvertTo-Json $branches -Depth 99 -Compress)"

--- a/Actions/GetGitBranches/GetGitBranches.ps1
+++ b/Actions/GetGitBranches/GetGitBranches.ps1
@@ -1,6 +1,6 @@
 ﻿param(
     [Parameter(Mandatory = $false, HelpMessage = "JSON-formatted array of branches to include if they exist. If not specified, all branches are returned. Wildcards are supported.")]
-    [string] $includeBranches = '[]'
+    [string] $includeBranchesJson = '[]'
 )
 
 $gitHubHelperPath = Join-Path $PSScriptRoot '../Github-Helper.psm1' -Resolve
@@ -9,13 +9,7 @@ Import-Module $gitHubHelperPath -DisableNameChecking
 invoke-git fetch
 $allBranches = @(invoke-git for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })
 
-Write-Host "Including branches: $includeBranches"
-
-$includeBranches = ConvertFrom-Json $includeBranches
-
-Write-Host "Including branches: $includeBranches"
-
-
+$includeBranches = ConvertFrom-Json $includeBranchesJson
 if ($includeBranches) {
     Write-Host "Filtering branches by: $($includeBranches -join ', ')"
     $branches = @()

--- a/Actions/GetGitBranches/GetGitBranches.ps1
+++ b/Actions/GetGitBranches/GetGitBranches.ps1
@@ -3,7 +3,8 @@
     [string] $includeBranches = '[]'
 )
 
-Import-Module '..\Github-Helper.psm1' -DisableNameChecking
+$gitHubHelperPath = Join-Path $PSScriptRoot '../Github-Helper.psm1' -Resolve
+Import-Module $gitHubHelperPath -DisableNameChecking
 
 invoke-git fetch
 $allBranches = @(invoke-git for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })

--- a/Actions/GetGitBranches/README.md
+++ b/Actions/GetGitBranches/README.md
@@ -1,0 +1,27 @@
+# Creates release notes
+Creates release notes for a release, based on a given tag and the tag from the latest release
+
+## INPUT
+
+### ENV variables
+none
+
+### Parameters
+| Name | Required | Description | Default value |
+| :-- | :-: | :-- | :-- |
+| shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
+| token | | The GitHub token running the action | github.token |
+| parentTelemetryScopeJson | | Specifies the parent telemetry scope for the telemetry signal | {} |
+| tag_name | Yes | This release tag name | |
+| target_commitish | | Last commit to include in release notes | Latest |
+
+## OUTPUT
+
+### ENV variables
+none
+
+### OUTPUT variables
+| Name | Description |
+| :-- | :-- |
+| ReleaseVersion | The release version |
+| ReleaseNotes | Release notes generated based on the changes |

--- a/Actions/GetGitBranches/README.md
+++ b/Actions/GetGitBranches/README.md
@@ -1,5 +1,5 @@
-# Creates release notes
-Creates release notes for a release, based on a given tag and the tag from the latest release
+# Get Git Branches
+Gets current git branches defined on the remote repository
 
 ## INPUT
 
@@ -10,10 +10,7 @@ none
 | Name | Required | Description | Default value |
 | :-- | :-: | :-- | :-- |
 | shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
-| token | | The GitHub token running the action | github.token |
-| parentTelemetryScopeJson | | Specifies the parent telemetry scope for the telemetry signal | {} |
-| tag_name | Yes | This release tag name | |
-| target_commitish | | Last commit to include in release notes | Latest |
+| includeBranches | | JSON-formatted array of branches to include if they exist. If not specified, all branches are returned. Wildcards are supported. ||
 
 ## OUTPUT
 
@@ -23,5 +20,4 @@ none
 ### OUTPUT variables
 | Name | Description |
 | :-- | :-- |
-| ReleaseVersion | The release version |
-| ReleaseNotes | Release notes generated based on the changes |
+| Branches | The list of branches on the remote repository |

--- a/Actions/GetGitBranches/action.yaml
+++ b/Actions/GetGitBranches/action.yaml
@@ -1,0 +1,36 @@
+name: Get Git Branches
+author: Microsoft Corporation
+description: Get the list of branches in the repository
+inputs:
+  shell:
+    description: Shell in which you want to run the action (powershell or pwsh)
+    required: false
+    default: powershell
+  includeBranches:
+    description: Filters to apply to the branche names. If not specified, all branches are returned. Wildcards are supported.
+    required: false
+    default: '[]'
+outputs:
+  GitBranches:
+    description: The list of branches in the repository
+    value: ${{ steps.GetGitBranches.outputs.branches }}
+runs:
+  using: composite
+  steps:
+    - name: run
+      shell: ${{ inputs.shell }}
+      id: GetGitBranches
+      env:
+        _includeBranches: ${{ inputs.includeBranches }}
+      run: |
+        $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
+        try {
+          ${{ github.action_path }}/GetGitBranches.ps1 -includeBranches (ConvertFrom-Json $env:_includeBranches)
+        }
+        catch {
+          Write-Host "::ERROR::Unexpected error when running action. Error Message: $($_.Exception.Message.Replace("`r",'').Replace("`n",' ')), StackTrace: $($_.ScriptStackTrace.Replace("`r",'').Replace("`n",' <- '))";
+          exit 1
+        }
+branding:
+  icon: terminal
+  color: blue

--- a/Actions/GetGitBranches/action.yaml
+++ b/Actions/GetGitBranches/action.yaml
@@ -21,11 +21,11 @@ runs:
       shell: ${{ inputs.shell }}
       id: GetGitBranches
       env:
-        _includeBranches: ${{ inputs.includeBranches }}
+        _includeBranchesJson: ${{ inputs.includeBranchesJson }}
       run: |
         $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
         try {
-          ${{ github.action_path }}/GetGitBranches.ps1 -includeBranches $env:_includeBranches
+          ${{ github.action_path }}/GetGitBranches.ps1 -includeBranchesJson $env:_includeBranches
         }
         catch {
           Write-Host "::ERROR::Unexpected error when running action. Error Message: $($_.Exception.Message.Replace("`r",'').Replace("`n",' ')), StackTrace: $($_.ScriptStackTrace.Replace("`r",'').Replace("`n",' <- '))";

--- a/Actions/GetGitBranches/action.yaml
+++ b/Actions/GetGitBranches/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: Shell in which you want to run the action (powershell or pwsh)
     required: false
     default: powershell
-  includeBranches:
+  includeBranchesJson:
     description: JSON-formatted array of branches to include if they exist. If not specified, all branches are returned. Wildcards are supported.
     required: false
     default: '[]'
@@ -25,7 +25,7 @@ runs:
       run: |
         $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
         try {
-          ${{ github.action_path }}/GetGitBranches.ps1 -includeBranchesJson $env:_includeBranches
+          ${{ github.action_path }}/GetGitBranches.ps1 -includeBranchesJson $env:_includeBranchesJson
         }
         catch {
           Write-Host "::ERROR::Unexpected error when running action. Error Message: $($_.Exception.Message.Replace("`r",'').Replace("`n",' ')), StackTrace: $($_.ScriptStackTrace.Replace("`r",'').Replace("`n",' <- '))";

--- a/Actions/GetGitBranches/action.yaml
+++ b/Actions/GetGitBranches/action.yaml
@@ -7,13 +7,13 @@ inputs:
     required: false
     default: powershell
   includeBranches:
-    description: Filters to apply to the branche names. If not specified, all branches are returned. Wildcards are supported.
+    description: JSON-formatted array of branches to include if they exist. If not specified, all branches are returned. Wildcards are supported.
     required: false
     default: '[]'
 outputs:
   GitBranches:
     description: The list of branches in the repository
-    value: ${{ steps.GetGitBranches.outputs.branches }}
+    value: ${{ steps.GetGitBranches.outputs.Branches }}
 runs:
   using: composite
   steps:
@@ -25,7 +25,7 @@ runs:
       run: |
         $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
         try {
-          ${{ github.action_path }}/GetGitBranches.ps1 -includeBranches (ConvertFrom-Json $env:_includeBranches)
+          ${{ github.action_path }}/GetGitBranches.ps1 -includeBranches $env:_includeBranches
         }
         catch {
           Write-Host "::ERROR::Unexpected error when running action. Error Message: $($_.Exception.Message.Replace("`r",'').Replace("`n",' ')), StackTrace: $($_.ScriptStackTrace.Replace("`r",'').Replace("`n",' <- '))";

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -57,7 +57,7 @@ $settings.Keys | ForEach-Object {
     }
     $outSettings += @{ "$setting" = $settingValue }
     if ($getSettings -contains $setting) {
-        if ($settingValue -is [System.Collections.Specialized.OrderedDictionary] -or $settingValue -is [hashtable] -or $serSettingValue -is [array]) {
+        if ($settingValue -is [System.Collections.Specialized.OrderedDictionary] -or $settingValue -is [hashtable] -or $settingValue -is [array]) {
             Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$setting=$(ConvertTo-Json $settingValue -Depth 99 -Compress)"
         }
         else {

--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -57,7 +57,7 @@ $settings.Keys | ForEach-Object {
     }
     $outSettings += @{ "$setting" = $settingValue }
     if ($getSettings -contains $setting) {
-        if ($settingValue -is [System.Collections.Specialized.OrderedDictionary] -or $settingValue -is [hashtable]) {
+        if ($settingValue -is [System.Collections.Specialized.OrderedDictionary] -or $settingValue -is [hashtable] -or $serSettingValue -is [array]) {
             Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "$setting=$(ConvertTo-Json $settingValue -Depth 99 -Compress)"
         }
         else {

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -41,24 +41,14 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          get: UpdateALGoBranches
-
-      - name: Default to main
-        shell: powershell
-        if: ${{ env.UpdateALGoBranches == '' }}
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-
-          $UpdateALGoBranches = @("main")
-          Write-Host "No branches specified to update AL-Go on a schedule. Defaulting to main"
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "UpdateALGoBranches=$(ConvertTo-Json $UpdateALGoBranches -Compress)"
+          get: updateALGoBranches
 
       - name: Get Supported Branches
         id: GetSupportedBranches
         uses: microsoft/AL-Go-Actions/GetGitBranches@main
         with:
           shell: powershell
-          includeBranches: ${{ env.UpdateALGoBranches }}
+          includeBranches: ${{ env.updateALGoBranches }}
 
   UpdateALGoSystemFiles:
     needs: [ GetBranches ]

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   GetBranches:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     outputs:
       SupportedBranches: ${{ steps.GetSupportedBranches.outputs.GitBranches }}
     steps:

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/GetGitBranches@main
         with:
           shell: powershell
-          includeBranches: ${{ $env:UpdateALGoBranches }}
+          includeBranches: ${{ env:UpdateALGoBranches }}
 
   UpdateALGoSystemFiles:
     needs: [ GetBranches ]

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -28,9 +28,47 @@ env:
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
+  GetBranches:
+    runs-on: ubuntu-latest
+    outputs:
+      SupportedBranches: ${{ steps.GetSupportedBranches.outputs.GitBranches }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
+        with:
+          shell: powershell
+          get: UpdateALGoBranches
+
+      - name: Default to main
+        shell: powershell
+        if: ${{ env.UpdateALGoBranches == '' }}
+        run: |
+          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
+
+          Write-Host "No branches specified to update AL-Go on a schedule. Defaulting to main"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "UpdateALGoBranches=main"
+
+      - name: Get Supported Branches
+        id: GetSupportedBranches
+        uses: microsoft/AL-Go-Actions/GetGitBranches@main
+        with:
+          shell: powershell
+          includeBranches: $env:UpdateALGoBranches
+
+
+
   UpdateALGoSystemFiles:
-    needs: [ ]
+    needs: [ GetBranches ]
     runs-on: [ windows-latest ]
+    name: "[${{ matrix.branch }}] Update AL-Go"
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.GetBranches.outputs.SupportedBranches) }}
+      fail-fast: false
+
     steps:
       - name: Dump Workflow Information
         uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@main
@@ -39,6 +77,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
 
       - name: Initialize the workflow
         id: init

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
 
-          $UpdateALGoBranches = "main"
+          $UpdateALGoBranches = @("main")
           Write-Host "No branches specified to update AL-Go on a schedule. Defaulting to main"
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "UpdateALGoBranches=$(ConvertTo-Json $UpdateALGoBranches -Compress)"
 

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -57,9 +57,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/GetGitBranches@main
         with:
           shell: powershell
-          includeBranches: $env:UpdateALGoBranches
-
-
+          includeBranches: ${{ $env:UpdateALGoBranches }}
 
   UpdateALGoSystemFiles:
     needs: [ GetBranches ]

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/GetGitBranches@main
         with:
           shell: powershell
-          includeBranches: ${{ env:UpdateALGoBranches }}
+          includeBranches: ${{ env.UpdateALGoBranches }}
 
   UpdateALGoSystemFiles:
     needs: [ GetBranches ]

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -48,8 +48,9 @@ jobs:
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
 
+          $UpdateALGoBranches = "main"
           Write-Host "No branches specified to update AL-Go on a schedule. Defaulting to main"
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "UpdateALGoBranches=[main]"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "UpdateALGoBranches=$(ConvertTo-Json $UpdateALGoBranches -Compress)"
 
       - name: Get Supported Branches
         id: GetSupportedBranches

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -30,6 +30,7 @@ env:
 jobs:
   GetBranches:
     runs-on: windows-latest
+    name: Get Supported Branches
     outputs:
       SupportedBranches: ${{ steps.GetSupportedBranches.outputs.GitBranches }}
     steps:

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/GetGitBranches@main
         with:
           shell: powershell
-          includeBranches: ${{ env.updateALGoBranches }}
+          includeBranchesJson: ${{ env.updateALGoBranches }}
 
   UpdateALGoSystemFiles:
     needs: [ GetBranches ]

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -49,7 +49,7 @@ jobs:
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
 
           Write-Host "No branches specified to update AL-Go on a schedule. Defaulting to main"
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "UpdateALGoBranches=main"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "UpdateALGoBranches=[main]"
 
       - name: Get Supported Branches
         id: GetSupportedBranches


### PR DESCRIPTION
"Update AL-Go System Files" workflow could only be run on one branch at a time. Moreover, the schedule mechanism works only on the default branch (GitHub Actions limitation).

This PR alters the workflow to run the update logic on multiple branches, defined in a new AL-Go setting `updateALGoBranches`.