### PR TITLE
AL-Go E2E tests - Use GH_Token rather than passing token as parameter

### DIFF
--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -117,9 +117,10 @@ jobs:
         id: setup
         env:
           _bcContainerHelperVersion: ${{ github.event.inputs.bcContainerHelperVersion }}
+          GH_TOKEN: ${{ secrets.E2EPAT }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          . (Join-Path "." "e2eTests/SetupRepositories.ps1") -githubOwner '${{ needs.Check.outputs.githubowner }}' -e2epat '${{ Secrets.E2EPAT }}' -bcContainerHelperVersion $ENV:_bcContainerHelperVersion
+          . (Join-Path "." "e2eTests/SetupRepositories.ps1") -githubOwner '${{ needs.Check.outputs.githubowner }}' -bcContainerHelperVersion $ENV:_bcContainerHelperVersion
 
   Analyze:
     runs-on: [ ubuntu-latest ]

--- a/e2eTests/SetupRepositories.ps1
+++ b/e2eTests/SetupRepositories.ps1
@@ -1,6 +1,5 @@
 ﻿Param(
     [string] $githubOwner,
-    [string] $e2epat,
     [string] $bcContainerHelperVersion = ''
 )
 
@@ -24,7 +23,7 @@ $config = [ordered]@{
     "defaultBcContainerHelperVersion" = $bcContainerHelperVersion
 }
 
-. (Join-Path $PSScriptRoot "..\Internal\Deploy.ps1") -config $config -token $e2epat -DirectCommit $true
+. (Join-Path $PSScriptRoot "..\Internal\Deploy.ps1") -config $config -DirectCommit $true
 
 Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "actionsRepo=$actionsRepo"
 Write-Host "actionsRepo=$actionsRepo"


### PR DESCRIPTION
Use GH_Token rather than passing token as parameter

Current error: 
```
Deploy.ps1: /home/runner/work/AL-Go/AL-Go/e2eTests/SetupRepositories.ps1:27
Line |
  27 |  … PSScriptRoot "..\Internal\Deploy.ps1") -config $config -token $e2epat …
     |                                                           ~~~~~~
     | A parameter cannot be found that matches parameter name 'token'.
```