### PR TITLE
During deployment, known dependencies are considered unknown

### DIFF
--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -234,7 +234,7 @@ if (Test-Path $artifactsFolder -PathType Container) {
                     if ($appJson.id -notin $deploymentSettings.excludeAppIds) {
                         # If app should be included, verify that it does not depend on Tests-TestLibraries
                         $dependenciesForApp = @()
-                        Sort-AppFilesByDependencies -appFiles @($app.FullName) -unknownDependencies ([ref]$dependenciesForApp) | Out-Null
+                        Sort-AppFilesByDependencies -appFiles @($app.FullName) -unknownDependencies ([ref]$dependenciesForApp) -WarningAction SilentlyContinue | Out-Null
                         $dependenciesForApp | ForEach-Object {
                             if ($_.Split(':')[0] -eq $TestsTestLibrariesAppId) {
                                 Write-Host "::WARNING::Test-TestLibraries can't be installed - skipping app $($app.Name)"

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -206,7 +206,7 @@ if (Test-Path $artifactsFolder -PathType Container) {
             Write-Host "Excluding apps with ids $($deploymentSettings.excludeAppIds) from deployment"
         }
         if ($deploymentSettings.DependencyInstallMode -ne "ignore") {
-            $dependencies += @((Get-ChildItem -Path $artifactsFolder -Filter "$project-$refname-$($buildMode)Dependencies-*.*.*.*") | ForEach-Object { $_.FullName })
+            $dependencies += @((Get-ChildItem -Path $artifactsFolder -Filter "$project-$refname-$($buildMode)Dependencies-*.*.*.*/*.app") | ForEach-Object { $_.FullName })
         }
         if (!($projectApps)) {
             if ($project -ne '*') {

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -206,7 +206,7 @@ if (Test-Path $artifactsFolder -PathType Container) {
             Write-Host "Excluding apps with ids $($deploymentSettings.excludeAppIds) from deployment"
         }
         if ($deploymentSettings.DependencyInstallMode -ne "ignore") {
-            $dependencies += @(Get-ChildItem -Path (Join-Path $artifactsFolder "$project-$refname-$($buildMode)Dependencies-*.*.*.*/*.app") | ForEach-Object { $_.FullName } )
+            $dependencies += @((Get-ChildItem -Path (Join-Path $artifactsFolder "$project-$refname-$($buildMode)Dependencies-*.*.*.*/*.app")) | ForEach-Object { $_.FullName } )
         }
         if (!($projectApps)) {
             if ($project -ne '*') {

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -233,9 +233,9 @@ if (Test-Path $artifactsFolder -PathType Container) {
                     $appJson = Get-AppJsonFromAppFile -appFile $app.FullName
                     if ($appJson.id -notin $deploymentSettings.excludeAppIds) {
                         # If app should be included, verify that it does not depend on Tests-TestLibraries
-                        $unknownDependenciesForApp = @()
-                        Sort-AppFilesByDependencies -appFiles @($app.FullName) -unknownDependencies ([ref]$unknownDependenciesForApp) | Out-Null
-                        $unknownDependenciesForApp | ForEach-Object {
+                        $dependenciesForApp = @()
+                        Sort-AppFilesByDependencies -appFiles @($app.FullName) -unknownDependencies ([ref]$dependenciesForApp) | Out-Null
+                        $dependenciesForApp | ForEach-Object {
                             if ($_.Split(':')[0] -eq $TestsTestLibrariesAppId) {
                                 Write-Host "::WARNING::Test-TestLibraries can't be installed - skipping app $($app.Name)"
                                 continue

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -206,7 +206,7 @@ if (Test-Path $artifactsFolder -PathType Container) {
             Write-Host "Excluding apps with ids $($deploymentSettings.excludeAppIds) from deployment"
         }
         if ($deploymentSettings.DependencyInstallMode -ne "ignore") {
-            $dependencies += @(Get-ChildItem -Path $artifactsFolder -Filter "$project-$refname-$($buildMode)Dependencies-*.*.*.*" -Directory | ForEach-Object { Get-ChildItem -Path $_.FullName -Filter '*.app' -File | ForEach-Object { $_.FullName } })
+            $dependencies += @(Get-ChildItem -Path (Join-Path $artifactsFolder "$project-$refname-$($buildMode)Dependencies-*.*.*.*/*.app") | ForEach-Object { $_.FullName } )
         }
         if (!($projectApps)) {
             if ($project -ne '*') {

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -233,14 +233,15 @@ if (Test-Path $artifactsFolder -PathType Container) {
                     $appJson = Get-AppJsonFromAppFile -appFile $app.FullName
                     if ($appJson.id -notin $deploymentSettings.excludeAppIds) {
                         # If app should be included, verify that it does not depend on Tests-TestLibraries
-                        $dependenciesForApp = @()
-                        Sort-AppFilesByDependencies -appFiles @($app.FullName) -unknownDependencies ([ref]$dependenciesForApp) -WarningAction SilentlyContinue | Out-Null
-                        $dependenciesForApp | ForEach-Object {
+                        $unknownDependenciesForApp = @()
+                        Sort-AppFilesByDependencies -appFiles @($app.FullName) -unknownDependencies ([ref]$unknownDependenciesForApp) -WarningAction SilentlyContinue | Out-Null
+                        $unknownDependenciesForApp | ForEach-Object {
                             if ($_.Split(':')[0] -eq $TestsTestLibrariesAppId) {
                                 Write-Host "::WARNING::Test-TestLibraries can't be installed - skipping app $($app.Name)"
                                 continue
                             }
                         }
+
                         $apps += $app.FullName
                         Write-Host "App $($app.Name) with id $($appJson.id) included in deployment"
                     }
@@ -250,7 +251,6 @@ if (Test-Path $artifactsFolder -PathType Container) {
                 }
             }
         }
-
     }
 }
 else {

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -206,7 +206,7 @@ if (Test-Path $artifactsFolder -PathType Container) {
             Write-Host "Excluding apps with ids $($deploymentSettings.excludeAppIds) from deployment"
         }
         if ($deploymentSettings.DependencyInstallMode -ne "ignore") {
-            $dependencies += @((Get-ChildItem -Path $artifactsFolder -Filter "$project-$refname-$($buildMode)Dependencies-*.*.*.*/*.app") | ForEach-Object { $_.FullName })
+            $dependencies += @((Get-ChildItem -Path (Join-Path $artifactsFolder "$project-$refname-$($buildMode)Dependencies-*.*.*.*") -Filter "*.app") | ForEach-Object { $_.FullName })
         }
         if (!($projectApps)) {
             if ($project -ne '*') {

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -206,7 +206,7 @@ if (Test-Path $artifactsFolder -PathType Container) {
             Write-Host "Excluding apps with ids $($deploymentSettings.excludeAppIds) from deployment"
         }
         if ($deploymentSettings.DependencyInstallMode -ne "ignore") {
-            $dependencies += @((Get-ChildItem -Path (Join-Path $artifactsFolder "$project-$refname-$($buildMode)Dependencies-*.*.*.*") -Filter "*.app") | ForEach-Object { $_.FullName })
+            $dependencies += @(Get-ChildItem -Path $artifactsFolder -Filter "$project-$refname-$($buildMode)Dependencies-*.*.*.*" -Directory | ForEach-Object { Get-ChildItem -Path $_.FullName -Filter '*.app' -File | ForEach-Object { $_.FullName } })
         }
         if (!($projectApps)) {
             if ($project -ne '*') {

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -234,7 +234,11 @@ if (Test-Path $artifactsFolder -PathType Container) {
                     if ($appJson.id -notin $deploymentSettings.excludeAppIds) {
                         # If app should be included, verify that it does not depend on Tests-TestLibraries
                         $unknownDependenciesForApp = @()
-                        Sort-AppFilesByDependencies -appFiles @($app.FullName+$dependencies) -unknownDependencies ([ref]$unknownDependenciesForApp) | Out-Null
+                        $knownApps = @($app.FullName)
+                        if ($dependencies) {
+                            $knownApps += @($dependencies.FullName)
+                        }
+                        Sort-AppFilesByDependencies -appFiles $knownApps -unknownDependencies ([ref]$unknownDependenciesForApp) | Out-Null
                         $unknownDependenciesForApp | ForEach-Object {
                             if ($_.Split(':')[0] -eq $TestsTestLibrariesAppId) {
                                 Write-Host "::WARNING::Test-TestLibraries can't be installed - skipping app $($app.Name)"

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -234,11 +234,7 @@ if (Test-Path $artifactsFolder -PathType Container) {
                     if ($appJson.id -notin $deploymentSettings.excludeAppIds) {
                         # If app should be included, verify that it does not depend on Tests-TestLibraries
                         $unknownDependenciesForApp = @()
-                        $knownApps = @($app.FullName)
-                        if ($dependencies) {
-                            $knownApps += @($dependencies.FullName)
-                        }
-                        Sort-AppFilesByDependencies -appFiles $knownApps -unknownDependencies ([ref]$unknownDependenciesForApp) | Out-Null
+                        Sort-AppFilesByDependencies -appFiles @($app.FullName + $dependencies) -unknownDependencies ([ref]$unknownDependenciesForApp) | Out-Null
                         $unknownDependenciesForApp | ForEach-Object {
                             if ($_.Split(':')[0] -eq $TestsTestLibrariesAppId) {
                                 Write-Host "::WARNING::Test-TestLibraries can't be installed - skipping app $($app.Name)"

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -225,16 +225,16 @@ if (Test-Path $artifactsFolder -PathType Container) {
         else {
             $allApps += $projectTestApps
         }
-        #Go through all .app files and exclude any with ids in the excludeAppIds list
+        # Go through all .app files and exclude any with ids in the excludeAppIds list
         if ($allApps) {
             foreach($folder in $allApps) {
                 foreach($app in (Get-ChildItem -Path $folder -Filter "*.app")) {
                     Write-Host "Processing app: $($app.Name)"
                     $appJson = Get-AppJsonFromAppFile -appFile $app.FullName
                     if ($appJson.id -notin $deploymentSettings.excludeAppIds) {
-                        #If app should be included, verify that it does not depend on Tests-TestLibraries
+                        # If app should be included, verify that it does not depend on Tests-TestLibraries
                         $unknownDependenciesForApp = @()
-                        Sort-AppFilesByDependencies -appFiles @($app.FullName) -unknownDependencies ([ref]$unknownDependenciesForApp) | Out-Null
+                        Sort-AppFilesByDependencies -appFiles @($app.FullName+$dependencies) -unknownDependencies ([ref]$unknownDependenciesForApp) | Out-Null
                         $unknownDependenciesForApp | ForEach-Object {
                             if ($_.Split(':')[0] -eq $TestsTestLibrariesAppId) {
                                 Write-Host "::WARNING::Test-TestLibraries can't be installed - skipping app $($app.Name)"


### PR DESCRIPTION
I found a problem, which occured as a result of this PR: https://github.com/microsoft/AL-Go/pull/1437

Causing logs like:
![image](https://github.com/user-attachments/assets/2a3418db-236a-42bb-ac34-1c06ee63856a)

Where known dependencies are not considered when calculating unknown dependencies - (I should have seen that in code review).

This PR fixes this, and the log looks like:

![image](https://github.com/user-attachments/assets/6f36d254-41e4-4843-93b9-48c7cc0cb655)
