### PR TITLE
Update E2E tests to only run upgrades on supported versions

### DIFF
--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -35,7 +35,7 @@ on:
         default: 'preview'
 
 env:
-  TestUpgradesFromVersion: 'v3.1'
+  TestUpgradesFromVersion: 'v5.0'
 
 defaults:
   run:


### PR DESCRIPTION
Update E2E tests to only run upgrades on supported versions. Versions lower than 5.0 will soon no longer work since they rely on direct access to our storage account (not through AFD)