### PR TITLE
Support deploying AL-Go without OrgPAT

### DIFF
--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -151,19 +151,30 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        if: ${{ vars.APP_ID != '' }}
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Deploy
         env:
           branch: ${{ needs.Inputs.outputs.branch }}
           copyToMain: ${{ needs.Inputs.outputs.copyToMain }}
           directCommit: ${{ needs.Inputs.outputs.directCommit }}
           defaultBcContainerHelperVersion: ${{ needs.Inputs.outputs.defaultBcContainerHelperVersion }}
+          AuthToken: ${{ steps.app-token.outputs.token || Secrets.OrgPAT }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           try {
-            $token = '${{ Secrets.OrgPAT }}'
-            if (!$token) {
-              throw "In order to run the Deploy workflow, you need a Secret called OrgPAT containing a valid Personal Access Token"
+            # Check if auth token is set
+            if ($env:AuthToken -eq "") {
+              throw "In order to run the Deploy workflow, you need a Secret called OrgPAT containing a valid Personal Access Token or a GitHub app set up."
             }
+            Write-Host "Updating GitHub token"
+            $ENV:GITHUB_TOKEN = $env:AuthToken
             $githubOwner = "$env:GITHUB_REPOSITORY_OWNER"
             if ("$env:defaultBcContainerHelperVersion" -eq "") {
               if ($env:branch -eq 'preview') {
@@ -181,7 +192,7 @@ jobs:
                   "copyToMain" = ($env:copyToMain -eq 'true')
                   "defaultBcContainerHelperVersion" = $env:defaultBcContainerHelperVersion
             }
-            . ".\Internal\Deploy.ps1" -config $config -token $token -directCommit ($env:directCommit -eq 'true')
+            . ".\Internal\Deploy.ps1" -config $config -directCommit ($env:directCommit -eq 'true')
           }
           catch {
             Write-Host "::Error::Error deploying repositories. The error was $($_.Exception.Message)"

--- a/Internal/Deploy.ps1
+++ b/Internal/Deploy.ps1
@@ -2,8 +2,6 @@
 Param(
     [Parameter(Mandatory=$true)]
     [Hashtable] $config,
-    [Parameter(Mandatory=$true)]
-    [string] $token,
     [Parameter(Mandatory=$false)]
     [bool] $directCommit
 )
@@ -44,7 +42,6 @@ function PushChanges
     }
 }
 
-$token = GetAccessToken -token $token -repository "$($config.githubOwner)/.github"
 $oldPath = Get-Location
 try {
 
@@ -53,11 +50,6 @@ try {
     invoke-git config --global user.name "$($config.githubOwner)"
     invoke-git config --global hub.protocol https
     invoke-git config --global core.autocrlf false
-    $ENV:GITHUB_TOKEN = ''
-
-    Write-Host "Authenticating with GitHub using token"
-    $token | invoke-gh auth login --with-token
-    $ENV:GITHUB_TOKEN = $token
 
     # All references inside microsoft/AL-Go and forks of it are to microsoft/AL-Go-Actions@main, microsoft/AL-Go-PTE@main and microsoft/AL-Go-AppSource@main
     # When deploying to new repos, the originalOwnerAndRepo should be changed to the new owner and repo
@@ -71,10 +63,6 @@ try {
     $baseRepoPath = $ENV:GITHUB_WORKSPACE
     Write-Host "Base repo path: $baseRepoPath"
     Set-Location $baseRepoPath
-
-    # Whoami
-    $user = invoke-gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" user -silent -returnValue | ConvertFrom-Json
-    Write-Host "GitHub user: $($user.login)"
 
     # Dump configuration
     Write-Host "Configuration:"
@@ -162,12 +150,13 @@ try {
         Write-Host -ForegroundColor Yellow "Deploying to $repo"
 
         try {
-            $serverUrl = "https://$($config.githubOwner):$token@github.com/$($config.githubOwner)/$repo.git"
+            $serverUrl = "https://$($config.githubOwner)@github.com/$($config.githubOwner)/$repo.git"
             if (Test-Path $repo) {
                 Remove-Item $repo -Recurse -Force
             }
             invoke-git clone --quiet $serverUrl
             Set-Location $repo
+            invoke-gh auth setup-git
             try {
                 invoke-git checkout $branch
                 Get-ChildItem -Path "." -Exclude ".git" -Force | Remove-Item -Force -Recurse
@@ -186,6 +175,7 @@ try {
             invoke-gh repo create $ownerRepo --public --clone
             Start-Sleep -Seconds 10
             Set-Location $repo
+            invoke-gh auth setup-git
             invoke-git checkout -b $branch
             invoke-git commit --allow-empty -m 'init'
             invoke-git branch -M $branch


### PR DESCRIPTION
Rather than using a PAT to deploy AL-Go we should support deploying using a GitHub app. 