### PR TITLE
Remove permissions from GitHub actions (are not allowed)

### DIFF
--- a/Actions/AddExistingApp/action.yaml
+++ b/Actions/AddExistingApp/action.yaml
@@ -1,8 +1,5 @@
 name: Add Existing App
 author: Microsoft Corporation
-permissions:
-  contents: write
-  pull-requests: write
 inputs:
   shell:
     description: Shell in which you want to run the action (powershell or pwsh)

--- a/Actions/CheckForUpdates/action.yaml
+++ b/Actions/CheckForUpdates/action.yaml
@@ -1,9 +1,5 @@
 name: Check For Updates
 author: Microsoft Corporation
-permissions:
-  contents: write
-  pull-requests: write
-  workflows: write
 inputs:
   shell:
     description: Shell in which you want to run the action (powershell or pwsh)

--- a/Actions/CreateApp/action.yaml
+++ b/Actions/CreateApp/action.yaml
@@ -1,8 +1,5 @@
 name: Create App
 author: Microsoft Corporation
-permissions:
-  contents: write
-  pull-requests: write
 inputs:
   shell:
     description: Shell in which you want to run the action (powershell or pwsh)

--- a/Actions/CreateDevelopmentEnvironment/action.yaml
+++ b/Actions/CreateDevelopmentEnvironment/action.yaml
@@ -1,8 +1,5 @@
 name: Create Development Environment
 author: Microsoft Corporation
-permissions:
-  contents: write
-  pull-requests: write
 inputs:
   shell:
     description: Shell in which you want to run the action (powershell or pwsh)

--- a/Actions/CreateReleaseNotes/action.yaml
+++ b/Actions/CreateReleaseNotes/action.yaml
@@ -1,8 +1,5 @@
 name: Create Release Notes
 author: Microsoft Corporation
-permissions:
-  contents: write
-  pull-requests: write
 inputs:
   shell:
     description: Shell in which you want to run the action (powershell or pwsh)

--- a/Actions/IncrementVersionNumber/action.yaml
+++ b/Actions/IncrementVersionNumber/action.yaml
@@ -1,8 +1,5 @@
 name: Increment Version Number
 author: Microsoft Corporation
-permissions:
-  contents: write
-  pull-requests: write
 inputs:
   shell:
     description: Shell in which you want to run the action (powershell or pwsh)

--- a/Tests/AddExistingApp.Action.Test.ps1
+++ b/Tests/AddExistingApp.Action.Test.ps1
@@ -18,13 +18,9 @@ Describe "AddExistingApp Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-            "contents" = "write"
-            "pull-requests" = "write"
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/AnalyzeTests.Test.ps1
+++ b/Tests/AnalyzeTests.Test.ps1
@@ -63,11 +63,9 @@ Describe "AnalyzeTests Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     It 'Test ReadBcptFile' {

--- a/Tests/BuildReferenceDocumentation.Action.Test.ps1
+++ b/Tests/BuildReferenceDocumentation.Action.Test.ps1
@@ -18,11 +18,9 @@ Describe "BuildReferenceDocumentation Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     It 'CalculateProjectsAndApps' {

