### PR TITLE
FIx issue with removal of pre-built apps.

### DIFF
--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -127,7 +127,7 @@ try {
     $buildArtifactFolder = Join-Path $projectPath ".buildartifacts"
     New-Item $buildArtifactFolder -ItemType Directory | Out-Null
 
-    $downloadedAppsByType = @{}
+    $downloadedAppsByType = @()
     if ($baselineWorkflowSHA -and $baselineWorkflowRunId -ne '0' -and $settings.incrementalBuilds.mode -eq 'modifiedApps') {
         # Incremental builds are enabled and we are only building modified apps
         try {


### PR DESCRIPTION
$downloadedAppsByType was incorrectly initialized as an object instead of a list.
This failed because checking if the object exist in an if statement, will return true for an empty object, but false for a list.