### PR TITLE
Fix PR build publishing failing when branch name includes a slash

### DIFF
--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -240,18 +240,21 @@ if (Test-Path $artifactsFolder -PathType Container) {
             $refname = (GetHeadRefFromPRId -repository $ENV:GITHUB_REPOSITORY -prId $prId -token $token).Replace('/','_')
         }
         Write-Host "project '$project'"
-
+        
         $allApps = @()
+        OutputDebug -message "projectApps filter: $project-$refname-$($buildMode)Apps-$artifactVersionFilter"
         $projectApps = @((Get-ChildItem -Path $artifactsFolder -Filter "$project-$refname-$($buildMode)Apps-$artifactVersionFilter") | ForEach-Object { $_.FullName })
         $projectTestApps = @()
         if ($deploymentSettings.includeTestAppsInSandboxEnvironment) {
             Write-Host "Including test apps for deployment"
+            OutputDebug -message "projectTestApps filter: $project-$refname-$($buildMode)TestApps-$artifactVersionFilter"
             $projectTestApps = @((Get-ChildItem -Path $artifactsFolder -Filter "$project-$refname-$($buildMode)TestApps-$artifactVersionFilter") | ForEach-Object { $_.FullName })
         }
         if ($deploymentSettings.excludeAppIds) {
             Write-Host "Excluding apps with ids $($deploymentSettings.excludeAppIds) from deployment"
         }
         if ($deploymentSettings.DependencyInstallMode -ne "ignore") {
+            OutputDebug -message "projectDependencies filter: $project-$refname-$($buildMode)Dependencies-$artifactVersionFilter/*.app"
             $dependencies += @((Get-ChildItem -Path (Join-Path $artifactsFolder "$project-$refname-$($buildMode)Dependencies-$artifactVersionFilter/*.app")) | ForEach-Object { $_.FullName } )
         }
         if (!($projectApps)) {

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -237,7 +237,7 @@ if (Test-Path $artifactsFolder -PathType Container) {
                 throw "Invalid PR id: $prId"
             }
             $artifactVersionFilter = "PR$prId-*"
-            $refname = GetHeadRefFromPRId -repository $ENV:GITHUB_REPOSITORY -prId $prId -token $token
+            $refname = (GetHeadRefFromPRId -repository $ENV:GITHUB_REPOSITORY -prId $prId -token $token).Replace('/','_')
         }
         Write-Host "project '$project'"
 

--- a/Actions/Deploy/Deploy.ps1
+++ b/Actions/Deploy/Deploy.ps1
@@ -240,7 +240,7 @@ if (Test-Path $artifactsFolder -PathType Container) {
             $refname = (GetHeadRefFromPRId -repository $ENV:GITHUB_REPOSITORY -prId $prId -token $token).Replace('/','_')
         }
         Write-Host "project '$project'"
-        
+
         $allApps = @()
         OutputDebug -message "projectApps filter: $project-$refname-$($buildMode)Apps-$artifactVersionFilter"
         $projectApps = @((Get-ChildItem -Path $artifactsFolder -Filter "$project-$refname-$($buildMode)Apps-$artifactVersionFilter") | ForEach-Object { $_.FullName })

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -30,7 +30,7 @@ Please note, that due to certain security limitations, the properties `runs-on`,
 - Issue 1787 Publish to Environment from PR fails in private repos
 - Issue 1722 Check if apps are already installed on a higher version before deploying
 - Issue 1774 Increment Version Number with +0.1 can increment some version numbers twice
-- Issue 1837 Deployment from PR builds fail if PR branch name includes
+- Issue 1837 Deployment from PR builds fail if PR branch name includes forward slashes (e.g., `feature/branch-name`).
 
 ### Additional debug logging functionality
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -30,6 +30,7 @@ Please note, that due to certain security limitations, the properties `runs-on`,
 - Issue 1787 Publish to Environment from PR fails in private repos
 - Issue 1722 Check if apps are already installed on a higher version before deploying
 - Issue 1774 Increment Version Number with +0.1 can increment some version numbers twice
+- Issue 1837 Deployment from PR builds fail if PR branch name includes
 
 ### Additional debug logging functionality
 


### PR DESCRIPTION
The logic for handling PR publishing did not take branch names with slashes into consideration. This fix simple adds .Replace('/','_') to the ref name, similar to how it is done for other scenarios.

Related to issue: #1837 
