### PR TITLE
Sign apps during 'Test XXX' workflows

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -25,7 +25,7 @@ By setting failOn to 'newWarning', pull requests will fail if new warnings are i
 
 ### Signing apps during 'Test Next Major', 'Test Next Minor' and 'Test Current' workflows
 
-App artifacts produced in 'Test Next Major', 'Test Next Minor' and 'Test Current' workflows are now signed by default. In order to skip signing, you must set `doNotSignApps` setting to `false`, either as a conditional setting or a workflow-specific setting.
+App artifacts produced in 'Test Next Major', 'Test Next Minor' and 'Test Current' workflows are now signed by default. In order to skip signing, you must set `doNotSignApps` setting to `true`, either as a conditional setting or a workflow-specific setting.
 
 ## v7.1
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,3 @@
-
 ### Security
 
 - Add top-level permissions for _Increment Version Number_ workflow

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
+
 ### Security
 
 - Add top-level permissions for _Increment Version Number_ workflow
@@ -22,6 +23,10 @@ AL-Go for GitHub settings now has a schema. The following line is added at the b
 ### Failing pull requests if new warnings are added
 
 By setting failOn to 'newWarning', pull requests will fail if new warnings are introduced. This feature compares the warnings in the pull request build against those in the latest successful CI/CD build and fails if new warnings are detected.
+
+### Signing apps during 'Test Next Major', 'Test Next Minor' and 'Test Current' workflows
+
+App artifacts produced in 'Test Next Major', 'Test Next Minor' and 'Test Current' workflows are now signed by default. In order to skip signing, you must set `doNotSignApps` setting to `false`, either as a conditional setting or a workflow-specific setting.
 
 ## v7.1
 

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -193,7 +193,6 @@ jobs:
       baselineWorkflowRunId: ${{ needs.Initialization.outputs.baselineWorkflowRunId }}
       baselineWorkflowSHA: ${{ needs.Initialization.outputs.baselineWorkflowSHA }}
       secrets: 'licenseFileUrl,codeSignCertificateUrl,*codeSignCertificatePassword,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
-      signArtifacts: true
       useArtifactCache: true
 
   DeployALDoc:

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -65,10 +65,6 @@ on:
         required: false
         default: ''
         type: string
-      signArtifacts:
-        description: Flag indicating whether the apps should be signed
-        type: boolean
-        default: false
       useArtifactCache:
         description: Flag determining whether to use the Artifacts Cache
         type: boolean
@@ -179,7 +175,7 @@ jobs:
 
       - name: Sign
         id: sign
-        if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
+        if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
         uses: microsoft/AL-Go-Actions/Sign@main
         with:
           shell: ${{ inputs.shell }}

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -193,7 +193,6 @@ jobs:
       baselineWorkflowRunId: ${{ needs.Initialization.outputs.baselineWorkflowRunId }}
       baselineWorkflowSHA: ${{ needs.Initialization.outputs.baselineWorkflowSHA }}
       secrets: 'licenseFileUrl,codeSignCertificateUrl,*codeSignCertificatePassword,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
-      signArtifacts: true
       useArtifactCache: true
 
   BuildPP:

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -65,10 +65,6 @@ on:
         required: false
         default: ''
         type: string
-      signArtifacts:
-        description: Flag indicating whether the apps should be signed
-        type: boolean
-        default: false
       useArtifactCache:
         description: Flag determining whether to use the Artifacts Cache
         type: boolean
@@ -179,7 +175,7 @@ jobs:
 
       - name: Sign
         id: sign
-        if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
+        if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
         uses: microsoft/AL-Go-Actions/Sign@main
         with:
           shell: ${{ inputs.shell }}


### PR DESCRIPTION
Sign apps produced in 'Test Next Major', 'Test Next Minor' and 'Test Current' workflows.

Fixes #1750 