### PR TITLE
Multi-Project Repository Test App Dependencies Not Resolved

### DIFF
--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -145,11 +145,8 @@ function GetDependencies {
                     $project = $project.Replace('\','_').Replace('/','_') # sanitize project name
 
                     $downloadName = Join-Path $saveToPath "$project-$branchName-$mask-*"
-                    Write-Host "------- $downloadName"
-
                     if (Test-Path $downloadName -PathType Container) {
                         $folder = Get-Item $downloadName
-                        Write-Host "++++++ $folder"
                         Get-ChildItem -Path $folder | ForEach-Object {
                             if ($mask -like '*TestApps') {
                                 $downloadedList += @("($($_.FullName))")

--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -145,6 +145,7 @@ function GetDependencies {
                     $project = $project.Replace('\','_').Replace('/','_') # sanitize project name
 
                     $downloadName = Join-Path $saveToPath "$project-$branchName-$mask-*"
+
                     if (Test-Path $downloadName -PathType Container) {
                         $folder = Get-Item $downloadName
                         Get-ChildItem -Path $folder | ForEach-Object {

--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -160,7 +160,7 @@ function GetDependencies {
                             Write-Host "$($_.FullName) found from previous job"
                         }
                     }
-                    elseif ($mask -notlike '*TestApps') {
+                    elseif ($mask -like '*Apps') {
                         Write-Host "$project not built, downloading from artifacts"
                         $missingProjects += @($project)
                     }

--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -145,9 +145,11 @@ function GetDependencies {
                     $project = $project.Replace('\','_').Replace('/','_') # sanitize project name
 
                     $downloadName = Join-Path $saveToPath "$project-$branchName-$mask-*"
+                    Write-Host "------- $downloadName"
 
                     if (Test-Path $downloadName -PathType Container) {
                         $folder = Get-Item $downloadName
+                        Write-Host "++++++ $folder"
                         Get-ChildItem -Path $folder | ForEach-Object {
                             if ($mask -like '*TestApps') {
                                 $downloadedList += @("($($_.FullName))")


### PR DESCRIPTION
When locating project dependencies and no Dependencies artifact is present - no TestApps will be searched for because the project will be marked as not built.

Fixes #1338