### PR TITLE
Update releasenotes logic

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1329,6 +1329,7 @@ function CommitFromNewFolder {
     Param(
         [string] $serverUrl,
         [string] $commitMessage,
+        [string] $body = '',
         [string] $branch
     )
 
@@ -1357,7 +1358,7 @@ function CommitFromNewFolder {
         }
         invoke-git push -u $serverUrl $branch
         try {
-            invoke-gh pr create --fill --head $branch --repo $env:GITHUB_REPOSITORY --base $ENV:GITHUB_REF_NAME
+            invoke-gh pr create --fill --head $branch --repo $env:GITHUB_REPOSITORY --base $ENV:GITHUB_REF_NAME --body "$body"
         }
         catch {
             OutputError("GitHub actions are not allowed to create Pull Requests (see GitHub Organization or Repository Actions Settings). You can create the PR manually by navigating to $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/tree/$branch")

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -206,7 +206,7 @@ else {
     # $update set, update the files
     try {
         # If a pull request already exists with the same REF, then exit
-        $commitMessage = "[$updateBranch] Update AL-Go System Files - $templateSha"
+        $commitMessage = "[$updateBranch] Update AL-Go System Files from $templateInfo -  $templateSha"
         $env:GH_TOKEN = $token
         $existingPullRequest = (gh api --paginate "/repos/$env:GITHUB_REPOSITORY/pulls?base=$updateBranch" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" | ConvertFrom-Json) | Where-Object { $_.title -eq $commitMessage } | Select-Object -First 1
         if ($existingPullRequest) {
@@ -225,7 +225,6 @@ else {
         # Calculate the release notes, while updating
         $releaseNotes = ""
         $updateFiles | ForEach-Object {
-            Write-Host ">>>>>>>> $($_.DstFile)"
             # Create the destination folder if it doesn't exist
             $path = [System.IO.Path]::GetDirectoryName($_.DstFile)
             if (-not (Test-Path -path $path -PathType Container)) {

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -231,9 +231,11 @@ else {
                 New-Item -Path $path -ItemType Directory | Out-Null
             }
             if (([System.IO.Path]::GetFileName($_.DstFile) -eq "RELEASENOTES.copy.md") -and (Test-Path $_.DstFile)) {
-                $oldReleaseNotes = Get-ContentLF -path $_.DstFile
+                # Read the release notes of the version currently installed
+                $oldReleaseNotes = Get-ContentLF -Path $_.DstFile
+                # Get the release notes of the new version (for the PR body)
                 $releaseNotes = $_.Content
-                # Get the first line in the release notes with ## vX.Y, this is the latest shipped version already installed
+                # The first line with ## vX.Y, this is the latest shipped version already installed
                 $version = $oldReleaseNotes.Split("`n") | Where-Object { $_ -like '## v*.*' } | Select-Object -First 1
                 if ($version) {
                     # Grab all release notes up to the version already installed

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -96,12 +96,11 @@ if (-not $isDirectALGo) {
 # - All files in .github that ends with .copy.md
 # - All PowerShell scripts in .AL-Go folders (all projects)
 $checkfiles = @(
-    @{ 'dstPath' = Join-Path '.github' 'workflows'; 'srcPath' = Join-Path '.github' 'workflows'; 'pattern' = '*'; 'type' = 'workflow' },
-    @{ 'dstPath' = '.github'; 'srcPath' = '.github'; 'pattern' = '*.copy.md'; 'type' = 'releasenotes' }
+    @{ 'dstPath' = Join-Path '.github' 'workflows'; 'srcPath' = Join-Path '.github' 'workflows'; 'pattern' = '*'; 'type' = 'workflow' }
 )
 if ($isDirectALGo) {
     $checkfiles += @(
-        @{ 'dstPath' = '.github'; 'srcPath' = '.'; 'pattern' = 'RELEASENOTES.md'; 'type' = 'releasenotes' }
+        @{ 'dstPath' = '.github'; 'srcPath' = '../..'; 'pattern' = 'RELEASENOTES.md'; 'type' = 'releasenotes' }
     )
 }
 else {

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -251,8 +251,6 @@ else {
         Write-Host "ReleaseNotes:"
         Write-Host $releaseNotes
 
-        $releaseNotes = "## $templateInfo`n`n$releaseNotes"
-
         if (!(CommitFromNewFolder -serverUrl $serverUrl -commitMessage $commitMessage -branch $branch -body $releaseNotes)) {
             OutputWarning "No updates available for AL-Go for GitHub."
         }

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -74,7 +74,7 @@ Write-Host "Template Folder: $templateFolder"
 
 $templateBranch = $templateUrl.Split('@')[1]
 $templateOwner = $templateUrl.Split('/')[3]
-$templateRepo = $templateUrl.Split('/')[4]
+$templateInfo = "$templateOwner/$($templateUrl.Split('/')[4])"
 
 $isDirectALGo = IsDirectALGo -templateUrl $templateUrl
 if (-not $isDirectALGo) {
@@ -252,7 +252,7 @@ else {
         Write-Host "ReleaseNotes:"
         Write-Host $releaseNotes
 
-        $releaseNotes = "# $templateOwner/$templateRepo@$templateBranch`n`n$releaseNotes"
+        $releaseNotes = "## $templateInfo`n`n$releaseNotes"
 
         if (!(CommitFromNewFolder -serverUrl $serverUrl -commitMessage $commitMessage -branch $branch -body $releaseNotes)) {
             OutputWarning "No updates available for AL-Go for GitHub."

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -99,6 +99,16 @@ $checkfiles = @(
     @{ 'dstPath' = Join-Path '.github' 'workflows'; 'srcPath' = Join-Path '.github' 'workflows'; 'pattern' = '*'; 'type' = 'workflow' },
     @{ 'dstPath' = '.github'; 'srcPath' = '.github'; 'pattern' = '*.copy.md'; 'type' = 'releasenotes' }
 )
+if ($isDirectALGo) {
+    $checkfiles += @(
+        @{ 'dstPath' = '.github'; 'srcPath' = ''; 'pattern' = 'releasenotes.md'; 'type' = 'releasenotes' }
+    )
+}
+else {
+    $checkfiles += @(
+        @{ 'dstPath' = '.github'; 'srcPath' = '.github'; 'pattern' = '*.copy.md'; 'type' = 'releasenotes' }
+    )
+}
 
 # Get the list of projects in the current repository
 $baseFolder = $ENV:GITHUB_WORKSPACE
@@ -144,6 +154,9 @@ foreach($checkfile in $checkfiles) {
                 $fileName = $_.Name
                 Write-Host "- $filename"
                 $dstFile = Join-Path $dstFolder $fileName
+                if ($fileName -eq "releasenotes.md" -and $type -eq "releasenotes") {
+                    $dstFile = Join-Path $dstFolder 'RELEASENOTES.copy.md'
+                }
                 $srcFile = $_.FullName
                 Write-Host "SrcFolder: $srcFolder"
                 if ($type -eq "workflow") {

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -224,29 +224,19 @@ else {
         # Calculate the release notes, while updating
         $releaseNotes = ""
         $updateFiles | ForEach-Object {
+            Write-Host "<<<<<<<< $($_.SrcFile)"
+            Write-Host ">>>>>>>> $($_.DstFile)"
             # Create the destination folder if it doesn't exist
             $path = [System.IO.Path]::GetDirectoryName($_.DstFile)
             if (-not (Test-Path -path $path -PathType Container)) {
                 New-Item -Path $path -ItemType Directory | Out-Null
             }
             if (([System.IO.Path]::GetFileName($_.DstFile) -eq "RELEASENOTES.copy.md") -and (Test-Path $_.DstFile)) {
-                $oldReleaseNotes = Get-ContentLF -Path $_.DstFile
-                while ($oldReleaseNotes) {
-                    $releaseNotes = $_.Content
-                    if ($releaseNotes.indexOf($oldReleaseNotes) -gt 0) {
-                        $releaseNotes = $releaseNotes.SubString(0, $releaseNotes.indexOf($oldReleaseNotes))
-                        $oldReleaseNotes = ""
-                    }
-                    else {
-                        $idx = $oldReleaseNotes.IndexOf("`n## ")
-                        if ($idx -gt 0) {
-                            $oldReleaseNotes = $oldReleaseNotes.Substring($idx)
-                        }
-                        else {
-                            $oldReleaseNotes = ""
-                        }
-                    }
-                }
+                $oldReleaseNotes = Get-ContentLF -path $file
+                $releaseNotes = $_.Content
+                $version = $oldReleaseNotes.Split("`n") | Where-Object { $_ -like '## v*.*' } | Select-Object -First 1
+                $index = $releaseNotes.IndexOf("`n$version`n")
+                if ($index -ge 0) { $releaseNotes = $releaseNotes.Substring(0,$index) }
             }
             Write-Host "Update $($_.DstFile)"
             $_.Content | Set-ContentLF -Path $_.DstFile

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -101,7 +101,7 @@ $checkfiles = @(
 )
 if ($isDirectALGo) {
     $checkfiles += @(
-        @{ 'dstPath' = '.github'; 'srcPath' = ''; 'pattern' = 'releasenotes.md'; 'type' = 'releasenotes' }
+        @{ 'dstPath' = '.github'; 'srcPath' = '.'; 'pattern' = 'RELEASENOTES.md'; 'type' = 'releasenotes' }
     )
 }
 else {

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -97,7 +97,7 @@ if (-not $isDirectALGo) {
 # - All PowerShell scripts in .AL-Go folders (all projects)
 $checkfiles = @(
     @{ 'dstPath' = Join-Path '.github' 'workflows'; 'srcPath' = Join-Path '.github' 'workflows'; 'pattern' = '*'; 'type' = 'workflow' },
-    @{ 'dstPath' = '.github'; 'srcPath' = '.AL-Go'; 'pattern' = '*.copy.md'; 'type' = 'releasenotes' }
+    @{ 'dstPath' = '.github'; 'srcPath' = '.github'; 'pattern' = '*.copy.md'; 'type' = 'releasenotes' }
 )
 
 # Get the list of projects in the current repository

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -251,7 +251,7 @@ else {
         Write-Host "ReleaseNotes:"
         Write-Host $releaseNotes
 
-        if (!(CommitFromNewFolder -serverUrl $serverUrl -commitMessage $commitMessage -branch $branch)) {
+        if (!(CommitFromNewFolder -serverUrl $serverUrl -commitMessage $commitMessage -branch $branch -body $releaseNotes)) {
             OutputWarning "No updates available for AL-Go for GitHub."
         }
     }

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -238,7 +238,7 @@ else {
                 # The first line with ## vX.Y, this is the latest shipped version already installed
                 $version = $oldReleaseNotes.Split("`n") | Where-Object { $_ -like '## v*.*' } | Select-Object -First 1
                 if ($version) {
-                    # Grab all release notes up to the version already installed
+                    # Only use the release notes up to the version already installed
                     $index = $releaseNotes.IndexOf("`n$version`n")
                     if ($index -ge 0) {
                         $releaseNotes = $releaseNotes.Substring(0,$index)

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -233,9 +233,15 @@ else {
             if (([System.IO.Path]::GetFileName($_.DstFile) -eq "RELEASENOTES.copy.md") -and (Test-Path $_.DstFile)) {
                 $oldReleaseNotes = Get-ContentLF -path $_.DstFile
                 $releaseNotes = $_.Content
+                # Get the first line in the release notes with ## vX.Y, this is the latest shipped version already installed
                 $version = $oldReleaseNotes.Split("`n") | Where-Object { $_ -like '## v*.*' } | Select-Object -First 1
-                $index = $releaseNotes.IndexOf("`n$version`n")
-                if ($index -ge 0) { $releaseNotes = $releaseNotes.Substring(0,$index) }
+                if ($version) {
+                    # Grab all release notes up to the version already installed
+                    $index = $releaseNotes.IndexOf("`n$version`n")
+                    if ($index -ge 0) {
+                        $releaseNotes = $releaseNotes.Substring(0,$index)
+                    }
+                }
             }
             Write-Host "Update $($_.DstFile)"
             $_.Content | Set-ContentLF -Path $_.DstFile

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -231,7 +231,7 @@ else {
                 New-Item -Path $path -ItemType Directory | Out-Null
             }
             if (([System.IO.Path]::GetFileName($_.DstFile) -eq "RELEASENOTES.copy.md") -and (Test-Path $_.DstFile)) {
-                $oldReleaseNotes = Get-ContentLF -path $file
+                $oldReleaseNotes = Get-ContentLF -path $_.DstFile
                 $releaseNotes = $_.Content
                 $version = $oldReleaseNotes.Split("`n") | Where-Object { $_ -like '## v*.*' } | Select-Object -First 1
                 $index = $releaseNotes.IndexOf("`n$version`n")

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -224,7 +224,6 @@ else {
         # Calculate the release notes, while updating
         $releaseNotes = ""
         $updateFiles | ForEach-Object {
-            Write-Host "<<<<<<<< $($_.SrcFile)"
             Write-Host ">>>>>>>> $($_.DstFile)"
             # Create the destination folder if it doesn't exist
             $path = [System.IO.Path]::GetDirectoryName($_.DstFile)

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -74,6 +74,7 @@ Write-Host "Template Folder: $templateFolder"
 
 $templateBranch = $templateUrl.Split('@')[1]
 $templateOwner = $templateUrl.Split('/')[3]
+$templateRepo = $templateUrl.Split('/')[4]
 
 $isDirectALGo = IsDirectALGo -templateUrl $templateUrl
 if (-not $isDirectALGo) {
@@ -96,18 +97,9 @@ if (-not $isDirectALGo) {
 # - All files in .github that ends with .copy.md
 # - All PowerShell scripts in .AL-Go folders (all projects)
 $checkfiles = @(
-    @{ 'dstPath' = Join-Path '.github' 'workflows'; 'srcPath' = Join-Path '.github' 'workflows'; 'pattern' = '*'; 'type' = 'workflow' }
+    @{ 'dstPath' = Join-Path '.github' 'workflows'; 'srcPath' = Join-Path '.github' 'workflows'; 'pattern' = '*'; 'type' = 'workflow' },
+    @{ 'dstPath' = '.github'; 'srcPath' = '.github'; 'pattern' = '*.copy.md'; 'type' = 'releasenotes' }
 )
-if ($isDirectALGo) {
-    $checkfiles += @(
-        @{ 'dstPath' = '.github'; 'srcPath' = '../..'; 'pattern' = 'RELEASENOTES.md'; 'type' = 'releasenotes' }
-    )
-}
-else {
-    $checkfiles += @(
-        @{ 'dstPath' = '.github'; 'srcPath' = '.github'; 'pattern' = '*.copy.md'; 'type' = 'releasenotes' }
-    )
-}
 
 # Get the list of projects in the current repository
 $baseFolder = $ENV:GITHUB_WORKSPACE
@@ -153,9 +145,6 @@ foreach($checkfile in $checkfiles) {
                 $fileName = $_.Name
                 Write-Host "- $filename"
                 $dstFile = Join-Path $dstFolder $fileName
-                if ($fileName -eq "releasenotes.md" -and $type -eq "releasenotes") {
-                    $dstFile = Join-Path $dstFolder 'RELEASENOTES.copy.md'
-                }
                 $srcFile = $_.FullName
                 Write-Host "SrcFolder: $srcFolder"
                 if ($type -eq "workflow") {
@@ -262,6 +251,8 @@ else {
 
         Write-Host "ReleaseNotes:"
         Write-Host $releaseNotes
+
+        $releaseNotes = "# $templateOwner/$templateRepo@$templateBranch`n`n$releaseNotes"
 
         if (!(CommitFromNewFolder -serverUrl $serverUrl -commitMessage $commitMessage -branch $branch -body $releaseNotes)) {
             OutputWarning "No updates available for AL-Go for GitHub."


### PR DESCRIPTION
Fixes #1092

The logic for showing release notes in the Update AL-Go for GitHub PR hasn't been working for a while.
This PR also includes info about which template is used in the PR name