### PR TITLE
Deployment - GitHub app auth and pin dependency

### DIFF
--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -151,7 +151,7 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
         id: app-token
         if: ${{ vars.APP_ID != '' }}
         with:

--- a/Internal/Deploy.ps1
+++ b/Internal/Deploy.ps1
@@ -50,6 +50,7 @@ try {
     invoke-git config --global user.name "$($config.githubOwner)"
     invoke-git config --global hub.protocol https
     invoke-git config --global core.autocrlf false
+    invoke-gh auth setup-git
 
     # All references inside microsoft/AL-Go and forks of it are to microsoft/AL-Go-Actions@main, microsoft/AL-Go-PTE@main and microsoft/AL-Go-AppSource@main
     # When deploying to new repos, the originalOwnerAndRepo should be changed to the new owner and repo
@@ -156,7 +157,6 @@ try {
             }
             invoke-git clone --quiet $serverUrl
             Set-Location $repo
-            invoke-gh auth setup-git
             try {
                 invoke-git checkout $branch
                 Get-ChildItem -Path "." -Exclude ".git" -Force | Remove-Item -Force -Recurse
@@ -175,7 +175,6 @@ try {
             invoke-gh repo create $ownerRepo --public --clone
             Start-Sleep -Seconds 10
             Set-Location $repo
-            invoke-gh auth setup-git
             invoke-git checkout -b $branch
             invoke-git commit --allow-empty -m 'init'
             invoke-git branch -M $branch


### PR DESCRIPTION
The PR moves gh auth setup-git up so it is run before trying to clone the repository. Additionally, the PR pins the dependency on actions/create-github-app-token

Related to #1636