### PR TITLE
fix: Use ghTokenWorkflow for CheckForUpdates in CreateRelease.yaml

### DIFF
--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -104,7 +104,7 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForPush'
+          getSecrets: 'TokenForPush,ghTokenWorkflow'
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Determine Projects
@@ -118,7 +118,7 @@ jobs:
         with:
           shell: powershell
           templateUrl: ${{ env.templateUrl }}
-          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).TokenForPush }}
+          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
           downloadLatest: true
 
       - name: Analyze Artifacts

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -104,7 +104,7 @@ jobs:
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'TokenForPush'
+          getSecrets: 'TokenForPush,ghTokenWorkflow'
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Determine Projects
@@ -118,7 +118,7 @@ jobs:
         with:
           shell: powershell
           templateUrl: ${{ env.templateUrl }}
-          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).TokenForPush }}
+          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
           downloadLatest: true
 
       - name: Analyze Artifacts


### PR DESCRIPTION
Fixes #1475 (hopefully completely this time)

My apologies Freddy, but I think I messed up when I tested #1477...

CI/CD worked just as intended, but "Create Release" did not work. It ended up with a 404 error. It seemed as if the token sent to the CreateRelase action was empty:
```
    _actor: jwikman
    _token:                                            <----------
    _templateUrl: https://github.com/[redacted]/AL-Go-PTE@preview
    _downloadLatest: true
    _update: N
    _updateBranch: main
    _directCommit: false
```

After the proposed change, the token is passed as expected
```
    _actor: jwikman
    _token: ***                                     <---------------------
    _templateUrl: https://github.com/[redacted]/AL-Go-PTE@preview
    _downloadLatest: true
    _update: N
    _updateBranch: main
    _directCommit: false
```

I do not fully follow the logic with the `TokenForPush` secret, but that token did not seem to work in this context?