### PR TITLE
Fixed access issue when Publishing from PR in private repo.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@ AL-Go now offers a dataexplorer dashboard to get started with AL-Go telemetry. A
 ### Issues
 
 - Issue 1770: Wrong type of _projects_ setting in settings schema
+- Issue 1787: Publish to Environment from PR fails in private repos
 
 ## v7.2
 

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -15,6 +15,8 @@ permissions:
   actions: read
   contents: read
   id-token: write
+  pull-requests: read
+  checks: read
 
 defaults:
   run:

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -16,6 +16,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  checks: read
 
 defaults:
   run:

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -15,7 +15,7 @@ permissions:
   actions: read
   contents: read
   id-token: write
-  pull_requests: read
+  pull-requests: read
 
 defaults:
   run:

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -15,6 +15,7 @@ permissions:
   actions: read
   contents: read
   id-token: write
+  pull_requests: read
 
 defaults:
   run:


### PR DESCRIPTION
When using the Pubish to Environment workflow, targeting a PR in a private repo, the flow will fail with a permission issue, as the Github token does not have access to read the PR and PR annotations.
I have updated the permissions of the workflow to allow the Github token to access these.

Issue #1787 