### PR TITLE
Fix incremental build problems

### DIFF
--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
@@ -35,7 +35,7 @@ if(-not $buildAllProjects) {
 
     Write-Host "::group::Get Modified Files"
     try {
-        $modifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA)
+        $buildAllProjects, $modifiedFiles = Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA
         OutputMessageAndArray -message "Modified files" -arrayOfStrings $modifiedFiles
     }
     catch {

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
@@ -39,7 +39,7 @@ try {
     OutputMessageAndArray -message "Modified files" -arrayOfStrings $modifiedFiles
 }
 catch {
-    Write-Host "Failed to calculate modified files, building all projects"
+    OutputNotice -message "Failed to calculate modified files since $baselineWorkflowSHA, building all projects"
     $buildAllProjects = $true
     $modifiedFiles = @()
 }

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
@@ -52,6 +52,8 @@ if (-not $buildAllProjects) {
 }
 
 # If we are to publish artifacts for skipped projects later, we include the full project list and in the build step, just avoid building the skipped projects
+# buildAllProjects is set to true if we are to build all projects
+# publishSkippedProjects is set to true if we are to publish artifacts for skipped projects (meaning we are still going through the build process for all projects, just not building)
 Write-Host "::group::Get Projects To Build"
 $allProjects, $modifiedProjects, $projectsToBuild, $projectDependencies, $buildOrder = Get-ProjectsToBuild -baseFolder $baseFolder -buildAllProjects ($buildAllProjects -or $publishSkippedProjects) -modifiedFiles $modifiedFiles -maxBuildDepth $maxBuildDepth
 if ($buildAllProjects) {

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -298,7 +298,7 @@ function Get-BuildAllProjects {
     $settings = $env:Settings | ConvertFrom-Json
 
     if (!$modifiedFiles) {
-        Write-Host "No files modified, building everything"
+        Write-Host "::notice::No files modified, building everything"
         return $true
     }
 
@@ -315,7 +315,7 @@ function Get-BuildAllProjects {
         $fullBuildFolder = Join-Path $baseFolder $fullBuildFolder
 
         if ($modifiedFiles -like $fullBuildFolder) {
-            Write-Host "Changes to $fullBuildFolder, building everything"
+            Write-Host "::notice::Changes to $fullBuildFolder detected, building everything"
             return $true
         }
     }

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -26,15 +26,18 @@ function Get-ModifiedFiles {
             }
             Invoke-CommandWithRetry -ScriptBlock { RunAndCheck git fetch origin $baselineSHA | Out-Host }
         }
-        else {
+        elseif ($baselineSHA) {
             $headSHA = git rev-parse HEAD
             Write-Host "Current HEAD is $headSHA"
             Invoke-CommandWithRetry -ScriptBlock { RunAndCheck git fetch origin $baselineSHA | Out-Host }
             Write-Host "Not a pull request, using baseline SHA $baselineSHA and current HEAD $headSHA"
         }
+        else {
+            return $true, @()
+        }
         Write-Host "git diff --name-only $baselineSHA $headSHA"
         $modifiedFiles = @(RunAndCheck git diff --name-only $baselineSHA $headSHA | ForEach-Object { "$_".Replace('/', [System.IO.Path]::DirectorySeparatorChar) })
-        return $modifiedFiles
+        return $false, $modifiedFiles
     }
     finally {
         Pop-Location

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -346,7 +346,7 @@ function Get-BuildAllProjects {
         [string[]] $modifiedFiles = @()
     )
 
-    return (IsFullBuildRequired -baseFolder $baseFolder -modifiedFiles $modifiedFiles -noticeMessage "building all projects")
+    return (IsFullBuildRequired -baseFolder $baseFolder -modifiedFiles $modifiedFiles -noticeMessage "building everything")
 }
 
 <#

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -282,23 +282,23 @@ function Get-BuildAllProjectsBasedOnEventAndSettings {
 .Description
     Determines whether a full build is required.
     A full build is required if:
-    - No files were modified
     - The modified files contain a file that matches one of the fullBuildPatterns
 #>
-function Get-BuildAllProjects {
+function IsFullBuildRequired {
     param(
         [Parameter(HelpMessage = "The base folder", Mandatory = $true)]
         [string] $baseFolder,
         [Parameter(HelpMessage = "The modified files", Mandatory = $false)]
         [string[]] $modifiedFiles = @(),
         [Parameter(HelpMessage = "Full build patterns", Mandatory = $false)]
-        [string[]] $fullBuildPatterns = @()
+        [string[]] $fullBuildPatterns = @(),
+        [string] $noticeMessage = ''
     )
 
     $settings = $env:Settings | ConvertFrom-Json
 
     if (!$modifiedFiles) {
-        Write-Host "No files modified!"
+        Write-Host "No modified files"
         return $false
     }
 
@@ -315,14 +315,38 @@ function Get-BuildAllProjects {
         $fullBuildFolder = Join-Path $baseFolder $fullBuildFolder
 
         if ($modifiedFiles -like $fullBuildFolder) {
-            Write-Host "::notice::Changes to $fullBuildFolder detected, building everything"
+            if ($noticeMessage) {
+                Write-Host "::notice::Changes to $fullBuildFolder detected, $noticeMessage"
+            }
+            else {
+                Write-Host "Changes to $fullBuildFolder detected"
+            }
             return $true
         }
     }
-
-    Write-Host "No changes to fullBuildPatterns, not building everything"
-
+    Write-Host "No changes to full build patterns detected"
     return $false
+}
+
+<#
+.Synopsis
+    Determines whether all projects in a repository should be built
+.Outputs
+    A boolean indicating whether a full build is required.
+.Description
+    Determines whether a full build is required.
+    A full build is required if:
+    - The modified files contain a file that matches one of the fullBuildPatterns
+#>
+function Get-BuildAllProjects {
+    param(
+        [Parameter(HelpMessage = "The base folder", Mandatory = $true)]
+        [string] $baseFolder,
+        [Parameter(HelpMessage = "The modified files", Mandatory = $false)]
+        [string[]] $modifiedFiles = @()
+    )
+
+    return (IsFullBuildRequired -baseFolder $baseFolder -modifiedFiles $modifiedFiles -noticeMessage "building all projects")
 }
 
 <#
@@ -333,7 +357,7 @@ function Get-BuildAllProjects {
 .Description
     Determines whether a full build is required.
     A full build is required if:
-    - Get-BuildAllProjects returns true
+    - The modified files contain a file that matches one of the fullBuildPatterns
     - The .AL-Go/settings.json file has been modified
 #>
 function Get-BuildAllApps {
@@ -346,13 +370,17 @@ function Get-BuildAllApps {
         [string[]] $modifiedFiles = @()
     )
 
+    if (IsFullBuildRequired -baseFolder $baseFolder -modifiedFiles $modifiedFiles) {
+        # Notice already given in Initialize
+        return $true
+    }
     if ($project) {
         $ALGoSettingsFile = @(Join-Path $project '.AL-Go/settings.json')
     }
     else {
         $ALGoSettingsFile = @('.AL-Go/settings.json')
     }
-    return (Get-BuildAllProjects -baseFolder $baseFolder -modifiedFiles $modifiedFiles -fullBuildPatterns @($ALGoSettingsFile))
+    return (IsFullBuildRequired -baseFolder $baseFolder -modifiedFiles $modifiedFiles -fullBuildPatterns @($ALGoSettingsFile) -noticeMessage "building all apps")
 }
 
 <#

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -353,10 +353,10 @@ function Get-BuildAllProjects {
 .Synopsis
     Determines whether all apps in a project should be built
 .Outputs
-    A boolean indicating whether a full build is required.
+    A boolean indicating whether all apps in a project should be built.
 .Description
-    Determines whether a full build is required.
-    A full build is required if:
+    Determines whether all apps in a project should be built.
+    All apps should be built if:
     - The modified files contain a file that matches one of the fullBuildPatterns
     - The .AL-Go/settings.json file has been modified
 #>

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -298,8 +298,8 @@ function Get-BuildAllProjects {
     $settings = $env:Settings | ConvertFrom-Json
 
     if (!$modifiedFiles) {
-        Write-Host "::notice::No files modified, building everything"
-        return $true
+        Write-Host "No files modified!"
+        return $false
     }
 
     $fullBuildPatterns += @(Join-Path '.github' '*.json')

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -26,18 +26,15 @@ function Get-ModifiedFiles {
             }
             Invoke-CommandWithRetry -ScriptBlock { RunAndCheck git fetch origin $baselineSHA | Out-Host }
         }
-        elseif ($baselineSHA) {
+        else {
             $headSHA = git rev-parse HEAD
             Write-Host "Current HEAD is $headSHA"
             Invoke-CommandWithRetry -ScriptBlock { RunAndCheck git fetch origin $baselineSHA | Out-Host }
             Write-Host "Not a pull request, using baseline SHA $baselineSHA and current HEAD $headSHA"
         }
-        else {
-            return $true, @()
-        }
         Write-Host "git diff --name-only $baselineSHA $headSHA"
         $modifiedFiles = @(RunAndCheck git diff --name-only $baselineSHA $headSHA | ForEach-Object { "$_".Replace('/', [System.IO.Path]::DirectorySeparatorChar) })
-        return $false, $modifiedFiles
+        return $modifiedFiles
     }
     finally {
         Pop-Location

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -135,7 +135,7 @@ try {
             $buildAll = Get-BuildAllApps -baseFolder $baseFolder -project $project -modifiedFiles $modifiedFiles
         }
         catch {
-            OutputWarning -message "Failed to calculate modified files since $baselineWorkflowSHA, building all apps"
+            OutputNotice -message "Failed to calculate modified files since $baselineWorkflowSHA, building all apps"
             $buildAll = $true
         }
         if (!$buildAll) {

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -280,7 +280,7 @@ jobs:
           project: ${{ inputs.project }}
 
       - name: Cleanup
-        if: always()
+        if: always() && steps.DetermineBuildProject.outputs.BuildIt == 'True'
         uses: microsoft/AL-Go-Actions/PipelineCleanup@main
         with:
           shell: ${{ inputs.shell }}

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -280,7 +280,7 @@ jobs:
           project: ${{ inputs.project }}
 
       - name: Cleanup
-        if: always()
+        if: always() && steps.DetermineBuildProject.outputs.BuildIt == 'True'
         uses: microsoft/AL-Go-Actions/PipelineCleanup@main
         with:
           shell: ${{ inputs.shell }}

--- a/Tests/DetermineProjectsToBuild.Test.ps1
+++ b/Tests/DetermineProjectsToBuild.Test.ps1
@@ -762,13 +762,13 @@ Describe "Get-BuildAllProjects" {
         $baseFolder = (New-Item -ItemType Directory -Path (Join-Path $([System.IO.Path]::GetTempPath()) $([System.IO.Path]::GetRandomFileName()))).FullName
     }
 
-    It ('returns true if there are no modified filed') {
+    It ('returns false if there are no modified filed') {
         # Add AL-Go settings
         $alGoSettings = @{ fullBuildPatterns = @() }
         $env:Settings = ConvertTo-Json $alGoSettings -Depth 99 -Compress
 
         $buildAllProjects = Get-BuildAllProjects -baseFolder $baseFolder
-        $buildAllProjects | Should -Be $true
+        $buildAllProjects | Should -Be $false
     }
 
     It ('returns true if any of the modified files matches any of the patterns in fullBuildPatterns setting') {

--- a/Tests/DetermineProjectsToBuild.Test.ps1
+++ b/Tests/DetermineProjectsToBuild.Test.ps1
@@ -762,7 +762,7 @@ Describe "Get-BuildAllProjects" {
         $baseFolder = (New-Item -ItemType Directory -Path (Join-Path $([System.IO.Path]::GetTempPath()) $([System.IO.Path]::GetRandomFileName()))).FullName
     }
 
-    It ('returns false if there are no modified filed') {
+    It ('returns false if there are no modified files') {
         # Add AL-Go settings
         $alGoSettings = @{ fullBuildPatterns = @() }
         $env:Settings = ConvertTo-Json $alGoSettings -Depth 99 -Compress


### PR DESCRIPTION
It can be hard to discover the reason why a full build was triggered deep inside the log.
This PR adds a notice to the build when a full build is triggered, with the reason behind it.

Fixes #1487

Additionally, a Pull Request, which should trigger a full build (due to files changed) wouldn't trigger the change due to a parameter error.

Thirdly - in some cases, we would attempt to do a git diff with an empty sha.

Lastly - skip the build cleanup step if no build step was ever run (saves ~10 seconds)
