### PR TITLE
Move power platform scenario to App Auth

### DIFF
--- a/.github/workflows/CleanupTempRepos.yaml
+++ b/.github/workflows/CleanupTempRepos.yaml
@@ -30,14 +30,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
-        id: app-token
-        if: ${{ vars.E2E_APP_ID != '' }}
-        with:
-          app-id: ${{ vars.E2E_APP_ID }}
-          private-key: ${{ secrets.E2E_PRIVATE_KEY }}
-          owner: ${{ github.event.inputs.githubOwner }}
-
       - name: Check E2EPAT Secret is defined
         if: ${{ vars.E2E_APP_ID == '' }}
         run: |
@@ -54,6 +46,14 @@ jobs:
           githubOwner: ${{ github.event.inputs.githubOwner }}
         run: |
           ${{ github.workspace }}/Internal/Scripts/GetOwnerForE2ETests.ps1 -githubOwner $env:githubOwner
+
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        if: ${{ vars.E2E_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.E2E_APP_ID }}
+          private-key: ${{ secrets.E2E_PRIVATE_KEY }}
+          owner: ${{ steps.getGitHubOwner.outputs.githubOwner }}
 
       - name: Cleanup Temp Repositories
         env:

--- a/e2eTests/scenarios/PowerPlatform/runtest.ps1
+++ b/e2eTests/scenarios/PowerPlatform/runtest.ps1
@@ -74,7 +74,7 @@ foreach($sourceRepo in $repositories) {
 
     # Upgrade AL-Go System Files to test version
     SetRepositorySecret -repository $repository -name 'GHTOKENWORKFLOW' -value $algoauthapp
-    RunUpdateAlGoSystemFiles -templateUrl $template -wait -repository $repository | Out-Null
+    RunUpdateAlGoSystemFiles -directCommit -templateUrl $template -wait -repository $repository | Out-Null
 
     CancelAllWorkflows -repository $repository
 

--- a/e2eTests/scenarios/PowerPlatform/runtest.ps1
+++ b/e2eTests/scenarios/PowerPlatform/runtest.ps1
@@ -73,10 +73,8 @@ foreach($sourceRepo in $repositories) {
     Write-Host "PowerPlatform Solution Folder: $($settings.powerPlatformSolutionFolder)"
 
     # Upgrade AL-Go System Files to test version
-    # TODO: Use e2epat until bcsamples powerplatform repositories have been updated to latest version
-    RunUpdateAlGoSystemFiles -directCommit -wait -templateUrl $template -ghTokenWorkflow $e2epat -repository $repository | Out-Null
-
     SetRepositorySecret -repository $repository -name 'GHTOKENWORKFLOW' -value $algoauthapp
+    RunUpdateAlGoSystemFiles -templateUrl $template -wait -repository $repository | Out-Null
 
     CancelAllWorkflows -repository $repository
 


### PR DESCRIPTION
* Move power platform scenario to App Auth
* Use the GitHub owner output by GetOwnerForE2ETests during cleanup. Fixes this issue: https://github.com/microsoft/AL-Go/actions/runs/14750830165

The following PRs need to be merged before this one can go in: 
* https://github.com/microsoft/bcsamples-warehousehelper/pull/5
* https://github.com/microsoft/bcsamples-takeorder/pull/13
* https://github.com/microsoft/bcsamples-CoffeeMR/pull/7

Related to [AB#573954](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/573954)