### PR TITLE
end 2 end test failures

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -487,6 +487,9 @@ function GetModifiedSettingsContent {
 
     $dstSettings | Add-Member -MemberType NoteProperty -Name "$schemaKey" -Value $schemaValue -Force
 
+    # Make sure the $schema property is the first property in the object
+    $dstSettings = $dstSettings | Select-Object @{ Name = '$schema'; Expression = { $_.'$schema' } }, * -ExcludeProperty '$schema'
+
     return $dstSettings | ConvertTo-JsonLF
 }
 

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -251,8 +251,6 @@ else {
 
         invoke-git status
 
-        UpdateSettingsFile -settingsFile (Join-Path ".github" "AL-Go-Settings.json") -updateSettings @{ "templateUrl" = $templateUrl; "templateSha" = $templateSha }
-
         # Update the files
         # Calculate the release notes, while updating
         $releaseNotes = ""
@@ -287,6 +285,9 @@ else {
             Write-Host "Remove $_"
             Remove-Item (Join-Path (Get-Location).Path $_) -Force
         }
+
+        # Update the templateUrl and templateSha in the repo settings file
+        UpdateSettingsFile -settingsFile (Join-Path ".github" "AL-Go-Settings.json") -updateSettings @{ "templateUrl" = $templateUrl; "templateSha" = $templateSha }
 
         Write-Host "ReleaseNotes:"
         Write-Host $releaseNotes

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -244,6 +244,7 @@ jobs:
   UploadArtifacts:
     needs: [ CreateRelease ]
     runs-on: [ windows-latest ]
+    name: Upload ${{ matrix.name }}
     strategy:
       matrix: ${{ fromJson(needs.CreateRelease.outputs.artifacts) }}
       fail-fast: true

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -244,6 +244,7 @@ jobs:
   UploadArtifacts:
     needs: [ CreateRelease ]
     runs-on: [ windows-latest ]
+    name: Upload ${{ matrix.name }}
     strategy:
       matrix: ${{ fromJson(needs.CreateRelease.outputs.artifacts) }}
       fail-fast: true


### PR DESCRIPTION
ReleaseBranches failed due to .zip files having paths which are too long for Expand-Archive to handle,

Incremental builds failed because the new json schema changed the file by moving the schema to the end of the .json file always and also remove the templateSha setting - set shortly before the updatefiles.