### PR TITLE
Fix PSScriptAnalyzer warning

### DIFF
--- a/Actions/Deliver/Deliver.ps1
+++ b/Actions/Deliver/Deliver.ps1
@@ -1,6 +1,4 @@
 Param(
-    [Parameter(HelpMessage = "The GitHub actor running the action", Mandatory = $false)]
-    [string] $actor,
     [Parameter(HelpMessage = "The GitHub token running the action", Mandatory = $false)]
     [string] $token,
     [Parameter(HelpMessage = "Projects to deliver (default is all)", Mandatory = $false)]

--- a/Actions/Deliver/README.md
+++ b/Actions/Deliver/README.md
@@ -16,7 +16,6 @@ Deliver App to deliveryTarget (AppSource, Storage, or...)
 | Name | Required | Description | Default value |
 | :-- | :-: | :-- | :-- |
 | shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
-| actor | | The GitHub actor running the action | github.actor |
 | token | | The GitHub token running the action | github.token |
 | projects | | Comma-separated list of projects to deliver | * |
 | deliveryTarget | Yes | Delivery target (AppSource, Storage, GitHubPackages,...) | |

--- a/Actions/Deliver/action.yaml
+++ b/Actions/Deliver/action.yaml
@@ -5,10 +5,6 @@ inputs:
     description: Shell in which you want to run the action (powershell or pwsh)
     required: false
     default: powershell
-  actor:
-    description: The GitHub actor running the action
-    required: false
-    default: ${{ github.actor }}
   token:
     description: The GitHub token running the action
     required: false
@@ -41,7 +37,6 @@ runs:
     - name: run
       shell: ${{ inputs.shell }}
       env:
-        _actor: ${{ inputs.actor }}
         _token: ${{ inputs.token }}
         _projects: ${{ inputs.projects }}
         _deliveryTarget: ${{ inputs.deliveryTarget }}
@@ -51,7 +46,7 @@ runs:
         _goLive: ${{ inputs.goLive }}
       run: |
         ${{ github.action_path }}/../Invoke-AlGoAction.ps1 -ActionName "Deliver" -Action {
-          ${{ github.action_path }}/Deliver.ps1 -actor $ENV:_actor -token $ENV:_token -projects $ENV:_projects -deliveryTarget $ENV:_deliveryTarget -artifacts $ENV:_artifacts -type $ENV:_type -atypes $ENV:_atypes -goLive ($ENV:_goLive -eq 'true')
+          ${{ github.action_path }}/Deliver.ps1 -token $ENV:_token -projects $ENV:_projects -deliveryTarget $ENV:_deliveryTarget -artifacts $ENV:_artifacts -type $ENV:_type -atypes $ENV:_atypes -goLive ($ENV:_goLive -eq 'true')
         }
 branding:
   icon: terminal


### PR DESCRIPTION
Fix the following warnings from PSScriptAnalyzer:
- The parameter 'projectsJson' has been declared but not used (Actions/DetermineDeliveryTargets/DetermineDeliveryTargets.ps1:3)
- The parameter 'actor' has been declared but not used. (Actions/Deliver/Deliver.ps1:3)

