### PR TITLE
WorkflowPostProcess only runs on successful PR Builds 

### DIFF
--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -119,6 +119,7 @@ jobs:
       - name: Finalize the workflow
         id: PostProcess
         uses: microsoft/AL-Go-Actions/WorkflowPostProcess@main
+        if: success() || failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -119,6 +119,7 @@ jobs:
       - name: Finalize the workflow
         id: PostProcess
         uses: microsoft/AL-Go-Actions/WorkflowPostProcess@main
+        if: success() || failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
WorkflowPostProcess only runs on successful PR Builds. This is a problem for telemetry because we use the WorkflowPostProcess action to emit the "AL-Go workflow ran/failed" telemetry. Therefore, we're not emitting that telemetry right now when PR Builds are failing. 

See for example: https://github.com/microsoft/BCApps/actions/runs/10315611720/job/28556490157