### PR TITLE
use settings for BCCH

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -423,12 +423,10 @@ function DownloadAndImportBcContainerHelper([string] $baseFolder = $ENV:GITHUB_W
     if ("$env:settings" -ne "") {
         $repoSettingsPath = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString()).json"
         $env:settings | Set-Content -Path $repoSettingsPath -Encoding UTF8
-        $env:settings | Out-Host
     }
     else {
         $repoSettingsPath = Join-Path $baseFolder $repoSettingsFile
     }
-    Write-Host $repoSettingsPath
     if (Test-Path $repoSettingsPath) {
         # Override default BcContainerHelper version from AL-Go-Helper only if new version is specifically specified in settings
         $repoSettings = Get-Content $repoSettingsPath -Encoding UTF8 | ConvertFrom-Json | ConvertTo-HashTable
@@ -444,7 +442,8 @@ function DownloadAndImportBcContainerHelper([string] $baseFolder = $ENV:GITHUB_W
         }
         $params += @{ "bcContainerHelperConfigFile" = $repoSettingsPath }
     }
-     if ($bcContainerHelperVersion -eq '') {
+
+    if ($bcContainerHelperVersion -eq '') {
         $bcContainerHelperVersion = "latest"
     }
 

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -421,12 +421,14 @@ function DownloadAndImportBcContainerHelper([string] $baseFolder = $ENV:GITHUB_W
     $bcContainerHelperVersion = $defaultBcContainerHelperVersion
 
     if ("$env:settings" -ne "") {
+        Write-Host "------------------------------- $env:settings"
         $repoSettingsPath = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString()).json"
         $env:settings | ConvertTo-Json -Depth 100 | Set-Content -Path $repoSettingsPath -Encoding UTF8
     }
     else {
         $repoSettingsPath = Join-Path $baseFolder $repoSettingsFile
     }
+    Write-Host $repoSettingsPath
     if (Test-Path $repoSettingsPath) {
         # Override default BcContainerHelper version from AL-Go-Helper only if new version is specifically specified in settings
         $repoSettings = Get-Content $repoSettingsPath -Encoding UTF8 | ConvertFrom-Json | ConvertTo-HashTable

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -421,9 +421,9 @@ function DownloadAndImportBcContainerHelper([string] $baseFolder = $ENV:GITHUB_W
     $bcContainerHelperVersion = $defaultBcContainerHelperVersion
 
     if ("$env:settings" -ne "") {
-        Write-Host "------------------------------- $env:settings"
         $repoSettingsPath = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString()).json"
         $env:settings | ConvertTo-Json -Depth 100 | Set-Content -Path $repoSettingsPath -Encoding UTF8
+        $env:settings | ConvertTo-Json -Depth 100 | Out-Host
     }
     else {
         $repoSettingsPath = Join-Path $baseFolder $repoSettingsFile
@@ -444,8 +444,7 @@ function DownloadAndImportBcContainerHelper([string] $baseFolder = $ENV:GITHUB_W
         }
         $params += @{ "bcContainerHelperConfigFile" = $repoSettingsPath }
     }
-
-    if ($bcContainerHelperVersion -eq '') {
+     if ($bcContainerHelperVersion -eq '') {
         $bcContainerHelperVersion = "latest"
     }
 

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -416,13 +416,19 @@ function GetBcContainerHelperPath([string] $bcContainerHelperVersion) {
 #
 function DownloadAndImportBcContainerHelper([string] $baseFolder = $ENV:GITHUB_WORKSPACE) {
     $params = @{ "ExportTelemetryFunctions" = $true }
-    $repoSettingsPath = Join-Path $baseFolder $repoSettingsFile
 
     # Default BcContainerHelper Version is hardcoded in AL-Go-Helper (replaced during AL-Go deploy)
     $bcContainerHelperVersion = $defaultBcContainerHelperVersion
+
+    if ("$env:settings" -ne "") {
+        $repoSettingsPath = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString()).json"
+        $env:settings | ConvertTo-Json -Depth 100 | Set-Content -Path $repoSettingsPath -Encoding UTF8
+    }
+    else {
+        $repoSettingsPath = Join-Path $baseFolder $repoSettingsFile
+    }
     if (Test-Path $repoSettingsPath) {
-        # Read Repository Settings file (without applying organization variables, repository variables or project settings files)
-        # Override default BcContainerHelper version from AL-Go-Helper only if new version is specifically specified in repo settings file
+        # Override default BcContainerHelper version from AL-Go-Helper only if new version is specifically specified in settings
         $repoSettings = Get-Content $repoSettingsPath -Encoding UTF8 | ConvertFrom-Json | ConvertTo-HashTable
         if ($repoSettings.Keys -contains "BcContainerHelperVersion" -and $defaultBcContainerHelperVersion -notlike 'https://*') {
             $bcContainerHelperVersion = $repoSettings.BcContainerHelperVersion

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -422,8 +422,8 @@ function DownloadAndImportBcContainerHelper([string] $baseFolder = $ENV:GITHUB_W
 
     if ("$env:settings" -ne "") {
         $repoSettingsPath = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString()).json"
-        $env:settings | ConvertTo-Json -Depth 100 | Set-Content -Path $repoSettingsPath -Encoding UTF8
-        $env:settings | ConvertTo-Json -Depth 100 | Out-Host
+        $env:settings | Set-Content -Path $repoSettingsPath -Encoding UTF8
+        $env:settings | Out-Host
     }
     else {
         $repoSettingsPath = Join-Path $baseFolder $repoSettingsFile

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,7 +1,6 @@
 ### Issues
 
-- BcContainerHelper settings was only read from .github/AL-Go-Settings.json, not allowing global settings in ALGoOrgSettings for TrustedNuGetFeeds, MemoryLimit and other things that should be possible to define globally
-
+- BcContainerHelper settings were only read from .github/AL-Go-Settings.json, not allowing global settings in ALGoOrgSettings for TrustedNuGetFeeds, MemoryLimit and other things that should be possible to define globally
 ## v6.4
 
 ### Deprecations

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+### Issues
+
+- BcContainerHelper settings was only read from .github/AL-Go-Settings.json, not allowing global settings in ALGoOrgSettings for TrustedNuGetFeeds, MemoryLimit and other things that should be possible to define globally
+
 ## v6.4
 
 ### Deprecations

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 ### Issues
 
 - BcContainerHelper settings were only read from .github/AL-Go-Settings.json, not allowing global settings in ALGoOrgSettings for TrustedNuGetFeeds, MemoryLimit and other things that should be possible to define globally
+
 ## v6.4
 
 ### Deprecations

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,8 @@
 ### Issues
 
+- Issue 1519 Submitting to AppSource WARNING: AuthContext.Scopes is .. should be
+- Issue 1521 Dependencies not installed for multi project incremental PR build
+- Issue 1522 Strange warnings in Deploy job post update to AL-Go 6.4
 - BcContainerHelper settings were only read from .github/AL-Go-Settings.json, not allowing global settings in ALGoOrgSettings for TrustedNuGetFeeds, MemoryLimit and other things that should be possible to define globally
 
 ## v6.4

--- a/Scenarios/settings.md
+++ b/Scenarios/settings.md
@@ -328,7 +328,8 @@ This functionality is also available in AL-Go for GitHub, by adding a file to th
 | InstallMissingDependencies | Install missing dependencies |
 | BackupBcContainerDatabases | Backup Databases in container for subsequent restore(s) |
 | RestoreDatabasesInBcContainer | Restore Databases in container |
-| InstallMissingDependencies | Install missing dependencies |
+| PreCompileApp | Custom script to run _before_ compiling an app. The script should accept the type of the app (`[string] $appType`) and a reference to the compilation parameters (`[ref] $compilationParams`).<br/>Possible values for `$appType` are: _app_, _testApp_, _bcptApp_.
+| PostCompileApp | Custom script to run _after_ compiling an app. The script should accept the file path of the produced .app file (`[string] $appFilePath`), the type of the app (`[string] $appType`), and a hashtable of the compilation parameters (`[hashtable] $compilationParams`).<br/>Possible values for `$appType` are: _app_, _testApp_, _bcptApp_.
 
 ## BcContainerHelper settings
 


### PR DESCRIPTION
BcContainerHelper settings was only read from .github/AL-Go-Settings.json, not allowing global settings in ALGoOrgSettings for TrustedNuGetFeeds, MemoryLimit and other things that should be possible to define globally

Added release notes for the bug fixes checked in yesterday