### PR TITLE
Fix error message when versioning strategy is unknown

### DIFF
--- a/Actions/ReadSettings/ReadSettings.ps1
+++ b/Actions/ReadSettings/ReadSettings.ps1
@@ -48,7 +48,7 @@ if ($settings.versioningstrategy -ne -1) {
             $settings.appRevision = 0
         }
         default {
-            OutputError -message "Unknown version strategy $versionStrategy"
+            OutputError -message "Unknown versioning strategy $($settings.versioningStrategy)"
             exit
         }
     }


### PR DESCRIPTION
Steps to reproduce:

1. Create a PTE app from a template (and add an app)
2. Specify the "versioningStrategy": 7 setting in the ALGoRepoSettings repository variable.

The Read Settings step fails with the following error:
`Error: Unexpected error when running action. Error Message: The variable '$versionStrategy' cannot be retrieved because it has not been set.`

![image](https://github.com/user-attachments/assets/94696f03-53a8-402c-8cce-73bfcf2a1e2e)

Link to the job run: https://github.com/ashirokikh/pte-bc-app/actions/runs/13445999964/job/37571346317

After the fix is applied, the error message variable is displayed in the logs. The error message is as follows:
`Error: Unknown versioning strategy 7`

![image](https://github.com/user-attachments/assets/f493e037-14df-411a-94be-2899e5642fb8)

Link to the job run: https://github.com/ashirokikh/pte-bc-app/actions/runs/13446113979/job/37571703584


