### PR TITLE
Remove top-level permissions in IncrementVersionNumber workflow

### DIFF
--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -26,10 +26,6 @@ on:
         type: boolean
         default: false
 
-permissions:
-  actions: read
-  contents: read
-
 defaults:
   run:
     shell: powershell
@@ -43,6 +39,7 @@ jobs:
     needs: [ ]
     runs-on: [ windows-latest ]
     permissions:
+      actions: read
       contents: write
       id-token: write
       pull-requests: write

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -26,10 +26,6 @@ on:
         type: boolean
         default: false
 
-permissions:
-  actions: read
-  contents: read
-
 defaults:
   run:
     shell: powershell
@@ -43,6 +39,7 @@ jobs:
     needs: [ ]
     runs-on: [ windows-latest ]
     permissions:
+      actions: read
       contents: write
       id-token: write
       pull-requests: write


### PR DESCRIPTION
The workflow fails in private repos if top-level (workflow-level) permissions are defined.