### PR TITLE
Add RunnerEnvironment to Telemetry

### DIFF
--- a/Actions/TelemetryHelper.psm1
+++ b/Actions/TelemetryHelper.psm1
@@ -69,6 +69,7 @@ function AddTelemetryEvent()
 
         Add-TelemetryProperty -Hashtable $Data -Key 'WorkflowName' -Value $ENV:GITHUB_WORKFLOW
         Add-TelemetryProperty -Hashtable $Data -Key 'RunnerOs' -Value $ENV:RUNNER_OS
+        Add-TelemetryProperty -Hashtable $Data -Key 'RunnerEnvironment' -Value $ENV:RUNNER_ENVIRONMENT
         Add-TelemetryProperty -Hashtable $Data -Key 'RunId' -Value $ENV:GITHUB_RUN_ID
         Add-TelemetryProperty -Hashtable $Data -Key 'RunNumber' -Value $ENV:GITHUB_RUN_NUMBER
         Add-TelemetryProperty -Hashtable $Data -Key 'RunAttempt' -Value $ENV:GITHUB_RUN_ATTEMPT


### PR DESCRIPTION
Add RunnerEnvironment to Telemetry to help determine if the action was run on a GitHub-hosted or self-hosted machine. 