### PR TITLE
Update each app.json once when running Increment Version Number

### DIFF
--- a/Actions/IncrementVersionNumber/IncrementVersionNumber.ps1
+++ b/Actions/IncrementVersionNumber/IncrementVersionNumber.ps1
@@ -57,8 +57,8 @@ if ($projectList.Count -eq 0 -and $PPprojects.Count -eq 0) {
 $repositorySettingsPath = Join-Path $baseFolder $RepoSettingsFile # $RepoSettingsFile is defined in AL-Go-Helper.ps1
 
 # Increment version number in AL Projects
+$allAppFolders = @()
 if ($projectList.Count -gt 0) {
-    $allAppFolders = @()
     $repoVersionExistsInRepoSettings = Test-SettingExists -settingsFilePath $repositorySettingsPath -settingName 'repoVersion'
     $repoVersionInRepoSettingsWasUpdated = $false
     foreach ($project in $projectList) {
@@ -89,25 +89,13 @@ if ($projectList.Count -gt 0) {
         $projectSettings = ReadSettings -baseFolder $baseFolder -project $project
         ResolveProjectFolders -baseFolder $baseFolder -project $project -projectSettings ([ref] $projectSettings)
 
-        # Set version in app manifests (app.json files)
-        Set-VersionInAppManifests -projectPath $projectPath -projectSettings $projectSettings -newValue $versionNumber
-
-        # Collect all project's app folders
-        $allAppFolders += $projectSettings.appFolders | ForEach-Object { Join-Path $projectPath $_ -Resolve }
-        $allAppFolders += $projectSettings.testFolders | ForEach-Object { Join-Path $projectPath $_ -Resolve }
-        $allAppFolders += $projectSettings.bcptTestFolders | ForEach-Object { Join-Path $projectPath $_ -Resolve }
+        Set-VersionInAppManifests -projectPath $projectPath -projectSettings $projectSettings -newValue $versionNumber -updatedAppFolders ([ref] $allAppFolders)
     }
+}
 
-    if (-not $skipUpdatingDependencies) {
-        # Set dependencies in app manifests
-        if ($allAppFolders.Count -eq 0) {
-            Write-Host "No App folders found for projects $projects"
-        }
-        else {
-            # Set dependencies in app manifests
-            Set-DependenciesVersionInAppManifests -appFolders $allAppFolders
-        }
-    }
+if (-not $skipUpdatingDependencies) {
+    # Set dependencies in app manifests
+    Set-DependenciesVersionInAppManifests -appFolders $allAppFolders
 }
 
 # Increment version number in PowerPlatform Solution

--- a/Actions/IncrementVersionNumber/IncrementVersionNumber.psm1
+++ b/Actions/IncrementVersionNumber/IncrementVersionNumber.psm1
@@ -189,8 +189,10 @@ function Test-SettingExists {
         Name of the project (relative to the base folder).
     .Parameter newValue
         New version number. If the version number starts with a +, the new version number will be added to the old version number. Else the new version number will replace the old version number.
+    .Parameter updatedAppFolders
+        [ref] Array of paths to the app folders that were updated. This is used to avoid updating the same app folder multiple times.
 #>
-function Set-VersionInAppManifests($projectPath, $projectSettings, $newValue) {
+function Set-VersionInAppManifests($projectPath, $projectSettings, $newValue, [ref] $updatedAppFolders) {
 
     # Check if the project uses repoVersion versioning strategy
     $useRepoVersion = (($projectSettings.PSObject.Properties.Name -eq "versioningStrategy") -and (($projectSettings.versioningStrategy -band 16) -eq 16))
@@ -201,10 +203,15 @@ function Set-VersionInAppManifests($projectPath, $projectSettings, $newValue) {
     $allAppFolders = @($projectSettings.appFolders) + @($projectSettings.testFolders) + @($projectSettings.bcptTestFolders)
     # Set version in app.json files
     $allAppFolders | ForEach-Object {
-        $appFolder = Join-Path $projectPath $_
-        $appJson = Join-Path $appFolder "app.json"
+        $appFolder = Join-Path $projectPath $_ -Resolve
 
-        Set-VersionInSettingsFile -settingsFilePath $appJson -settingName 'version' -newValue $newValue
+        # Update the app only if it's not already updated
+        if (-not ($updatedAppFolders.Value -contains $appFolder)) {
+            $appJson = Join-Path $appFolder "app.json"
+            Set-VersionInSettingsFile -settingsFilePath $appJson -settingName 'version' -newValue $newValue
+
+            $updatedAppFolders.Value += @($appFolder)
+        }
     }
 }
 


### PR DESCRIPTION
### ❔What, Why & How

Fix Increment Version Number to only change the versions in app.json-s only once. The issue manifests when "+0.1" is used as a parameter to increment the version number.

Related to issue: #1774 

### ✅ Checklist

- [ ] Add tests (E2E, unit tests)
- [ ] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
