### PR TITLE
Downloaded apps no longer published in PR builds

### DIFF
--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -476,6 +476,8 @@ function Get-UnmodifiedAppsFromBaselineWorkflowRun {
         $additionalDataForTelemetry.Add("$($appType)Downloaded", $appsToDownload."$appType".Downloaded)
     }
     Trace-Information -Message "Incremental builds (apps)" -AdditionalData $additionalDataForTelemetry
+
+    return $downloadAppFolders, $downloadTestFolders, $downloadBcptTestFolders
 }
 
 Export-ModuleMember *-*

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -141,7 +141,7 @@ try {
         }
         if (!$buildAll) {
             Write-Host "Get unmodified apps from baseline workflow run"
-            $downloadAppFolders, $downloadTestFolders, $downloadBcptTestFolders = Get-UnmodifiedAppsFromBaselineWorkflowRun `
+            $downloadedAppsByType = Get-UnmodifiedAppsFromBaselineWorkflowRun `
                 -token $token `
                 -settings $settings `
                 -baseFolder $baseFolder `
@@ -508,12 +508,16 @@ try {
         -appBuild $appBuild -appRevision $appRevision `
         -uninstallRemovedApps
 
-    $downloadAppFolders, $downloadTestFolders, $downloadBcptTestFolders | ForEach-Object {
-        Write-Host "Debug: removing apps from $_"
-        foreach($downloadedApp in $_) {
-            if (Test-Path $downloadedApp) {
-                Write-Host "Debug: Removing downloaded app $downloadedApp"
-                Remove-Item $downloadedApp
+    $downloadedAppsByType | ForEach-Object {
+        $type = $_.type
+        $mask = $_.mask
+        $thisArtifactFolder = Join-Path $buildArtifactFolder $mask
+        Write-Host "Debug: removing $type apps with mask: $mask from $thisArtifactFolder"
+        foreach($downloadedApp in $_.downloadedApps) {
+            $thisApp = Join-Path $thisArtifactFolder $downloadedApp
+            Write-Host "Debug: app: $thisApp"
+            if (Test-Path $thisApp) {
+                Remove-Item $thisApp
             }
         }
     }

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -508,18 +508,20 @@ try {
         -appBuild $appBuild -appRevision $appRevision `
         -uninstallRemovedApps
 
+    #If any apps were downloaded as part of incremental builds, we should remove them again after the build
     $downloadedAppsByType | ForEach-Object {
-        $type = $_.type
-        $mask = $_.mask
-        $thisArtifactFolder = Join-Path $buildArtifactFolder $mask
-        Write-Host "Debug: removing $type apps with mask: $mask from $thisArtifactFolder"
-        foreach($downloadedApp in $_.downloadedApps) {
-            $thisApp = Join-Path $thisArtifactFolder $downloadedApp
-            Write-Host "Debug: app: $thisApp"
-            if (Test-Path $thisApp) {
-                Remove-Item $thisApp
+        if ($_.downloadedApps) {
+            $mask = $_.mask
+            $thisArtifactFolder = Join-Path $buildArtifactFolder $mask
+            Write-Host "Removing downloaded apps from $thisArtifactFolder"
+            foreach($downloadedApp in $_.downloadedApps) {
+                $thisApp = Join-Path $thisArtifactFolder $downloadedApp
+                Write-Host "Removing: $thisApp"
+                if (Test-Path $thisApp) {
+                    Remove-Item $thisApp
+                }
             }
-        }
+        }   
     }
 
     if ($containerBaseFolder) {


### PR DESCRIPTION
As part of the incremental builds feature, we download any apps that have not been updated. In single project repos, these downloaded apps are incorrectly published as artifacts in PR builds.

This PR adds a small snippet to remove any downloaded apps after the build, to ensure only compiled apps are published.