### PR TITLE
Increment Version Number might produce wrong app.json 

### DIFF
--- a/Actions/IncrementVersionNumber/IncrementVersionNumber.psm1
+++ b/Actions/IncrementVersionNumber/IncrementVersionNumber.psm1
@@ -204,8 +204,11 @@ function Set-DependenciesVersionInAppManifests {
         [string[]] $appFolders
     )
 
+    # Get all distinct app folders
+    $distinctAppFolders = $appFolders | Sort-Object -Unique
+
     # Get all apps info: app ID and app version
-    $appsInfos = @($appFolders | ForEach-Object {
+    $appsInfos = @($distinctAppFolders | ForEach-Object {
         $appJson = Join-Path $_ "app.json"
         $app = Get-Content -Path $appJson -Encoding UTF8 -Raw | ConvertFrom-Json
         return [PSCustomObject]@{
@@ -224,7 +227,7 @@ function Set-DependenciesVersionInAppManifests {
 
         $dependencies | ForEach-Object {
             $dependency = $_
-            $appInfo = $appsInfos | Where-Object { $_.Id -eq $dependency.id }
+            $appInfo = $appsInfos | Where-Object { $_.Id -eq $dependency.id } | Select-Object -First 1
             if ($appInfo) {
                 Write-Host "Updating dependency app $($dependency.id) in $appJsonPath from $($dependency.version) to $($appInfo.Version)"
                 $dependency.version = $appInfo.Version

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+### Issues
+
+- Issue 1241 Increment Version Number might produce wrong app.json
+
 ## v6.0
 
 ### Issues


### PR DESCRIPTION
**Problem**
When incrementing the version number in our repo, one of the dependency apps were given two version entries. 

https://github.com/microsoft/BCApps/pull/2152/commits/c4d59f07901fb4c0f4dcaba5a5b48789a67ec624

**Solution**
* Gather app infos by iterating over the distinct app folders 
* If multiple app ids are found, select the first one