### PR TITLE
Fix placeholder syntax in PR Handler action

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -9,6 +9,7 @@
 - Issue 1109 Why filter deployment settings?
 - Fix issue with github ref when running reusable workflows
 - Issue 1098 Support for specifying the name of the AZURE_CREDENTIALS secret by adding a AZURE_CREDENTIALSSecretName setting
+- Fix placeholder syntax for git ref in PullRequestHandler.yaml
 
 ### Dependencies to PowerShell modules
 

--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          ref: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/${0}/merge', github.event.pull_request.number) }}
+          ref: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
 
       - name: Initialize the workflow
         id: init
@@ -93,7 +93,7 @@ jobs:
     with:
       shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
       runsOn: ${{ needs.Initialization.outputs.githubRunner }}
-      checkoutRef: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/${0}/merge', github.event.pull_request.number) }}
+      checkoutRef: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
       parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
       project: ${{ matrix.project }}
       projectName: ${{ matrix.projectName }}

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          ref: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/${0}/merge', github.event.pull_request.number) }}
+          ref: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
 
       - name: Initialize the workflow
         id: init
@@ -93,7 +93,7 @@ jobs:
     with:
       shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
       runsOn: ${{ needs.Initialization.outputs.githubRunner }}
-      checkoutRef: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/${0}/merge', github.event.pull_request.number) }}
+      checkoutRef: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
       parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
       project: ${{ matrix.project }}
       projectName: ${{ matrix.projectName }}


### PR DESCRIPTION
This PR fixes an error introduced by #1130.
The new reference values use the `format()` command to generate a git reference, but the placeholder syntax was incorrect.
The two instances of `${0}` per template have been replaced with `{0}`.