### PR TITLE
Use App in E2E tests during setup

### DIFF
--- a/.github/workflows/CleanupTempRepos.yaml
+++ b/.github/workflows/CleanupTempRepos.yaml
@@ -58,6 +58,6 @@ jobs:
       - name: Cleanup Temp Repositories
         env:
           githubOwner: ${{ steps.getGitHubOwner.outputs.githubOwner }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token || Secrets.E2EPAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.E2EPAT }}
         run: |
           ${{ github.workspace }}/Internal/Scripts/RemoveTempRepos.ps1 -githubOwner $env:githubOwner

--- a/.github/workflows/CleanupTempRepos.yaml
+++ b/.github/workflows/CleanupTempRepos.yaml
@@ -30,7 +30,16 @@ jobs:
         with:
           egress-policy: audit
 
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        if: ${{ vars.E2E_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.E2E_APP_ID }}
+          private-key: ${{ secrets.E2E_PRIVATE_KEY }}
+          owner: ${{ github.event.inputs.githubOwner }}
+
       - name: Check E2EPAT Secret is defined
+        if: ${{ vars.E2E_APP_ID == '' }}
         run: |
           if ('${{ Secrets.E2EPAT }}' -eq '') {
             Write-Host "::Error::In order to run end to end tests, you need a Secret called E2EPAT containing a valid Personal Access Token with the following permissions: admin:org, delete_repo, repo, workflow, packages:write"
@@ -49,5 +58,6 @@ jobs:
       - name: Cleanup Temp Repositories
         env:
           githubOwner: ${{ steps.getGitHubOwner.outputs.githubOwner }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || Secrets.E2EPAT }}
         run: |
-          ${{ github.workspace }}/Internal/Scripts/RemoveTempRepos.ps1 -githubOwner $env:githubOwner -token '${{ Secrets.E2EPAT }}'
+          ${{ github.workspace }}/Internal/Scripts/RemoveTempRepos.ps1 -githubOwner $env:githubOwner

--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -125,7 +125,7 @@ jobs:
         id: setup
         env:
           _bcContainerHelperVersion: ${{ github.event.inputs.bcContainerHelperVersion }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token || Secrets.E2EPAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.E2EPAT }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           . (Join-Path "." "e2eTests/SetupRepositories.ps1") -githubOwner '${{ needs.Check.outputs.githubowner }}' -bcContainerHelperVersion $ENV:_bcContainerHelperVersion

--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -113,11 +113,19 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
 
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        if: ${{ vars.E2E_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.E2E_APP_ID }}
+          private-key: ${{ secrets.E2E_PRIVATE_KEY }}
+          owner: ${{ needs.Check.outputs.githubowner }}
+
       - name: Setup Repositories
         id: setup
         env:
           _bcContainerHelperVersion: ${{ github.event.inputs.bcContainerHelperVersion }}
-          GH_TOKEN: ${{ secrets.E2EPAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || Secrets.E2EPAT }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           . (Join-Path "." "e2eTests/SetupRepositories.ps1") -githubOwner '${{ needs.Check.outputs.githubowner }}' -bcContainerHelperVersion $ENV:_bcContainerHelperVersion
@@ -140,13 +148,22 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
 
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        if: ${{ vars.E2E_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.E2E_APP_ID }}
+          private-key: ${{ secrets.E2E_PRIVATE_KEY }}
+          owner: ${{ needs.Check.outputs.githubowner }}
+
       - name: Analyze
         id: Analyze
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || Secrets.E2EPAT }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $modulePath = Join-Path "." "e2eTests\e2eTestHelper.psm1" -resolve
           Import-Module $modulePath -DisableNameChecking
-          SetTokenAndRepository -github -githubOwner '${{ needs.Check.outputs.githubowner }}' -token '${{ Secrets.E2EPAT }}' -repository "microsoft/AL-Go"
           $maxParallel = [int]'${{ needs.Check.outputs.maxParallel }}'
 
           $publicTestruns = @{

--- a/Internal/Scripts/RemoveTempRepos.ps1
+++ b/Internal/Scripts/RemoveTempRepos.ps1
@@ -1,14 +1,10 @@
 param(
     [Parameter(Mandatory=$true, HelpMessage="The GitHub owner of the repositories to remove.")]
-    [string] $githubOwner,
-    [Parameter(Mandatory=$true, HelpMessage="The token use for the operation.")]
-    [string] $token
+    [string] $githubOwner
 )
 
 $ErrorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
 Import-Module (Join-Path "." "e2eTests/e2eTestHelper.psm1") -DisableNameChecking
-
-SetTokenAndRepository -github -githubOwner $githubOwner -token $token -repository ''
 
 @(invoke-gh repo list $githubOwner --limit 1000 -silent -returnValue) | ForEach-Object { $_.Split("`t")[0] } | Where-Object { "$_" -like "$githubOwner/tmp*" } | ForEach-Object {
     $repo = $_

--- a/e2eTests/scenarios/BCApps/runtest.ps1
+++ b/e2eTests/scenarios/BCApps/runtest.ps1
@@ -69,7 +69,7 @@ CreateAlGoRepository `
 $repoPath = (Get-Location).Path
 Write-Host "Repo Path: $repoPath"
 
-RunUpdateAlGoSystemFiles -directCommit -wait -templateUrl $template -ghTokenWorkflow $e2epat -repository $repository | Out-Null
+RunUpdateAlGoSystemFiles -directCommit -wait -templateUrl $template -ghTokenWorkflow $algoauthapp -repository $repository | Out-Null
 
 SetRepositorySecret -repository $repository -name 'GHTOKENWORKFLOW' -value $algoauthapp
 


### PR DESCRIPTION
This PR switches the E2E testing to use a GitHub app for setup and removal of the temp repositories. This is the first part of the work to remove our dependency on the E2EPAT wherever possible. Once this PR is merged, I will start working on using the same GitHub app for running the E2E tests. 

There are some places we will not be able to remove our dependency on the E2EPAT right now, but the goal (for now) is just to remove our dependency on the E2EPAT everywhere we can. 

Related to AB#573954