### PR TITLE
Legacy code signing

### DIFF
--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -140,7 +140,6 @@ try {
                 if ($base64encoded) {
                     Write-Host "Base64 encode secret"
                     $secretValue = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($secretValue))
-                    
                 }
                 $outSecrets += @{ "$secretsPropertyName" = $secretValue }
                 Write-Host "$($secretsPropertyName) successfully read from secret $secretName"

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -140,6 +140,7 @@ try {
                 if ($base64encoded) {
                     Write-Host "Base64 encode secret"
                     $secretValue = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($secretValue))
+                    
                 }
                 $outSecrets += @{ "$secretsPropertyName" = $secretValue }
                 Write-Host "$($secretsPropertyName) successfully read from secret $secretName"

--- a/Actions/ReadSecrets/ReadSecretsHelper.psm1
+++ b/Actions/ReadSecrets/ReadSecretsHelper.psm1
@@ -76,15 +76,12 @@ function GetGithubSecret {
     if ($script:gitHubSecrets.PSObject.Properties.Name -eq $secret) {
         $value = $script:githubSecrets."$secret"
         if ($value) {
-            MaskValue -key $envVar -value $value
             if ($encrypted) {
                 # Return encrypted string
-                return (ConvertTo-SecureString -String $value -AsPlainText -Force | ConvertFrom-SecureString)
+                $value = ConvertTo-SecureString -String $value -AsPlainText -Force | ConvertFrom-SecureString
             }
-            else {
-                # Return decrypted string
-                return $value
-            }
+            MaskValue -key $envVar -value $value
+            return $value
         }
     }
 
@@ -179,6 +176,7 @@ function GetKeyVaultSecret {
         if ($encrypted) {
             # Return encrypted string
             $value = $keyVaultSecret.SecretValue | ConvertFrom-SecureString
+            MaskValue -key $envVar -value $value
         }
         else {
             # Return decrypted string

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -86,7 +86,7 @@ try {
 
     $appBuild = $settings.appBuild
     $appRevision = $settings.appRevision
-    'licenseFileUrl','codeSignCertificateUrl','*codeSignCertificatePassword','keyVaultCertificateUrl','*keyVaultCertificatePassword','keyVaultClientId','gitHubPackagesContext','applicationInsightsConnectionString' | ForEach-Object {
+    'licenseFileUrl','codeSignCertificateUrl','codeSignCertificatePassword','keyVaultCertificateUrl','*keyVaultCertificatePassword','keyVaultClientId','gitHubPackagesContext','applicationInsightsConnectionString' | ForEach-Object {
         # Secrets might not be read during Pull Request runs
         if ($secrets.Keys -contains $_) {
             $value = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($secrets."$_"))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@
 - Issue 1522 Strange warnings in Deploy job post update to AL-Go 6.4
 - BcContainerHelper settings were only read from .github/AL-Go-Settings.json, not allowing global settings in ALGoOrgSettings for TrustedNuGetFeeds, MemoryLimit and other things that should be possible to define globally
 - Issue 1526 When updating AL-Go system files, the update process (creating a PR or directly pushing to the branch) fails when there is a file or directory in the repo with the same name as the branch that is to be updated
+- Legacy code signing stopped working
 
 ### Support for deploying to sandbox environments from a pull request
 


### PR DESCRIPTION
Legacy code signing stopped working

Base64 version of the encrypted version of secrets could be visible in the log. The secret would not be exposed as by using Base64 decoding you would get the encrypted version of the secret, which only can be decrypted on the runner on which it was encrypted - only if you have access to run code on that machine, you would be able to decrypt the secret.
