### PR TITLE
GithubPackageContext does not work together with private trustedNuGetFeeds

### DIFF
--- a/Actions/Deliver/Deliver.ps1
+++ b/Actions/Deliver/Deliver.ps1
@@ -240,6 +240,8 @@ foreach ($thisProject in $projectList) {
         catch {
             throw "$($deliveryTarget)Context secret is malformed. Needs to be formatted as Json, containing serverUrl and token as a minimum."
         }
+        # Do not search trusted NuGet feeds for packages when looking for whether packages have been delivered
+        $bcContainerHelperConfig.TrustedNuGetFeeds = @()
         'Apps','TestApps' | ForEach-Object {
             $folder = @(Get-ChildItem -Path (Join-Path $artifactsFolder "$project-$refname-$($_)-*.*.*.*") | Where-Object { $_.PSIsContainer })
             if ($folder.Count -gt 1) {

--- a/Actions/ReadSecrets/ReadSecrets.ps1
+++ b/Actions/ReadSecrets/ReadSecrets.ps1
@@ -139,7 +139,7 @@ try {
                 }
                 if ($base64encoded) {
                     Write-Host "Base64 encode secret"
-                    $secretValue = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($secretValue))
+                    $secretValue = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($secretValue.Trim()))
                 }
                 $outSecrets += @{ "$secretsPropertyName" = $secretValue }
                 Write-Host "$($secretsPropertyName) successfully read from secret $secretName"

--- a/Actions/ReadSecrets/ReadSecretsHelper.psm1
+++ b/Actions/ReadSecrets/ReadSecretsHelper.psm1
@@ -58,7 +58,7 @@ function MaskValue {
             Write-Host "::add-mask::$_"
         }
     }
-    Write-Host "::add-mask::$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($value.Trim())))"
+    Write-Host "::add-mask::$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($value)))"
 }
 
 function GetGithubSecret {

--- a/Actions/ReadSecrets/ReadSecretsHelper.psm1
+++ b/Actions/ReadSecrets/ReadSecretsHelper.psm1
@@ -58,7 +58,7 @@ function MaskValue {
             Write-Host "::add-mask::$_"
         }
     }
-    Write-Host "::add-mask::$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($value)))"
+    Write-Host "::add-mask::$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($value.Trim())))"
 }
 
 function GetGithubSecret {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,7 @@
 
 - Issue 1640 AL1040 error due to app folder within the artifacts cache being incorrectly recognized as an app folder
 - Issue 1630 Error when downloading a release, when the destination folder already exists.
+- Issue 1655 GithubPackageContext does not work together with private trustedNuGetFeeds
 
 ## v7.0
 


### PR DESCRIPTION
Secrets with teminating newlines might be exposed in the log

Fixes #1654 - GithubPackageContext does not work together with trustedNuGetFeeds
