### PR TITLE
Remove deprecated cleanModePreprocessorSymbols (April 1st 2025)

### DIFF
--- a/Actions/AL-Go-TestRepoHelper.ps1
+++ b/Actions/AL-Go-TestRepoHelper.ps1
@@ -49,11 +49,6 @@ function Test-Deprecations {
         [string] $settingsDescription
     )
 
-    # cleanModePreprocessorSymbols is deprecated
-    if ($json.Keys -contains 'cleanModePreprocessorSymbols') {
-        OutputWarning -Message "cleanModePreprocessorSymbols in $settingsDescription is deprecated. See https://aka.ms/algodeprecations#cleanModePreprocessorSymbols"
-    }
-
     # <workflowName>Schedule is deprecated
     ($json.Keys | Where-Object {$_ -like '*Schedule' -and $_ -ne 'WorkflowSchedule'}) | ForEach-Object {
         OutputWarning -Message "$_ in $settingsDescription is deprecated. See https://aka.ms/algodeprecations#_workflow_Schedule. This warning will become an error in the future."

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -466,14 +466,6 @@ try {
         $runAlPipelineParams["preprocessorsymbols"] = @()
     }
 
-    # DEPRECATION: REMOVE AFTER April 1st 2025 --->
-    if ($buildMode -eq 'Clean' -and $settings.ContainsKey('cleanModePreprocessorSymbols')) {
-        Write-Host "Adding Preprocessor symbols : $($settings.cleanModePreprocessorSymbols -join ',')"
-        $runAlPipelineParams["preprocessorsymbols"] += $settings.cleanModePreprocessorSymbols
-        Trace-DeprecationWarning -Message "cleanModePreprocessorSymbols is deprecated" -DeprecationTag "cleanModePreprocessorSymbols"
-    }
-    # <--- REMOVE AFTER April 1st 2025
-
     if ($settings.ContainsKey('preprocessorSymbols')) {
         Write-Host "Adding Preprocessor symbols : $($settings.preprocessorSymbols -join ',')"
         $runAlPipelineParams["preprocessorsymbols"] += $settings.preprocessorSymbols

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+### Removed functionality
+
+As stated in [AL-Go Deprecations](https://aka.ms/algodeprecations#cleanModePreprocessorSymbols), setting `cleanModePreprocessorSymbols` is now longer supported and will be ignored by AL-Go for GitHub.
+
 ### Security
 
 - Add top-level permissions for _Increment Version Number_ workflow


### PR DESCRIPTION
`cleanModePreprocessorSymbols` setting is deprecated and references need to be removed