### PR TITLE
Update build depth calculation

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -120,10 +120,9 @@ $removeFiles = @()
 # Every build job might spin up multiple jobs in parallel to build the projects without unresolved deependencies
 $depth = 1
 if ($repoSettings.useProjectDependencies -and $projects.Count -gt 1) {
-    $buildAlso = @{}
-    $projectDependencies = @{}
-    $projectsOrder = AnalyzeProjectDependencies -baseFolder $baseFolder -projects $projects -buildAlso ([ref]$buildAlso) -projectDependencies ([ref]$projectDependencies)
-    $depth = $projectsOrder.Count
+    Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "..\DetermineProjectsToBuild\DetermineProjectsToBuild.psm1" -Resolve) -DisableNameChecking
+    $allProjects, $projectsToBuild, $projectDependencies, $buildOrder = Get-ProjectsToBuild -baseFolder $baseFolder -buildAllProjects $true -maxBuildDepth 100
+    $depth = $buildOrder.Count
     Write-Host "Calculated dependency depth to be $depth"
 }
 


### PR DESCRIPTION
Update build depth calculation to use Get-ProjectsToBuild as this is also how we calculate build depth in the CICD workflow. 

Fixes #1175 