### PR TITLE
Add issue forms to AL-Go

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,53 @@
+name: Report a bug
+description: Report a bug in AL-Go for GitHub
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        Before you create a new issue, please check the following:
+        🔎 Search existing issues to avoid creating duplicates.
+
+  - type: input
+    id: algoversion
+    attributes:
+      label: AL-Go version
+      description: The version of AL-Go you are using
+      placeholder: For example 5.1 or preview
+    validations:
+      required: true
+  - type: textarea
+    id: describe-the-issue
+    attributes:
+      label: Describe the issue
+      description: A clear and concise description of what the issue is
+      placeholder: Describe the issue
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what behavior you expected
+      placeholder: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: List of steps to reproduce
+      placeholder: Steps to reproduce
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context (logs, screenshots, etc.)
+      description: To help us understand the issue better please paste some logs in the box below. Without logs, it will be harder to understand the issue. Make sure you don't share any sensitive information such as API keys, passwords, etc.
+      placeholder: Screenshots, log output, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Request a feature
+    url: https://aka.ms/bcideas
+    about: Please go to https://aka.ms/bcideas to log your idea. Creating an issue here is not the right way.
+  - name: Report a bug in the product
+    url: https://aka.ms/bcsupport?#bugs
+    about: Please follow the steps on https://aka.ms/bcsupport to get support. Creating an issue here is not the right way.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Request a feature
-    url: https://aka.ms/bcideas
-    about: Please go to https://aka.ms/bcideas to log your idea. Creating an issue here is not the right way.
-  - name: Report a bug in the product
-    url: https://aka.ms/bcsupport?#bugs
-    about: Please follow the steps on https://aka.ms/bcsupport to get support. Creating an issue here is not the right way.

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,0 +1,13 @@
+name: Feature request
+description: Suggest a feature you would like to see in AL-Go for GitHub
+title: "[Enhancement]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature description
+      description: Please describe the feature you would like to see in AL-Go for GitHub
+      placeholder: I would like to see...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,0 +1,12 @@
+name: Question about AL-Go for GitHub
+description: Question about AL-Go for GitHub
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Please type in your question about AL-Go for GitHub below
+    validations:
+      required: true


### PR DESCRIPTION
Adding some issue forms to AL-Go. You can see how it will look here: https://github.com/aholstrup1/AL-Go/issues/new/choose