### PR TITLE
fix: use invariante culture constant

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -513,7 +513,7 @@ function MergeCustomObjectIntoOrderedDictionary {
                         if ($srcElmType -eq "PSCustomObject") {
                             # Array of objects are not checked for uniqueness
                             $ht = [ordered]@{}
-                            $srcElm.PSObject.Properties | Sort-Object -Property Name -Culture "iv" | ForEach-Object {
+                            $srcElm.PSObject.Properties | Sort-Object -Property Name -Culture ([cultureinfo]::InvariantCulture) | ForEach-Object {
                                 $ht[$_.Name] = $_.Value
                             }
                             $dst."$prop" += @($ht)


### PR DESCRIPTION
The fix in #1633 didn't help us (seem I did something wrong during testing) but with the constant it did