### PR TITLE
runs-on type is ambiguous

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -788,7 +788,7 @@ function ReadSettings {
     # At some point in the future (likely version 3.0), we will switch to Ubuntu (Linux) as default for "runs-on"
     #
     if ($settings.shell -eq "") {
-        if ($settings."runs-on" -like "ubuntu-*") {
+        if ($settings."runs-on" -like "*ubuntu-*") {
             $settings.shell = "pwsh"
         }
         else {
@@ -796,7 +796,7 @@ function ReadSettings {
         }
     }
     if ($settings.githubRunner -eq "") {
-        if ($settings."runs-on" -like "ubuntu-*") {
+        if ($settings."runs-on" -like "*ubuntu-*") {
             $settings.githubRunner = "windows-latest"
         }
         else {
@@ -813,7 +813,7 @@ function ReadSettings {
     if ($settings.shell -ne "powershell" -and $settings.shell -ne "pwsh") {
         throw "Invalid value for setting: shell: $($settings.githubRunnerShell)"
     }
-    if (($settings.githubRunner -like "ubuntu-*") -and ($settings.githubRunnerShell -eq "powershell")) {
+    if (($settings.githubRunner -like "*ubuntu-*") -and ($settings.githubRunnerShell -eq "powershell")) {
         Write-Host "Switching shell to pwsh for ubuntu"
         $settings.githubRunnerShell = "pwsh"
     }

--- a/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
+++ b/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
@@ -268,7 +268,7 @@ else {
 $json = @{"matrix" = @{ "include" = @() }; "fail-fast" = $false }
 $deploymentEnvironments.Keys | Sort-Object | ForEach-Object {
     $deploymentEnvironment = $deploymentEnvironments."$_"
-    $json.matrix.include += @{ "environment" = $_; "os" = "$(ConvertTo-Json -InputObject @($deploymentEnvironment."runs-on".Split(',')) -compress)"; "shell" = $deploymentEnvironment."shell" }
+    $json.matrix.include += @{ "environment" = $_; "os" = "$(ConvertTo-Json -InputObject @($deploymentEnvironment."runs-on".Split(',').Trim()) -compress)"; "shell" = $deploymentEnvironment."shell" }
 }
 $environmentsMatrixJson = $json | ConvertTo-Json -Depth 99 -compress
 Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "EnvironmentsMatrixJson=$environmentsMatrixJson"

--- a/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
+++ b/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
@@ -195,6 +195,10 @@ else {
             if ($deploymentSettings."shell" -ne 'pwsh' -and $deploymentSettings."shell" -ne 'powershell') {
                 throw "The shell setting in $settingsName must be either 'pwsh' or 'powershell'"
             }
+            if ($deploymentSettings."runs-on" -like "*ubuntu-*" -and $deploymentSettings."shell" -eq "powershell") {
+                Write-Host "Switching deployment shell to pwsh for ubuntu"
+                $deploymentSettings."shell" = "pwsh"
+            }
         }
 
         # Get Branch policies on GitHub Environment

--- a/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
+++ b/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
@@ -112,7 +112,7 @@ if (!($environments)) {
                 "Scope" = $null
                 "buildMode" = $null
                 "continuousDeployment" = !($getEnvironments -like '* (PROD)' -or $getEnvironments -like '* (Production)' -or $getEnvironments -like '* (FAT)' -or $getEnvironments -like '* (Final Acceptance Test)')
-                "runs-on" = @($settings."runs-on".Split(',').Trim())
+                "runs-on" = $settings."runs-on"
                 "shell" = $settings."shell"
                 "companyId" = ''
                 "ppEnvironmentUrl" = ''
@@ -155,7 +155,7 @@ else {
             "Scope" = $null
             "buildMode" = $null
             "continuousDeployment" = $null
-            "runs-on" = @($settings."runs-on".Split(',').Trim())
+            "runs-on" = $settings."runs-on"
             "shell" = $settings."shell"
             "companyId" = ''
             "ppEnvironmentUrl" = ''
@@ -173,7 +173,14 @@ else {
             foreach($key in $keys) {
                 if ($deploymentSettings.ContainsKey($key)) {
                     if ($null -ne $deploymentSettings."$key" -and $null -ne $deployTo."$key" -and $deploymentSettings."$key".GetType().Name -ne $deployTo."$key".GetType().Name) {
-                        Write-Host "::WARNING::The property $key in $settingsName is expected to be of type $($deploymentSettings."$key".GetType().Name)"
+                        if ($key -eq "runs-on" -and $deployTo."$key" -is [Object[]]) {
+                            # Support setting runs-on as an array in settings to not break old settings
+                            # See https://github.com/microsoft/AL-Go/issues/1182
+                            $deployTo."$key" = $deployTo."$key" -join ','
+                        }
+                        else {
+                            Write-Host "::WARNING::The property $key in $settingsName is expected to be of type $($deploymentSettings."$key".GetType().Name)"
+                        }
                     }
                     Write-Host "Property $key = $($deployTo."$key")"
                     $deploymentSettings."$key" = $deployTo."$key"
@@ -261,7 +268,7 @@ else {
 $json = @{"matrix" = @{ "include" = @() }; "fail-fast" = $false }
 $deploymentEnvironments.Keys | Sort-Object | ForEach-Object {
     $deploymentEnvironment = $deploymentEnvironments."$_"
-    $json.matrix.include += @{ "environment" = $_; "os" = "$(ConvertTo-Json -InputObject $deploymentEnvironment."runs-on" -compress)"; "shell" = $deploymentEnvironment."shell" }
+    $json.matrix.include += @{ "environment" = $_; "os" = "$(ConvertTo-Json -InputObject @($deploymentEnvironment."runs-on".Split(',')) -compress)"; "shell" = $deploymentEnvironment."shell" }
 }
 $environmentsMatrixJson = $json | ConvertTo-Json -Depth 99 -compress
 Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "EnvironmentsMatrixJson=$environmentsMatrixJson"

--- a/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
+++ b/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
@@ -173,6 +173,8 @@ else {
             foreach($key in $keys) {
                 if ($deploymentSettings.ContainsKey($key)) {
                     if ($null -ne $deploymentSettings."$key" -and $null -ne $deployTo."$key" -and $deploymentSettings."$key".GetType().Name -ne $deployTo."$key".GetType().Name) {
+                        Write-Host "'$key'"
+                        Write-Host $deployTo."$key".GetType().Name
                         if ($key -eq "runs-on" -and $deployTo."$key" -is [Object[]]) {
                             # Support setting runs-on as an array in settings to not break old settings
                             # See https://github.com/microsoft/AL-Go/issues/1182

--- a/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
+++ b/Actions/DetermineDeploymentEnvironments/DetermineDeploymentEnvironments.ps1
@@ -173,8 +173,6 @@ else {
             foreach($key in $keys) {
                 if ($deploymentSettings.ContainsKey($key)) {
                     if ($null -ne $deploymentSettings."$key" -and $null -ne $deployTo."$key" -and $deploymentSettings."$key".GetType().Name -ne $deployTo."$key".GetType().Name) {
-                        Write-Host "'$key'"
-                        Write-Host $deployTo."$key".GetType().Name
                         if ($key -eq "runs-on" -and $deployTo."$key" -is [Object[]]) {
                             # Support setting runs-on as an array in settings to not break old settings
                             # See https://github.com/microsoft/AL-Go/issues/1182

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,7 @@
 - Issue 1330 CompilerFolder doesn't transfer installed Apps to NuGet resolution
 - Issue 1268 Do not throw an un-understandable error during nuGet download
 - Performance test sample code in 25.4 contains objects with ID 149201 and 149202, which are not renumbered
+- Issue 1182 Runs-on setting type is ambiguous - string or array
 
 ### New Workflow specific settings
 


### PR DESCRIPTION
Today, the runs-on type in settings must be a string (can be a comma separated number of runner tags) and the runs-on property under environment needs to be an array of strings = runner tags.

This PR makes the runs-on under Environments become a string as well, but support arrays, to not break old settings files.

Fixes #1182
FIxes https://www.yammer.com/dynamicsnavdev/threads/3172600716926976

This means that this setting:

![image](https://github.com/user-attachments/assets/17ac236c-9cf7-4055-b314-2ab538a0936b)

Yields identical os settings in environment matrix json:

```
EnvironmentsMatrixJson={"matrix":{"include":[{"environment":"TEST","os":"[\"windows-latest\",\"windows-2022\"]","shell":"powershell"},{"environment":"TEST2","os":"[\"windows-latest\",\"windows-2022\"]","shell":"powershell"}]},"fail-fast":false}
```

The PR also ensures that shell becomes pwsh if runs-on is `*ubuntu-*`