### PR TITLE
Fix PSScriptAnalyzer warning in AL-Go-Helper.ps1

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1251,12 +1251,12 @@ function CheckAppDependencyProbingPaths {
                                 foreach($propertyName in "appFolders", "testFolders", "bcptTestFolders") {
                                     Write-Host "Adding folders from $depProject to $propertyName in $project"
                                     $found = $false
-                                    foreach($_ in $depSettings."$propertyName") {
-                                        $folder = Resolve-Path -Path (Join-Path $baseFolder "$depProject/$_") -Relative
-                                        if (!$settings."$propertyName".Contains($folder)) {
-                                            $settings."$propertyName" += @($folder)
+                                    foreach($folder in $depSettings."$propertyName") {
+                                        $relativeFolderPath = Resolve-Path -Path (Join-Path $baseFolder "$depProject/$folder") -Relative
+                                        if (!$settings."$propertyName".Contains($relativeFolderPath)) {
+                                            $settings."$propertyName" += @($relativeFolderPath)
                                             $found = $true
-                                            Write-Host "- $folder"
+                                            Write-Host "- $relativeFolderPath"
                                         }
                                     }
                                     if (!$found) { Write-Host "- No folders added" }


### PR DESCRIPTION
Fix PSScriptAnalyzer warning:
```
The Variable '_' is an automatic variable that is built into PowerShell, assigning to it might have undesired side effects. If assignment is not by design, please use a different name.
```