### PR TITLE
Output a notice when there are no available updates for AL-Go

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -185,6 +185,19 @@ function OutputWarning {
     }
 }
 
+function OutputNotice {
+    Param(
+        [string] $message
+    )
+
+    if ($runningLocal) {
+        Write-Host $message
+    }
+    else {
+        Write-Host "::Notice::$message"
+    }
+}
+
 function MaskValueInLog {
     Param(
         [string] $value

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -198,7 +198,7 @@ if ($update -ne 'Y') {
         OutputWarning -message "There are updates for your AL-Go system, run 'Update AL-Go System Files' workflow to download the latest version of AL-Go."
     }
     else {
-        Write-Host "No updates available for AL-Go for GitHub."
+        OutputNotice -message "No updates available for AL-Go for GitHub."
     }
 }
 else {
@@ -259,7 +259,7 @@ else {
         Write-Host $releaseNotes
 
         if (!(CommitFromNewFolder -serverUrl $serverUrl -commitMessage $commitMessage -branch $branch -body $releaseNotes)) {
-            OutputWarning "No updates available for AL-Go for GitHub."
+            OutputNotice -message "No updates available for AL-Go for GitHub."
         }
     }
     catch {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,7 @@
 - Issue 1344 Experimental feature "git submodules" seems to be a breaking change
 - Issue 1305 Extra telemetry Property RepositoryOwner and RepositoryName¨
 - Add RunnerEnvironment to Telemetry
+- Output a notice, not a warning, when there are no available updates for AL-Go for GitHub
 
 ### New Repository Settings
 


### PR DESCRIPTION
This pull request introduces a new function to output notices and updates existing scripts to use this function instead of issuing warnings when there are no updates available for AL-Go for GitHub.

New function addition:

* [`Actions/AL-Go-Helper.ps1`](diffhunk://#diff-d6e7039af6c0c11ad1a23decab42e0c9d1faeb7756089f0ebf640a2694665014R188-R200): Added `OutputNotice` function to output messages as notices.

Updates to existing scripts:

* [`Actions/CheckForUpdates/CheckForUpdates.ps1`](diffhunk://#diff-263c4046164f3ede51bbb35b7cdaf06701d35691bf18971273f24eaeb9bd41edL201-R201): Updated to use `OutputNotice` instead of warnings when no updates are available.

Documentation update:

* [`RELEASENOTES.md`](diffhunk://#diff-310cf8dbf9f6a843674df7afb82cf592a81636c01f7c25221aba39cf86e8dcf1R7): Added an entry noting the change from warnings to notices for no updates available.