### PR TITLE
Improve E2E test Stability

### DIFF
--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -67,7 +67,8 @@ function RefreshToken {
             throw "Token not set."
         }
 
-        # Check if the last token refresh was more than 30 minutes ago
+        # Check if the last token refresh was more than 10 minutes ago
+
         if ((-not $force) -and ($script:lastTokenRefresh -ne 0) -and (([DateTime]::Now - $script:lastTokenRefresh).TotalMinutes -lt 10)) {
             return
         }

--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -68,7 +68,7 @@ function RefreshToken {
         }
 
         # Check if the last token refresh was more than 30 minutes ago
-        if ((-not $force) -and ($script:lastTokenRefresh -ne 0) -and (([DateTime]::Now - $script:lastTokenRefresh).TotalMinutes -lt 30)) {
+        if ((-not $force) -and ($script:lastTokenRefresh -ne 0) -and (([DateTime]::Now - $script:lastTokenRefresh).TotalMinutes -lt 10)) {
             return
         }
 

--- a/e2eTests/scenarios/FederatedCredentials/runtest.ps1
+++ b/e2eTests/scenarios/FederatedCredentials/runtest.ps1
@@ -137,7 +137,7 @@ $noOfApps = 0
 Get-Item "signedApps/Main App-main-Apps-$($newVersion.Major).$($newVersion.Minor).$($newVersion.Build).*/*.app" | ForEach-Object {
     $appFile = $_.FullName
     Write-Host "Check that $appFile was signed"
-    [System.Text.Encoding]::Ascii.GetString([System.IO.File]::ReadAllBytes($appFile)).indexof('DigiCert Trusted G4 RSA4096 SHA256 TimeStamping CA') | Should -BeGreaterThan -1
+    [System.Text.Encoding]::Ascii.GetString([System.IO.File]::ReadAllBytes($appFile)).indexof('DigiCert Trusted G4 TimeStamping RSA4096 SHA') | Should -BeGreaterThan -1
     $noOfApps++
 }
 # Check that two apps were signed


### PR DESCRIPTION
### ❔What, Why & How

<!-- Include description of the changes that will help reviewers in their task -->
* Refresh E2E access token more aggressively
* Update how app signing is validated 
