### PR TITLE
Unknown dependencies only installed for test apps.

### DIFF
--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -277,10 +277,6 @@ else {
     throw "Artifact $artifactsFolder was not found. Make sure that the artifact files exist and files are not corrupted."
 }
 
-# Calculate unknown dependencies for all apps and known dependencies
-# $unknownDependencies = @()
-# Sort-AppFilesByDependencies -appFiles @($apps + $dependencies) -unknownDependencies ([ref]$unknownDependencies) -WarningAction SilentlyContinue | Out-Null
-
 Write-Host "Apps to deploy"
 $apps | ForEach-Object {
     Write-Host "- $([System.IO.Path]::GetFileName($_))"

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -193,6 +193,7 @@ if (-not $authContext) {
 
 $apps = @()
 $dependencies = @()
+$unknownDependencies = @()
 $artifactsFolder = Join-Path $ENV:GITHUB_WORKSPACE $artifactsFolder
 if (Test-Path $artifactsFolder -PathType Container) {
     $deploymentSettings.Projects.Split(',') | ForEach-Object {
@@ -268,6 +269,8 @@ if (Test-Path $artifactsFolder -PathType Container) {
                 }
             }
         }
+        # Calculate unknown dependencies for all apps and known dependencies
+        Sort-AppFilesByDependencies -appFiles @($projectTestApps + $dependencies) -unknownDependencies ([ref]$unknownDependencies) -WarningAction SilentlyContinue | Out-Null
     }
 }
 else {
@@ -275,8 +278,8 @@ else {
 }
 
 # Calculate unknown dependencies for all apps and known dependencies
-$unknownDependencies = @()
-Sort-AppFilesByDependencies -appFiles @($apps + $dependencies) -unknownDependencies ([ref]$unknownDependencies) -WarningAction SilentlyContinue | Out-Null
+# $unknownDependencies = @()
+# Sort-AppFilesByDependencies -appFiles @($apps + $dependencies) -unknownDependencies ([ref]$unknownDependencies) -WarningAction SilentlyContinue | Out-Null
 
 Write-Host "Apps to deploy"
 $apps | ForEach-Object {


### PR DESCRIPTION
Installation of unknown apps was originally added for the deploy test apps feature, however it was incorrectly made to find unknown dependencies for all apps, not just test apps. This fix changes the logic to only get unknown dependencies for test apps.