### PR TITLE
Create $artifactsFolder only if it doesn't exist

### DIFF
--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -251,7 +251,9 @@ try {
             if ($latestRelease) {
                 Write-Host "Using $($latestRelease.name) (tag $($latestRelease.tag_name)) as previous release"
                 $artifactsFolder = Join-Path $baseFolder "artifacts"
-                New-Item $artifactsFolder -ItemType Directory | Out-Null
+                if(-not (Test-Path $artifactsFolder)) {
+                    New-Item $artifactsFolder -ItemType Directory | Out-Null
+                }
                 DownloadRelease -token $token -projects $project -api_url $ENV:GITHUB_API_URL -repository $ENV:GITHUB_REPOSITORY -release $latestRelease -path $artifactsFolder -mask "Apps"
                 $previousApps += @(Get-ChildItem -Path $artifactsFolder | ForEach-Object { $_.FullName })
             }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+### Issues
+
+- Issue 1630 Error when downloading a release, when the destination folder already exists.
+
 ## v7.0
 
 ### Issues


### PR DESCRIPTION
When downloading the previous release, the folder is always created.

However, in the case of issue #1630 the path already exists.

Fixes #1630 