### PR TITLE
Update how AL-Go version is determined

### DIFF
--- a/Actions/WorkflowPostProcess/README.md
+++ b/Actions/WorkflowPostProcess/README.md
@@ -15,6 +15,8 @@ none
 | shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
 | telemetryScopeJson | | Telemetry scope generated during the workflow initialization | {} |
 | currentJobContext | | The current job context | '' |
+| actionsRepo | No | The repository of the action | github.action_repository |
+| actionsRef | No | The ref of the action | github.action_ref |
 
 ## OUTPUT
 

--- a/Actions/WorkflowPostProcess/WorkflowPostProcess.ps1
+++ b/Actions/WorkflowPostProcess/WorkflowPostProcess.ps1
@@ -45,7 +45,6 @@ function GetWorkflowConclusion($JobContext) {
 }
 
 function GetAlGoVersion($ActionsRepo, $ActionRef) {
-    Write-Host "ActionsRepo: $ActionsRepo, ActionRef: $ActionRef"
     if ($ActionsRepo -eq "microsoft/AL-Go") {
         return "Preview"
     } elseif($ActionsRepo -notlike "microsoft/*") {

--- a/Actions/WorkflowPostProcess/WorkflowPostProcess.ps1
+++ b/Actions/WorkflowPostProcess/WorkflowPostProcess.ps1
@@ -3,6 +3,8 @@
     [string] $telemetryScopeJson = '',
     [Parameter(HelpMessage = "The current job context", Mandatory = $false)]
     [string] $currentJobContext = '',
+    [Parameter(HelpMessage = "The repository of the action", Mandatory = $false)]
+    [string] $actionsRepo,
     [Parameter(HelpMessage = "The ref of the action", Mandatory = $false)]
     [string] $actionsRef
 )
@@ -42,10 +44,11 @@ function GetWorkflowConclusion($JobContext) {
     return "Success"
 }
 
-function GetAlGoVersion($ActionRef) {
-    if ($ENV:GITHUB_REPOSITORY -eq "microsoft/AL-Go") {
+function GetAlGoVersion($ActionsRepo, $ActionRef) {
+    Write-Host "ActionsRepo: $ActionsRepo, ActionRef: $ActionRef"
+    if ($ActionsRepo -eq "microsoft/AL-Go") {
         return "Preview"
-    } elseif($ENV:GITHUB_REPOSITORY -notlike "microsoft/*") {
+    } elseif($ActionsRepo -notlike "microsoft/*") {
         return "Developer/Private"
     } else {
         return $ActionRef
@@ -102,7 +105,7 @@ function LogWorkflowEnd($TelemetryScopeJson, $JobContext, $AlGoVersion) {
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "..\TelemetryHelper.psm1" -Resolve)
 
 try {
-    LogWorkflowEnd -TelemetryScopeJson $telemetryScopeJson -JobContext $currentJobContext -AlGoVersion (GetAlGoVersion -ActionRef $actionsRef)
+    LogWorkflowEnd -TelemetryScopeJson $telemetryScopeJson -JobContext $currentJobContext -AlGoVersion (GetAlGoVersion -ActionsRepo $actionsRepo -ActionRef $actionsRef)
 } catch {
     # Log the exception to telemetry but don't fail the action if gathering telemetry fails
     Write-Host "::Warning::Unexpected error when running action. Error Message: $($_.Exception.Message.Replace("`r",'').Replace("`n",' ')), StackTrace: $($_.ScriptStackTrace.Replace("`r",'').Replace("`n",' <- '))";

--- a/Actions/WorkflowPostProcess/action.yaml
+++ b/Actions/WorkflowPostProcess/action.yaml
@@ -13,6 +13,10 @@ inputs:
     description: The current job context
     required: false
     default: ''
+  actionsRepo:
+    description: The repository of the action
+    required: false
+    default: ${{ github.action_repository }}
   actionsRef:
     description: The ref of the action
     required: false
@@ -28,7 +32,7 @@ runs:
         _actionsRef: ${{ inputs.actionsRef }}
       run: |
         ${{ github.action_path }}/../Invoke-AlGoAction.ps1 -ActionName "WorkflowPostProcess" -Action {
-          ${{ github.action_path }}/WorkflowPostProcess.ps1 -telemetryScopeJson $ENV:_telemetryScopeJson -currentJobContext $ENV:_currentJobContext -actionsRef $ENV:_actionsRef
+          ${{ github.action_path }}/WorkflowPostProcess.ps1 -telemetryScopeJson $ENV:_telemetryScopeJson -currentJobContext $ENV:_currentJobContext -actionsRepo $ENV:_actionsRepo -actionsRef $ENV:_actionsRef
         }
 branding:
   icon: terminal

--- a/Actions/WorkflowPostProcess/action.yaml
+++ b/Actions/WorkflowPostProcess/action.yaml
@@ -29,6 +29,7 @@ runs:
       env:
         _telemetryScopeJson: ${{ inputs.telemetryScopeJson }}
         _currentJobContext: ${{ inputs.currentJobContext }}
+        _actionsRepo: ${{ inputs.actionsRepo }}
         _actionsRef: ${{ inputs.actionsRef }}
       run: |
         ${{ github.action_path }}/../Invoke-AlGoAction.ps1 -ActionName "WorkflowPostProcess" -Action {


### PR DESCRIPTION
Update how AL-Go version is determined. 

Since $ENV:GITHUB_REPOSITORY is the repository that runs the workflow, AL-Go version will always be "Developer/Private" unless the workflow is being run from a Microsoft-owned repo.