--- a/Tests/CalculateArtifactNames.Test.ps1
+++ b/Tests/CalculateArtifactNames.Test.ps1
@@ -140,8 +140,6 @@ Describe 'CalculateArtifactNames Action Tests' {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
             "AppsArtifactsName" = "Artifacts name for Apps"
             "PowerPlatformSolutionArtifactsName" = "Artifacts name for PowerPlatform Solution"
@@ -155,6 +153,6 @@ Describe 'CalculateArtifactNames Action Tests' {
             "ContainerEventLogArtifactsName" = "Artifacts name for ContainerEventLog"
             "BuildMode" = "Build mode used when building the artifacts"
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 }

--- a/Tests/CheckForUpdates.Action.Test.ps1
+++ b/Tests/CheckForUpdates.Action.Test.ps1
@@ -15,14 +15,9 @@ Describe "CheckForUpdates Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-            "contents" = "write"
-            "pull-requests" = "write"
-            "workflows" = "write"
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     It 'Test YamlClass' {

--- a/Tests/CreateApp.Action.Test.ps1
+++ b/Tests/CreateApp.Action.Test.ps1
@@ -18,13 +18,9 @@ Describe "CreateApp Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-            "contents" = "write"
-            "pull-requests" = "write"
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/CreateDevelopmentEnvironment.Action.Test.ps1
+++ b/Tests/CreateDevelopmentEnvironment.Action.Test.ps1
@@ -18,13 +18,9 @@ Describe "CreateDevelopmentEnvironment Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-            "contents" = "write"
-            "pull-requests" = "write"
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/CreateReleaseNotes.Test.ps1
+++ b/Tests/CreateReleaseNotes.Test.ps1
@@ -22,15 +22,11 @@ Describe 'CreateReleaseNotes Tests' {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-            "contents" = "write"
-            "pull-requests" = "write"
-        }
         $outputs = [ordered]@{
             "ReleaseVersion" = "The release version"
             "ReleaseNotes" = "Release note generated based on the changes"
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     It 'Confirms that right functions are called' {

--- a/Tests/Deliver.Action.Test.ps1
+++ b/Tests/Deliver.Action.Test.ps1
@@ -18,11 +18,9 @@ Describe "Deliver Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/Deploy.Action.Test.ps1
+++ b/Tests/Deploy.Action.Test.ps1
@@ -18,12 +18,10 @@ Describe "Deploy Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
             "environmentUrl" = "The URL of the deployed environment"
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/DetermineArtifactUrl.Test.ps1
+++ b/Tests/DetermineArtifactUrl.Test.ps1
@@ -141,10 +141,8 @@ Describe "DetermineArtifactUrl Action Test" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 }

--- a/Tests/DetermineDeliveryTargets.Test.ps1
+++ b/Tests/DetermineDeliveryTargets.Test.ps1
@@ -29,13 +29,11 @@ Describe "DetermineDeliveryTargets Action Test" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
             "DeliveryTargetsJson" = "An array of Delivery Targets in compressed JSON format"
             "ContextSecrets" = "A comma-separated list of Context Secret names used"
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # PTE with NuGetContext secret defined, should yield NuGet

--- a/Tests/DetermineDeploymentEnvironments.Test.ps1
+++ b/Tests/DetermineDeploymentEnvironments.Test.ps1
@@ -37,8 +37,6 @@ Describe "DetermineDeploymentEnvironments Action Test" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
             "EnvironmentsMatrixJson" = "The Environment matrix to use for the Deploy step in compressed JSON format"
             "DeploymentEnvironmentsJson" = "Deployment Environments with settings in compressed JSON format"
@@ -47,7 +45,7 @@ Describe "DetermineDeploymentEnvironments Action Test" {
             "GenerateALDocArtifact" = "Flag determining whether to generate the ALDoc artifact"
             "DeployALDocArtifact" = "Flag determining whether to deploy the ALDoc artifact to GitHub Pages"
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # 2 environments defined in GitHub - no branch policy

--- a/Tests/GetWorkflowMultiRunBranches.Test.ps1
+++ b/Tests/GetWorkflowMultiRunBranches.Test.ps1
@@ -26,12 +26,10 @@ Describe "GetWorkflowMultiRunBranches Action" {
         }
 
         It 'Test action.yaml matches script' {
-            $permissions = [ordered]@{
-            }
             $outputs = [ordered]@{
                 "Result" = "JSON-formatted object with branches property, an array of branch names"
             }
-            YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+            YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
         }
     }
 

--- a/Tests/IncrementVersionNumber.Action.Test.ps1
+++ b/Tests/IncrementVersionNumber.Action.Test.ps1
@@ -19,13 +19,9 @@ Describe "IncrementVersionNumber Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-            "contents" = "write"
-            "pull-requests" = "write"
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/PipelineCleanup.Action.Test.ps1
+++ b/Tests/PipelineCleanup.Action.Test.ps1
@@ -18,11 +18,9 @@ Describe "PipelineCleanup Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/PullRequestStatusCheck.Test.ps1
+++ b/Tests/PullRequestStatusCheck.Test.ps1
@@ -20,11 +20,9 @@ Describe "PullRequestStatusCheck Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     It 'should fail if there is a job that fails' {

--- a/Tests/ReadPowerPlatformSettings.Action.Test.ps1
+++ b/Tests/ReadPowerPlatformSettings.Action.Test.ps1
@@ -207,8 +207,6 @@ Describe "Read Power Platform Settings Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
             "ppEnvironmentUrl" = "Power Platform Environment URL"
             "ppUserName" = "Power Platform Username"
@@ -219,6 +217,6 @@ Describe "Read Power Platform Settings Action Tests" {
             "companyId" = "Business Central Company Id"
             "environmentName" = "Business Central Environment Name"
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 }

--- a/Tests/ReadSecrets.Action.Test.ps1
+++ b/Tests/ReadSecrets.Action.Test.ps1
@@ -18,13 +18,11 @@ Describe "ReadSecrets Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
             "Secrets" = "All requested secrets in compressed JSON format"
             "TokenForPush" = "The token to use when workflows are pushing changes (either directly, or via pull requests)."
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/ReadSettings.Action.Test.ps1
+++ b/Tests/ReadSettings.Action.Test.ps1
@@ -18,13 +18,11 @@ Describe "ReadSettings Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
             "GitHubRunnerJson" = "GitHubRunner in compressed Json format"
             "GitHubRunnerShell" = "Shell for GitHubRunner jobs"
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/RunPipeline.Action.Test.ps1
+++ b/Tests/RunPipeline.Action.Test.ps1
@@ -18,11 +18,9 @@ Describe "RunPipeline Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/Sign.Test.ps1
+++ b/Tests/Sign.Test.ps1
@@ -18,11 +18,9 @@ Describe "Sign Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/TestActionsHelper.psm1
+++ b/Tests/TestActionsHelper.psm1
@@ -51,7 +51,6 @@ function YamlTest {
         [string] $scriptRoot,
         [string] $actionName,
         [string] $actionScript,
-        $permissions = @{},
         $outputs = @{}
     )
 
@@ -65,12 +64,6 @@ function YamlTest {
     $yaml = [System.Text.StringBuilder]::new()
     $yaml.AppendLine("name: *") | Out-Null
     $yaml.AppendLine("author: *") | Out-Null
-    if ($permissions -and $permissions.Count -gt 0) {
-        $yaml.AppendLine("permissions:") | Out-Null
-        $permissions.Keys | ForEach-Object {
-            $yaml.AppendLine("  $($_): $($permissions."$_")") | Out-Null
-        }
-    }
     $cmd = get-command $actionname
     $yaml.AppendLine("inputs:") | Out-Null
     $yaml.AppendLine("  shell:") | Out-Null

--- a/Tests/Troubleshooting.Test.ps1
+++ b/Tests/Troubleshooting.Test.ps1
@@ -18,11 +18,9 @@ Describe "Troubleshooting Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action

--- a/Tests/VerifyPRChanges.Action.Test.ps1
+++ b/Tests/VerifyPRChanges.Action.Test.ps1
@@ -138,10 +138,8 @@ Describe 'VerifyPRChanges Action Tests' {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 }

--- a/Tests/WorkflowInitialize.Test.ps1
+++ b/Tests/WorkflowInitialize.Test.ps1
@@ -18,12 +18,10 @@ Describe "WorkflowInitialize Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
           "telemetryScopeJson" = "A telemetryScope that covers the workflow"
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     It 'Test Test-AL-Go-Repository' {

--- a/Tests/WorkflowPostProcess.Test.ps1
+++ b/Tests/WorkflowPostProcess.Test.ps1
@@ -18,11 +18,9 @@ Describe "WorkflowPostProcess Action Tests" {
     }
 
     It 'Test action.yaml matches script' {
-        $permissions = [ordered]@{
-        }
         $outputs = [ordered]@{
         }
-        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -permissions $permissions -outputs $outputs
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs
     }
 
     # Call action


### PR DESCRIPTION
Originally, we had a permissions block in some of the GitHub actions.

That is not supported - not sure whether it ever was - the GITHUB_TOKEN is tranferred from the calling workflow and the action cannot request different permissions