### PR TITLE
Check release tag when creating a release

### DIFF
--- a/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
+++ b/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
@@ -56,7 +56,6 @@ if ($latestRelease -and $latestRelease.PSobject.Properties.name -eq "tag_name") 
             else {
                 OutputWarning -message "The release tag is older than the latest release tag. The app version is set to $appVersion, so the action will continue."
             }
-            throw "The release tag is older than the latest release tag."
         }
     }
     catch {

--- a/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
+++ b/Actions/CreateReleaseNotes/CreateReleaseNotes.ps1
@@ -1,6 +1,8 @@
 ﻿Param(
     [Parameter(HelpMessage = "The GitHub token running the action", Mandatory = $false)]
     [string] $token,
+    [Parameter(HelpMessage = "App Version", Mandatory = $true)]
+    [string] $appVersion,
     [Parameter(HelpMessage = "Tag name", Mandatory = $true)]
     [string] $tag_name,
     [Parameter(HelpMessage = "Last commit to include in release notes", Mandatory = $false)]
@@ -41,7 +43,28 @@ if ($latestRelease -and $latestRelease.PSobject.Properties.name -eq "target_comm
 $latestReleaseTag = ""
 if ($latestRelease -and $latestRelease.PSobject.Properties.name -eq "tag_name") {
     $latestReleaseTag = $latestRelease.tag_name
+    Write-Host "Latest release tag: $latestReleaseTag"
+    try {
+        $compareResult = CompareSemVerStrs -semVerStr1 $tag_name -semVerStr2 $latestReleaseTag
+        if ($compareResult -eq 0) {
+            OutputError "The release tag is the same as the latest release tag."
+        }
+        elseif ($compareResult -eq -1) {
+            if ($appVersion -eq 'latest') {
+                OutputError -message "The release tag is older than the latest release tag."
+            }
+            else {
+                OutputWarning -message "The release tag is older than the latest release tag. The app version is set to $appVersion, so the action will continue."
+            }
+            throw "The release tag is older than the latest release tag."
+        }
+    }
+    catch {
+        OutputWarning "Unable to compare the release tag $tag_name with the latest release tag $latestReleaseTag. The release might have been created manually."
+    }
 }
+
+
 
 try {
     $releaseNotes = GetReleaseNotes -token $token -api_url $ENV:GITHUB_API_URL -repository $ENV:GITHUB_REPOSITORY  -tag_name $tag_name -previous_tag_name $latestReleaseTag -target_commitish $target_commitish | ConvertFrom-Json

--- a/Actions/CreateReleaseNotes/README.md
+++ b/Actions/CreateReleaseNotes/README.md
@@ -14,6 +14,7 @@ none
 | :-- | :-: | :-- | :-- |
 | shell | | The shell (powershell or pwsh) in which the PowerShell script in this action should run | powershell |
 | token | | The GitHub token running the action | github.token |
+| appVersion | Yes | App version | |
 | tag_name | Yes | This release tag name | |
 | target_commitish | | Last commit to include in release notes | Latest |
 

--- a/Actions/CreateReleaseNotes/action.yaml
+++ b/Actions/CreateReleaseNotes/action.yaml
@@ -12,6 +12,9 @@ inputs:
     description: The GitHub token running the action
     required: false
     default: ${{ github.token }}
+  appVersion:
+    description: App version
+    required: true
   tag_name:
     description: Tag name
     required: true
@@ -34,11 +37,12 @@ runs:
       id: createreleasenotes
       env:
         _token: ${{ inputs.token }}
+        _appVersion: ${{ inputs.appVersion }}
         _tag_name: ${{ inputs.tag_name }}
         _target_commitish: ${{ inputs.target_commitish }}
       run: |
         ${{ github.action_path }}/../Invoke-AlGoAction.ps1 -ActionName "CreateReleaseNotes" -Action {
-          ${{ github.action_path }}/CreateReleaseNotes.ps1 -token $ENV:_token -tag_name $ENV:_tag_name -target_commitish $ENV:_target_commitish
+          ${{ github.action_path }}/CreateReleaseNotes.ps1 -token $ENV:_token -appVersion $ENV:_appVersion -tag_name $ENV:_tag_name -target_commitish $ENV:_target_commitish
         }
 branding:
   icon: terminal

--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -496,6 +496,40 @@ function SemVerStrToSemVerObj {
     }
 }
 
+# Compare SemVerStr1 and SemVerStr2
+# Returns -1 if SemVerStr1 < SemVerStrj2
+# Returns 1 if SemVerStr1 > SemVerStr2
+# Returns 0 if SemVerStr1 = SemVerStr2
+function CompareSemVerStrs {
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string] $semVerStr1,
+        [Parameter(Mandatory = $true)]
+        [string] $semVerStr2
+    )
+
+    Process {
+        $semVerObj1 = $semVerStr1 | SemVerStrToSemVerObj
+        $semVerObj2 = $semVerStr2 | SemVerStrToSemVerObj
+        $result = $semVerObj1.Major.CompareTo($semVerObj2.Major)
+        if ($result -eq 0) {
+            $result = $semVerObj1.Minor.CompareTo($semVerObj2.Minor)
+            if ($result -eq 0) {
+                $result = $semVerObj1.Patch.CompareTo($semVerObj2.Patch)
+                if ($result -eq 0) {
+                    for ($i=0; $i -lt 5; $i++) {
+                        $result = ("$($semVerObj1."Addt$i")".CompareTo("$($semVerObj2."Addt$i")"))
+                        if ($result -ne 0) {
+                            return $result
+                        }
+                    }
+                }
+            }
+        }
+        return $result
+    }
+}
+
 function GetReleases {
     Param(
         [string] $token,

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -212,6 +212,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/CreateReleaseNotes@main
         with:
           shell: powershell
+          appVersion: ${{ github.event.inputs.appVersion }}
           tag_name: ${{ github.event.inputs.tag }}
           target_commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
 

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -212,6 +212,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/CreateReleaseNotes@main
         with:
           shell: powershell
+          appVersion: ${{ github.event.inputs.appVersion }}
           tag_name: ${{ github.event.inputs.tag }}
           target_commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
 

--- a/Tests/GitHub-Helper.Test.ps1
+++ b/Tests/GitHub-Helper.Test.ps1
@@ -22,5 +22,19 @@
         { SemVerStrToSemVerObj -semVerStr 'v1.2.3-alpha.1.2.3.beta.5' } | Should -Throw
         { SemVerStrToSemVerObj -semVerStr 'v1.2.3-alpha.1.2.zzzz.beta.5' } | Should -Throw
 
+        CompareSemVerStrs -semVerStr1 '1.0.0' -semVerStr2 '1.0.0' | Should -Be 0
+        CompareSemVerStrs -semVerStr1 'v3.2.1' -semVerStr2 '3.2.1' | Should -Be 0
+        CompareSemVerStrs -semVerStr1 '1.0.0' -semVerStr2 '1.0.0' | Should -Be 0
+        CompareSemVerStrs -semVerStr1 '1.0.0' -semVerStr2 '1.0.1' | Should -Be -1
+        CompareSemVerStrs -semVerStr1 '1.0.0' -semVerStr2 '1.1.0' | Should -Be -1
+        CompareSemVerStrs -semVerStr1 '1.0.0' -semVerStr2 '2.0.0' | Should -Be -1
+        CompareSemVerStrs -semVerStr1 '2.0.1' -semVerStr2 '2.0.0' | Should -Be 1
+        CompareSemVerStrs -semVerStr1 '2.1.0' -semVerStr2 '2.0.0' | Should -Be 1
+        CompareSemVerStrs -semVerStr1 '2.0.0' -semVerStr2 '20.0.0' | Should -Be -1
+        CompareSemVerStrs -semVerStr1 '2.10.0' -semVerStr2 '2.1.0' | Should -Be 1
+        CompareSemVerStrs -semVerStr1 '2.10.2' -semVerStr2 '2.10.20' | Should -Be -1
+        CompareSemVerStrs -semVerStr1 '2.0.0' -semVerStr2 '2.0.0-alpha' | Should -Be 1
+        CompareSemVerStrs -semVerStr1 '2.0.0-alpha' -semVerStr2 '2.0.0-beta' | Should -Be -1
+        CompareSemVerStrs -semVerStr1 '1.2.3-alpha.1.2.3.beta' -semVerStr2 'v1.2.3-alpha.1.2.3.alpha' | Should -Be 1
     }
 }


### PR DESCRIPTION
This PR will check whether the latest release tag is lower than the release tag specified.

If this is not the case, you will get an error or a warning depending on whether you are creating a release based on the latest build (the default).

Fixes #1627
