### PR TITLE
Use matrix for shell value in PublishToEnvironment.yaml

### DIFF
--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -157,7 +157,7 @@ jobs:
       - name: Get Artifacts for deployment
         uses: microsoft/AL-Go-Actions/GetArtifactsForDeployment@main
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
           artifactsVersion: ${{ github.event.inputs.appVersion }}
           artifactsFolder: '.artifacts'
 
@@ -179,7 +179,7 @@ jobs:
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
           environmentName: ${{ matrix.environment }}
           artifactsFolder: '.artifacts'
           deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
@@ -196,6 +196,6 @@ jobs:
         id: PostProcess
         uses: microsoft/AL-Go-Actions/WorkflowPostProcess@main
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
           eventId: "DO0097"
           telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -157,7 +157,7 @@ jobs:
       - name: Get Artifacts for deployment
         uses: microsoft/AL-Go-Actions/GetArtifactsForDeployment@main
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
           artifactsVersion: ${{ github.event.inputs.appVersion }}
           artifactsFolder: '.artifacts'
 
@@ -179,7 +179,7 @@ jobs:
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
           environmentName: ${{ matrix.environment }}
           artifactsFolder: '.artifacts'
           deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
@@ -196,6 +196,6 @@ jobs:
         id: PostProcess
         uses: microsoft/AL-Go-Actions/WorkflowPostProcess@main
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
           eventId: "DO0097"
           telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}


### PR DESCRIPTION
This PR changes the "Publish To Environment" workflows of both the PTE and AppSource templates.
With this fix, all steps of the "Deploy" job now use the deployment matrix to determine the value of the `shell` property of each step.

Fixes #1101