### PR TITLE
Removing downloadedAppsByType variable.

### DIFF
--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -464,15 +464,9 @@ function Get-UnmodifiedAppsFromBaselineWorkflowRun {
         }
     }
     $additionalDataForTelemetry = [System.Collections.Generic.Dictionary[[System.String], [System.String]]]::new()
-    $downloadedAppsByType = @()
     $appsToDownload.Keys | ForEach-Object {
         $appType = $_
         $mask = $appsToDownload."$appType".Mask
-        $thisDownloadedAppsType = @{
-            "type" = $appType
-            "mask" = $mask
-            "downloadedApps" = @()
-        }
         $downloads = $appsToDownload."$appType".Downloads
         $thisArtifactFolder = Join-Path $buildArtifactFolder $mask
         if (!(Test-Path $thisArtifactFolder)) {
@@ -507,7 +501,6 @@ function Get-UnmodifiedAppsFromBaselineWorkflowRun {
                         Write-Host "Copy $($item.Name) to build folders"
                         Copy-Item -Path $item.FullName -Destination $thisArtifactFolder -Force
                         $appsToDownload."$appType".Downloaded++
-                        $thisDownloadedAppsType.downloadedApps += $item.Name
                     }
                 }
             }
@@ -515,11 +508,8 @@ function Get-UnmodifiedAppsFromBaselineWorkflowRun {
         }
         $additionalDataForTelemetry.Add("$($appType)ToDownload", $appsToDownload."$appType".Downloads.Count)
         $additionalDataForTelemetry.Add("$($appType)Downloaded", $appsToDownload."$appType".Downloaded)
-        $downloadedAppsByType += $thisDownloadedAppsType
     }
     Trace-Information -Message "Incremental builds (apps)" -AdditionalData $additionalDataForTelemetry
-
-    return $downloadedAppsByType
 }
 
 Export-ModuleMember *-*

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -127,7 +127,6 @@ try {
     $buildArtifactFolder = Join-Path $projectPath ".buildartifacts"
     New-Item $buildArtifactFolder -ItemType Directory | Out-Null
 
-    $downloadedAppsByType = @()
     if ($baselineWorkflowSHA -and $baselineWorkflowRunId -ne '0' -and $settings.incrementalBuilds.mode -eq 'modifiedApps') {
         # Incremental builds are enabled and we are only building modified apps
         try {
@@ -142,7 +141,7 @@ try {
         if (!$buildAll) {
             Write-Host "Get unmodified apps from baseline workflow run"
             # Downloaded apps are placed in the build artifacts folder, which is detected by Run-AlPipeline, meaning only non-downloaded apps are built
-            $downloadedAppsByType = Get-UnmodifiedAppsFromBaselineWorkflowRun `
+            Get-UnmodifiedAppsFromBaselineWorkflowRun `
                 -token $token `
                 -settings $settings `
                 -baseFolder $baseFolder `


### PR DESCRIPTION
downloadedAppsByType was added in a previous PR in order to remove downloaded apps from the build folder, and only keep ones that were built. This feature was later removed again, but the variable remained. 
As it is no longer used, and generating a warning, it is getting removed.