### PR TITLE
use basic parsing and ensure windows-latest in Update AL-Go System Files

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -48,7 +48,7 @@ if ($token) {
 # Use Authenticated API request if possible to avoid the 60 API calls per hour limit
 $headers = GetHeaders -token $ENV:GITHUB_TOKEN
 $templateRepositoryUrl = $templateUrl.Split('@')[0]
-$response = Invoke-WebRequest -Headers $headers -Method Head -Uri $templateRepositoryUrl -ErrorAction SilentlyContinue
+$response = Invoke-WebRequest -UseBasicParsing -Headers $headers -Method Head -Uri $templateRepositoryUrl -ErrorAction SilentlyContinue
 if (-not $response -or $response.StatusCode -ne 200) {
     # GITHUB_TOKEN doesn't have access to template repository, must be is private/internal
     # Get token with read permissions for the template repository

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,10 @@
 
 - Add top-level permissions for _Increment Version Number_ workflow
 
+### Issues
+
+- Issue 1697 Error in CheckForUpdates: "Internet Explorer engine is not available" when using self-hosted runners
+
 ## v7.1
 
 ### Issues

--- a/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -74,7 +74,7 @@ jobs:
   UpdateALGoSystemFiles:
     name: "[${{ matrix.branch }}] Update AL-Go System Files"
     needs: [ Initialize ]
-    runs-on: [ windows-latest ]
+    runs-on: windows-latest
     strategy:
       matrix:
         branch: ${{ fromJson(needs.Initialize.outputs.UpdateBranches).branches }}

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -74,7 +74,7 @@ jobs:
   UpdateALGoSystemFiles:
     name: "[${{ matrix.branch }}] Update AL-Go System Files"
     needs: [ Initialize ]
-    runs-on: [ windows-latest ]
+    runs-on: windows-latest
     strategy:
       matrix:
         branch: ${{ fromJson(needs.Initialize.outputs.UpdateBranches).branches }}

--- a/Tests/CheckForUpdates.Action.Test.ps1
+++ b/Tests/CheckForUpdates.Action.Test.ps1
@@ -116,5 +116,16 @@ Describe "CheckForUpdates Action Tests" {
         $permissionsContent.content[1].Trim() | Should -be 'actions: read'
     }
 
+    It 'Test that Update AL-Go System Files uses fixes runs-on' {
+        . (Join-Path $scriptRoot "yamlclass.ps1")
+
+        $updateYamlFile = Join-Path $scriptRoot "..\..\Templates\Per Tenant Extension\.github\workflows\UpdateGitHubGoSystemFiles.yaml"
+        $updateYaml = [Yaml]::Load($updateYamlFile)
+        $updateYaml.content | Where-Object { $_ -like '*runs-on:*' } | ForEach-Object {
+            $_.Trim() | Should -Be 'runs-on: windows-latest' -Because "Expected 'runs-on: windows-latest', in order to hardcode runner to windows-latest, but got $_"
+        }
+    }
+
+
     # Call action
 }


### PR DESCRIPTION
Fixes #1697

Also, modify runs-on in Update AL-Go System Files to `runs-on: windows-latest`, which doesn't get modified when running Update AL-Go System Files - to ensure that people doesn't get into the situation that they need to run Update AL-Go System Files to modify the runner and they cannot because the runner isn't running.

Added a test to ensure that Update AL-Go System Files stays hardcoded to windows-latest