### PR TITLE
fix: use two-letter invariant culture

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -513,7 +513,7 @@ function MergeCustomObjectIntoOrderedDictionary {
                         if ($srcElmType -eq "PSCustomObject") {
                             # Array of objects are not checked for uniqueness
                             $ht = [ordered]@{}
-                            $srcElm.PSObject.Properties | Sort-Object -Property Name -Culture "iv-iv" | ForEach-Object {
+                            $srcElm.PSObject.Properties | Sort-Object -Property Name -Culture "iv" | ForEach-Object {
                                 $ht[$_.Name] = $_.Value
                             }
                             $dst."$prop" += @($ht)


### PR DESCRIPTION
When running `ReadSettings` within a Linux container the script fails at the `Sort-Object` line in `MergeCustomObjectIntoOrderedDictionary` with the following error:

```
Cannot bind parameter
     | 'Culture' to the target. Exception setting \"Culture\": \"Culture is not
     | supported. (Parameter 'name')\niv-iv is an invalid culture
     | identifier.\": Cannot bind parameter 'Culture' to the target. Exception
     | setting \"Culture\": \"Culture is not supported. (Parameter
     | 'name')\niv-iv is an invalid culture identifier.\": Exception setting
     | \"Culture\": \"Culture is not supported. (Parameter 'name')\niv-iv is an
     | invalid culture identifier.\": Culture is not supported. (Parameter
     | 'name')\niv-iv is an invalid culture identifier.
```

This is because within containers there's only a limited set of cultures available. While `iv-iv` works on a full OS, it is not working in the container while the two letter code for invariant culture works in all scenarios.

Container pwsh:
```
$PSVersionTable                   

Name                           Value
----                           -----
PSVersion                      7.4.7
PSEdition                      Core
GitCommitId                    7.4.7
OS                             Alpine Linux v3.20
Platform                       Unix
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```