### PR TITLE
Add support for AL-Go development in GitHub codespaces 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
   "image": "mcr.microsoft.com/devcontainers/universal:latest",
   "tasks": {
-    "build": "Write-Host 'Not Supported'",
+    "build": "",
     "test": "pwsh -File Tests/runtests.ps1",
-    "run": "Write-Host 'Not Supported'"
+    "run": ""
   },
   "features": {
     "ghcr.io/devcontainers/features/powershell:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:latest",
+  "tasks": {
+    "build": "Write-Host 'Not Supported'",
+    "test": "pwsh -File Tests/runtests.ps1",
+    "run": "Write-Host 'Not Supported'"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/powershell:1": {
+      "modules": "BcContainerHelper,Pester"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "pip install pre-commit && pre-commit install --install-hooks --overwrite",
+  "customizations": {
+        "vscode": {
+            "extensions": [
+                "GitHub.copilot",
+                "GitHub.copilot-chat",
+                "GitHub.vscode-github-actions",
+                "GitHub.vscode-pull-request-github",
+                "ms-vscode.powershell"
+            ],
+            "settings": {
+              "terminal.integrated.defaultProfile.linux": "pwsh"
+            }
+        }
+    }
+}

--- a/Scenarios/Contribute.md
+++ b/Scenarios/Contribute.md
@@ -84,6 +84,12 @@ You can also run the end to end tests directly from VS Code, by providing the fo
 |$global:pteTemplate| String | URL for your PTE template (like `freddyk/AL-Go-PTE@main` or `freddydk/AL-Go@main\|Templates/Per Tenant Extension` for using your AL-Go fork directly) |
 |$global:appSourceTemplate| String | URL for your PTE template (like `freddyk/AL-Go-AppSource@main` or `freddydk/AL-Go@main\|Templates/AppSource App` for using your AL-Go fork directly) |
 
+## GitHub Codespaces
+
+AL-Go supports developing from GitHub Codespaces. You can create codespaces by going to: [https://github.com/codespaces/new](https://github.com/codespaces/new?skip_quickstart=true&repo=413794983&ref=main). From here you can create codespace either for microsoft/AL-Go or for your fork of AL-Go.
+
+Codespaces come pre-configured with Pre-Commit and with latest BCContainerHelper version installed.
+
 ______________________________________________________________________
 
 [back](../README.md)


### PR DESCRIPTION
Add a devcontainer.json file to install pre-commit and BCContainerHelper to make AL-Go development from codespaces easier. 