### PR TITLE
End 2 End Test Failure

### DIFF
--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -613,12 +613,19 @@ function Test-LogContainsFromRun {
         [string] $runid,
         [string] $jobName,
         [string] $stepName,
-        [string] $expectedText
+        [string] $expectedText,
+        [switch] $isRegEx
     )
 
     DownloadWorkflowLog -repository $repository -runid $runid -path 'logs'
     $runPipelineLog = Get-Content -Path (Get-Item "logs/$jobName/*_$stepName.txt").FullName -encoding utf8 -raw
-    if ($runPipelineLog.contains($expectedText, [System.StringComparison]::OrdinalIgnoreCase)) {
+    if ($isRegEx) {
+        $found = $runPipelineLog -match $expectedText
+    }
+    else {
+        $found = $runPipelineLog.contains($expectedText, [System.StringComparison]::OrdinalIgnoreCase)
+    }
+    if ($found) {
         Write-Host "'$expectedText' found in the log for $jobName/$stepName as expected"
     }
     else {

--- a/e2eTests/scenarios/FederatedCredentials/runtest.ps1
+++ b/e2eTests/scenarios/FederatedCredentials/runtest.ps1
@@ -80,7 +80,7 @@ $run = RunCICD -repository $repository -branch $branch -wait
 
 # Check that workflow run uses federated credentials and signing was successful
 Test-LogContainsFromRun -repository $repository -runid $run.id -jobName 'Build Main App (Default)  Main App (Default)' -stepName 'Sign' -expectedText 'Connecting to Azure using clientId and federated token'
-Test-LogContainsFromRun -repository $repository -runid $run.id -jobName 'Build Main App (Default)  Main App (Default)' -stepName 'Sign' -expectedText 'Signing succeeded'
+Test-LogContainsFromRun -repository $repository -runid $run.id -jobName 'Build Main App (Default)  Main App (Default)' -stepName 'Sign' -expectedText 'Signing .* succeeded' -isRegEx
 
 # Check that Deliver to AppSource uses federated credentials and that a new submission was created
 Test-LogContainsFromRun -repository $repository -runid $run.id -jobName 'Deliver to AppSource' -stepName 'Read secrets' -expectedText 'Query federated token'


### PR DESCRIPTION
The new sign tool returns

`Signing C:\Users\runneradmin\AppData\Local\Temp\5kjwvcol.khn\sv3h0r4d.app succeeded.`

instead of 

`Signing succeeded.`