### PR TITLE
CompilerFolder doesn't transfer installed Apps to NuGet resolution

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -18,7 +18,7 @@ $defaultCICDPushBranches = @( 'main', 'release/*', 'feature/*' )
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'defaultCICDPullRequestBranches', Justification = 'False positive.')]
 $defaultCICDPullRequestBranches = @( 'main' )
 $runningLocal = $local.IsPresent
-$defaultBcContainerHelperVersion = "preview" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step - ex. "https://github.com/organization/navcontainerhelper/archive/refs/heads/branch.zip"
+$defaultBcContainerHelperVersion = "https://github.com/microsoft/navcontainerhelper/archive/refs/heads/freddydk/algoissue1330.zip" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step - ex. "https://github.com/organization/navcontainerhelper/archive/refs/heads/branch.zip"
 $notSecretProperties = @("Scopes","TenantId","BlobName","ContainerName","StorageAccountName","ServerUrl","ppUserName","GitHubAppClientId")
 
 $runAlPipelineOverrides = @(

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -41,6 +41,7 @@ $runAlPipelineOverrides = @(
 )
 
 # Well known AppIds
+$platformAppId = "8874ed3a-0643-4247-9ced-7a7002f7135d"
 $systemAppId = "63ca2fa4-4f03-4f2b-a480-172fef340d3f"
 $baseAppId = "437dbf0e-84ff-417a-965d-ed2bb9650972"
 $applicationAppId = "c1335042-3002-4257-bf8a-75c898ccb1b8"

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -18,7 +18,7 @@ $defaultCICDPushBranches = @( 'main', 'release/*', 'feature/*' )
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'defaultCICDPullRequestBranches', Justification = 'False positive.')]
 $defaultCICDPullRequestBranches = @( 'main' )
 $runningLocal = $local.IsPresent
