### PR TITLE
AL-Go version in WorkflowInitialize

### DIFF
--- a/Actions/WorkflowInitialize/README.md
+++ b/Actions/WorkflowInitialize/README.md
@@ -11,6 +11,8 @@ none
 | :-- | :-: | :-- | :-- |
 | shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
 | eventId | Yes | The event id of the initiating workflow | |
+| actionsRepo | No | The repository of the action | github.action_repository |
+| actionsRef | No | The ref of the action | github.action_ref |
 
 ## OUTPUT
 

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -11,6 +11,8 @@ try {
 
     $actionsRef = $ENV:GITHUB_ACTION_REF
     $actionsRepo = $ENV:GITHUB_ACTION_REPOSITORY
+    Write-Host $actionsRef
+    Write-Host $actionsRepo    
     if ($actionsRepo -like 'microsoft/AL-Go-Actions') {
         Write-Host "Using AL-Go for GitHub $actionsRef"
         $verstr = $actionsRef

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -9,15 +9,15 @@ try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-TestRepoHelper.ps1" -Resolve)
 
-    # $ENV:GITHUB_ACTION_PATH is (for Direct AL-Go or preview)
-    #                                        -5     -4    -3     -2       -1
-    # linux:            /home/runner/work/freddydk/AL-Go/AL-Go/Actions/WorkflowInitialize
-    # windows:  C:\Users\runneradmin\work\freddydk\AL-Go\AL-Go\Actions\WorkflowInitialize
-    # and (for normal)
-    #                                        -3         -2          -1
-    # linux:           /home/runner/work/microsoft/AL-Go-Actions/WorkflowInitialize
-    # windows: C:\Users\runneradmin\work\microsoft\AL-Go-Actions\WorkflowInitialize
-    Write-Host $ENV:GITHUB_ACTION_PATH
+    # $ENV:GITHUB_ACTION_PATH is
+    #                                      -4       -3         -2       -1
+    # linux:            /home/runner/work/owner/AL-Go-Actions/branch/WorkflowInitialize
+    # windows:  C:\Users\runneradmin\work\owner\AL-Go-Actions\branch\WorkflowInitialize
+    #
+    # For Preview (or Direct AL-Go development branch)
+    #                                      -5    -4     -3     -2       -1
+    # linux:            /home/runner/work/owner/AL-Go/branch/Actions/WorkflowInitialize
+    # windows:  C:\Users\runneradmin\work\owner\AL-Go\branch\Actions\WorkflowInitialize
     $ap = "$ENV:GITHUB_ACTION_PATH".Split([System.IO.Path]::DirectorySeparatorChar)
     $branch = $ap[$ap.Count-2]
     $owner = $ap[$ap.Count-4]

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -9,6 +9,7 @@ try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-TestRepoHelper.ps1" -Resolve)
 
+    gci 'env:*' | out-host
     $actionsRef = $ENV:GITHUB_ACTION_REF
     $actionsRepo = $ENV:GITHUB_ACTION_REPOSITORY
     Write-Host $actionsRef

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -1,9 +1,9 @@
 ﻿Param(
     [Parameter(HelpMessage = "The event id of the initiating workflow", Mandatory = $true)]
     [string] $eventId,
-    [Parameter(HelpMessage = "Actions Repository", Mandatory = $true)]
+    [Parameter(HelpMessage = "The repository of the action", Mandatory = $false)]
     [string] $actionsRepo,
-    [Parameter(HelpMessage = "Actions Ref", Mandatory = $true)]
+    [Parameter(HelpMessage = "The ref of the action", Mandatory = $false)]
     [string] $actionsRef
 )
 
@@ -13,8 +13,8 @@ try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-TestRepoHelper.ps1" -Resolve)
 
-    Write-Host $actionsRef
     Write-Host $actionsRepo
+    Write-Host $actionsRef
     if ($actionsRepo -like 'microsoft/AL-Go-Actions') {
         Write-Host "Using AL-Go for GitHub $actionsRef"
         $verstr = $actionsRef

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -18,23 +18,30 @@ try {
     #                                      -5    -4     -3     -2       -1
     # linux:            /home/runner/work/owner/AL-Go/branch/Actions/WorkflowInitialize
     # windows:  C:\Users\runneradmin\work\owner\AL-Go\branch\Actions\WorkflowInitialize
-    $ap = "$ENV:GITHUB_ACTION_PATH".Split([System.IO.Path]::DirectorySeparatorChar)
+    # or:       C:\Users\runneradmin\work\owner\AL-Go\branch\Actions/WorkflowInitialize
+    $ap = "$ENV:GITHUB_ACTION_PATH".Split('/\')
     $branch = $ap[$ap.Count-2]
     $owner = $ap[$ap.Count-4]
+    # When using direct AL-Go development, the $ap[$ap.count-2] is the Actions subfolder in the AL-Go repository (see above)
+    # meaning that the actual owner and branch are in the $ap[$ap.count-5] and $ap[$ap.count-3] respectively
+    # We cannot index from the beginning of the array as the path can be different depending on the agent installation
     if ($branch -eq 'Actions' -and $owner -eq 'AL-Go') {
         # Using Direct AL-Go development branch
         $branch = $ap[$ap.Count-3]
         $owner = $ap[$ap.Count-5]
-        Write-Host "Using direct AL-Go development to $owner/AL-Go@$branch"
-        $verstr = "d"
+        if ($owner -eq "microsoft") {
+            Write-Host "Using AL-Go for GitHub Preview ($branch)"
+            $verstr = "p"
+        }
+        else {
+            Write-Host "Using direct AL-Go development to $owner/AL-Go@$branch"
+            $verstr = "d"
+        }
     }
     else {
         Write-Host "Using AL-Go for GitHub $branch"
         if ($owner -ne "microsoft") {
             $verstr = "d"
-        }
-        elseif ($branch -eq "preview") {
-            $verstr = "p"
         }
         else {
             $verstr = $branch

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -1,6 +1,10 @@
 ﻿Param(
     [Parameter(HelpMessage = "The event id of the initiating workflow", Mandatory = $true)]
-    [string] $eventId
+    [string] $eventId,
+    [Parameter(HelpMessage = "Actions Repository", Mandatory = $true)]
+    [string] $actionsRepo,
+    [Parameter(HelpMessage = "Actions Ref", Mandatory = $true)]
+    [string] $actionsRef
 )
 
 $telemetryScope = $null
@@ -9,11 +13,8 @@ try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-TestRepoHelper.ps1" -Resolve)
 
-    gci 'env:*' | out-host
-    $actionsRef = $ENV:GITHUB_ACTION_REF
-    $actionsRepo = $ENV:GITHUB_ACTION_REPOSITORY
     Write-Host $actionsRef
-    Write-Host $actionsRepo    
+    Write-Host $actionsRepo
     if ($actionsRepo -like 'microsoft/AL-Go-Actions') {
         Write-Host "Using AL-Go for GitHub $actionsRef"
         $verstr = $actionsRef

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -13,8 +13,6 @@ try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-TestRepoHelper.ps1" -Resolve)
 
-    Write-Host $actionsRepo
-    Write-Host $actionsRef
     if ($actionsRepo -like 'microsoft/AL-Go-Actions') {
         Write-Host "Using AL-Go for GitHub $actionsRef"
         $verstr = $actionsRef

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -9,18 +9,36 @@ try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-TestRepoHelper.ps1" -Resolve)
 
-    $ap = "$ENV:GITHUB_ACTION_PATH".Split('\')
+    # $ENV:GITHUB_ACTION_PATH is (for Direct AL-Go or preview)
+    #                                        -5     -4    -3     -2       -1
+    # linux:            /home/runner/work/freddydk/AL-Go/AL-Go/Actions/WorkflowInitialize
+    # windows:  C:\Users\runneradmin\work\freddydk\AL-Go\AL-Go\Actions\WorkflowInitialize
+    # and (for normal)
+    #                                        -3         -2          -1
+    # linux:           /home/runner/work/microsoft/AL-Go-Actions/WorkflowInitialize
+    # windows: C:\Users\runneradmin\work\microsoft\AL-Go-Actions\WorkflowInitialize
+    Write-Host $ENV:GITHUB_ACTION_PATH
+    $ap = "$ENV:GITHUB_ACTION_PATH".Split([System.IO.Path]::DirectorySeparatorChar)
     $branch = $ap[$ap.Count-2]
     $owner = $ap[$ap.Count-4]
-
-    if ($owner -ne "microsoft") {
+    if ($branch -eq 'Actions' -and $owner -eq 'AL-Go') {
+        # Using Direct AL-Go development branch
+        $branch = $ap[$ap.Count-3]
+        $owner = $ap[$ap.Count-5]
+        Write-Host "Using direct AL-Go development to $owner/AL-Go@$branch"
         $verstr = "d"
     }
-    elseif ($branch -eq "preview") {
-        $verstr = "p"
-    }
     else {
-        $verstr = $branch
+        Write-Host "Using AL-Go for GitHub $branch"
+        if ($owner -ne "microsoft") {
+            $verstr = "d"
+        }
+        elseif ($branch -eq "preview") {
+            $verstr = "p"
+        }
+        else {
+            $verstr = $branch
+        }
     }
 
     Write-Big -str "a$verstr"

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -9,43 +9,19 @@ try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-TestRepoHelper.ps1" -Resolve)
 
-    # $ENV:GITHUB_ACTION_PATH is
-    #                                      -4       -3         -2       -1
-    # linux:            /home/runner/work/owner/AL-Go-Actions/branch/WorkflowInitialize
-    # windows:  C:\Users\runneradmin\work\owner\AL-Go-Actions\branch\WorkflowInitialize
-    #
-    # For Preview (or Direct AL-Go development branch)
-    #                                      -5    -4     -3     -2       -1
-    # linux:            /home/runner/work/owner/AL-Go/branch/Actions/WorkflowInitialize
-    # windows:  C:\Users\runneradmin\work\owner\AL-Go\branch\Actions\WorkflowInitialize
-    # or:       C:\Users\runneradmin\work\owner\AL-Go\branch\Actions/WorkflowInitialize
-    $ap = "$ENV:GITHUB_ACTION_PATH".Split('/\')
-    $branch = $ap[$ap.Count-2]
-    $owner = $ap[$ap.Count-4]
-    # When using direct AL-Go development, the $ap[$ap.count-2] is the Actions subfolder in the AL-Go repository (see above)
-    # meaning that the actual owner and branch are in the $ap[$ap.count-5] and $ap[$ap.count-3] respectively
-    # We cannot index from the beginning of the array as the path can be different depending on the agent installation
-    if ($branch -eq 'Actions' -and $owner -eq 'AL-Go') {
-        # Using Direct AL-Go development branch
-        $branch = $ap[$ap.Count-3]
-        $owner = $ap[$ap.Count-5]
-        if ($owner -eq "microsoft") {
-            Write-Host "Using AL-Go for GitHub Preview ($branch)"
-            $verstr = "p"
-        }
-        else {
-            Write-Host "Using direct AL-Go development to $owner/AL-Go@$branch"
-            $verstr = "d"
-        }
+    $actionsRef = $ENV:GITHUB_ACTION_REF
+    $actionsRepo = $ENV:GITHUB_ACTION_REPOSITORY
+    if ($actionsRepo -like 'microsoft/AL-Go-Actions') {
+        Write-Host "Using AL-Go for GitHub $actionsRef"
+        $verstr = $actionsRef
+    }
+    elseif ($actionsRepo -like 'microsoft/AL-Go') {
+        Write-Host "Using AL-Go for GitHub Preview ($actionsRef)"
+        $verstr = "p"
     }
     else {
-        Write-Host "Using AL-Go for GitHub $branch"
-        if ($owner -ne "microsoft") {
-            $verstr = "d"
-        }
-        else {
-            $verstr = $branch
-        }
+        Write-Host "Using direct AL-Go development ($($actionsRepo)@$actionsRef)"
+        $verstr = "d"
     }
 
     Write-Big -str "a$verstr"

--- a/Actions/WorkflowInitialize/WorkflowInitialize.ps1
+++ b/Actions/WorkflowInitialize/WorkflowInitialize.ps1
@@ -13,11 +13,11 @@ try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-TestRepoHelper.ps1" -Resolve)
 
-    if ($actionsRepo -like 'microsoft/AL-Go-Actions') {
+    if ($actionsRepo -eq 'microsoft/AL-Go-Actions') {
         Write-Host "Using AL-Go for GitHub $actionsRef"
         $verstr = $actionsRef
     }
-    elseif ($actionsRepo -like 'microsoft/AL-Go') {
+    elseif ($actionsRepo -eq 'microsoft/AL-Go') {
         Write-Host "Using AL-Go for GitHub Preview ($actionsRef)"
         $verstr = "p"
     }

--- a/Actions/WorkflowInitialize/action.yaml
+++ b/Actions/WorkflowInitialize/action.yaml
@@ -8,6 +8,14 @@ inputs:
   eventId:
     description: The event id of the initiating workflow
     required: true
+  actionsRepo:
+    description: The repository of the action
+    default: ${{ github.action_repository }}
+    required: false
+  actionsRef:
+    description: The ref of the action
+    default: ${{ github.action_ref }}
+    required: false
 outputs:
   correlationId:
     description: A correlation Id for the workflow
@@ -23,8 +31,8 @@ runs:
       id: workflowinitialize
       env:
         _eventId: ${{ inputs.eventId }}
-        _actionsRepo: ${{ github.action_repository }}
-        _actionsRef: ${{ github.action_ref }}
+        _actionsRepo: ${{ inputs.actionsRepo }}
+        _actionsRef: ${{ inputs.actionRef }}
       run: |
         $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
         try {

--- a/Actions/WorkflowInitialize/action.yaml
+++ b/Actions/WorkflowInitialize/action.yaml
@@ -23,10 +23,12 @@ runs:
       id: workflowinitialize
       env:
         _eventId: ${{ inputs.eventId }}
+        _actionsRepo: ${{ github.action_repository }}
+        _actionsRef: ${{ github.action_ref }}
       run: |
         $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
         try {
-          ${{ github.action_path }}/WorkflowInitialize.ps1 -eventId $ENV:_eventId
+          ${{ github.action_path }}/WorkflowInitialize.ps1 -eventId $ENV:_eventId -actionsRepo $ENV:_actionsRepo -actionsRef $ENV:_actionsRef
         }
         catch {
           Write-Host "::ERROR::Unexpected error when running action. Error Message: $($_.Exception.Message.Replace("`r",'').Replace("`n",' ')), StackTrace: $($_.ScriptStackTrace.Replace("`r",'').Replace("`n",' <- '))";

--- a/Actions/WorkflowInitialize/action.yaml
+++ b/Actions/WorkflowInitialize/action.yaml
@@ -10,12 +10,12 @@ inputs:
     required: true
   actionsRepo:
     description: The repository of the action
-    default: ${{ github.action_repository }}
     required: false
+    default: ${{ github.action_repository }}
   actionsRef:
     description: The ref of the action
-    default: ${{ github.action_ref }}
     required: false
+    default: ${{ github.action_ref }}
 outputs:
   correlationId:
     description: A correlation Id for the workflow

--- a/Actions/WorkflowInitialize/action.yaml
+++ b/Actions/WorkflowInitialize/action.yaml
@@ -32,7 +32,7 @@ runs:
       env:
         _eventId: ${{ inputs.eventId }}
         _actionsRepo: ${{ inputs.actionsRepo }}
-        _actionsRef: ${{ inputs.actionRef }}
+        _actionsRef: ${{ inputs.actionsRef }}
       run: |
         $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
         try {


### PR DESCRIPTION
AL-Go version is not displayed correctly in WorkflowInitialize

Example (when using the AL-Go PPPreview)
![image](https://github.com/microsoft/AL-Go/assets/10775043/fed95309-7092-4397-97a0-fe2d3ea98723)

When running Linux it would fail, but swallow the exception