-$defaultBcContainerHelperVersion = "https://github.com/microsoft/navcontainerhelper/archive/refs/heads/freddydk/algoissue1330.zip" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step - ex. "https://github.com/organization/navcontainerhelper/archive/refs/heads/branch.zip"
+$defaultBcContainerHelperVersion = "preview" # Must be double quotes. Will be replaced by BcContainerHelperVersion if necessary in the deploy step - ex. "https://github.com/organization/navcontainerhelper/archive/refs/heads/branch.zip"
 $notSecretProperties = @("Scopes","TenantId","BlobName","ContainerName","StorageAccountName","ServerUrl","ppUserName","GitHubAppClientId")
 
 $runAlPipelineOverrides = @(

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -363,7 +363,7 @@ try {
                         }
                     }
                     if ($parameters.ContainsKey('containerName')) {
-                        Publish-BcNuGetPackageToContainer -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder @publishParams -ErrorAction SilentlyContinue
+                        Publish-BcNuGetPackageToContainer -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder @publishParams
                     }
                     else {
                         if ($parameters.ContainsKey('installedApps') -and $parameters.ContainsKey('installedCountry')) {

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -365,6 +365,8 @@ try {
                         Publish-BcNuGetPackageToContainer -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder @publishParams -ErrorAction SilentlyContinue
                     }
                     else {
+                        Write-Host "Enumerate symbols folder"
+                        Get-ChildItem -path $parameters.appSymbolsFolder | ForEach-Object { Write-Host "- $($_.FullName)" }
                         Download-BcNuGetPackageToFolder -folder $parameters.appSymbolsFolder @publishParams | Out-Null
                     }
                 }

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -365,9 +365,17 @@ try {
                         Publish-BcNuGetPackageToContainer -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder @publishParams -ErrorAction SilentlyContinue
                     }
                     else {
-                        Write-Host "Enumerate symbols folder"
-                        Get-ChildItem -path $parameters.appSymbolsFolder | ForEach-Object { Write-Host "- $($_.FullName)" }
-                        Download-BcNuGetPackageToFolder -folder $parameters.appSymbolsFolder @publishParams | Out-Null
+                        if ($parameters.ContainsKey('installedApps') -and $parameters.ContainsKey('installedCountry')) {
+                            $platformApp = $installedApps | Where-Object { $_.AppId -eq $platformAppId }
+                            if ($platformApp) {
+                                $publishParams += @{
+                                    "installedApps" = $parameters.installedApps
+                                    "installedPlatform" = ([System.Version]$platformApp.Version)
+                                    "installedCountry" = $parameters.installedCountry
+                                }
+                            }
+                        }
+                        Download-BcNuGetPackageToFolder -folder $parameters.appSymbolsFolder @publishParams  | Out-Null
                     }
                 }
             }

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -366,7 +366,7 @@ try {
                     }
                     else {
                         if ($parameters.ContainsKey('installedApps') -and $parameters.ContainsKey('installedCountry')) {
-                            $platformApp = $installedApps | Where-Object { $_.AppId -eq $platformAppId }
+                            $platformApp = $parameters.installedApps | Where-Object { $_.AppId -eq $platformAppId }
                             if ($platformApp) {
                                 $publishParams += @{
                                     "installedApps" = $parameters.installedApps

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -363,15 +363,12 @@ try {
                         }
                     }
                     if ($parameters.ContainsKey('containerName')) {
-                        Publish-BcNuGetPackageToContainer -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder @publishParams
+                        Publish-BcNuGetPackageToContainer -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder @publishParams -ErrorAction SilentlyContinue
                     }
                     else {
                         if ($parameters.ContainsKey('installedApps') -and $parameters.ContainsKey('installedCountry')) {
                             $platformApp = $parameters.installedApps | Where-Object { $_.Id -eq $platformAppId }
                             if ($platformApp) {
-                                Write-Host "Add installedPlatform and installedCountry to publishParams"
-                                Write-Host "Installed platform app: $($platformApp.Version)"
-                                Write-Host "Installed country: $($parameters.installedCountry)"
                                 $publishParams += @{
                                     "installedApps" = $parameters.installedApps
                                     "installedPlatform" = ([System.Version]$platformApp.Version)

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -367,12 +367,14 @@ try {
                     }
                     else {
                         if ($parameters.ContainsKey('installedApps') -and $parameters.ContainsKey('installedCountry')) {
-                            $platformApp = $parameters.installedApps | Where-Object { $_.Id -eq $platformAppId }
-                            if ($platformApp) {
-                                $publishParams += @{
-                                    "installedApps" = $parameters.installedApps
-                                    "installedPlatform" = ([System.Version]$platformApp.Version)
-                                    "installedCountry" = $parameters.installedCountry
+                            foreach($installedApp in $parameters.installedApps) {
+                                if ($installedApp.Id -eq $platformAppId) {
+                                    $publishParams += @{
+                                        "installedApps" = $parameters.installedApps
+                                        "installedPlatform" = ([System.Version]$installedApp.Version)
+                                        "installedCountry" = $parameters.installedCountry
+                                    }
+                                    break
                                 }
                             }
                         }

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -355,6 +355,7 @@ try {
                         "nuGetToken" = GetAccessToken -token $gitHubPackagesCredential.token -permissions @{"packages"="read";"contents"="read";"metadata"="read"} -repositories @()
                         "packageName" = $appId
                         "version" = $version
+                        "select" = "LatestMatching"
                     }
                     if ($parameters.ContainsKey('CopyInstalledAppsToFolder')) {
                         $publishParams += @{
@@ -378,7 +379,7 @@ try {
                                 }
                             }
                         }
-                        Download-BcNuGetPackageToFolder -folder $parameters.appSymbolsFolder @publishParams  | Out-Null
+                        Download-BcNuGetPackageToFolder -folder $parameters.appSymbolsFolder @publishParams | Out-Null
                     }
                 }
             }

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -366,7 +366,7 @@ try {
                     }
                     else {
                         if ($parameters.ContainsKey('installedApps') -and $parameters.ContainsKey('installedCountry')) {
-                            $platformApp = $parameters.installedApps | Where-Object { $_.AppId -eq $platformAppId }
+                            $platformApp = $parameters.installedApps | Where-Object { $_.Id -eq $platformAppId }
                             if ($platformApp) {
                                 Write-Host "Add installedPlatform and installedCountry to publishParams"
                                 Write-Host "Installed platform app: $($platformApp.Version)"

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -368,6 +368,9 @@ try {
                         if ($parameters.ContainsKey('installedApps') -and $parameters.ContainsKey('installedCountry')) {
                             $platformApp = $parameters.installedApps | Where-Object { $_.AppId -eq $platformAppId }
                             if ($platformApp) {
+                                Write-Host "Add installedPlatform and installedCountry to publishParams"
+                                Write-Host "Installed platform app: $($platformApp.Version)"
+                                Write-Host "Installed country: $($parameters.installedCountry)"
                                 $publishParams += @{
                                     "installedApps" = $parameters.installedApps
                                     "installedPlatform" = ([System.Version]$platformApp.Version)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,8 @@
 
 - Issue 1433 Publish to Environment - DependencyInstallMode not found
 - Issue 1440 Create Release fails due to recent changes to the AL-Go
+- Issue 1330 CompilerFolder doesn't transfer installed Apps to NuGet resolution
+- Issue 1268 Do not throw an un-understandable error during nuGet download
 
 ### Support for GitHub App authentication
 


### PR DESCRIPTION
Fixes #1330
Fixes #1268

This requires a new version of BcContainerHelper with https://github.com/microsoft/navcontainerhelper/pull/3832 for the bugs to be fixed. It will still work like before with the old version.

This PR makes sure that the installed apps, the platform and the country are transferred to NuGet resolution when locating apps for downloading - making sure that you don't download a package with dependencies to BC which is newer than what you are building for.
