### PR TITLE
AL code analysis tracking in GitHub.

### DIFF
--- a/Actions/.Modules/ReadSettings.psm1
+++ b/Actions/.Modules/ReadSettings.psm1
@@ -133,6 +133,7 @@ function GetDefaultSettings
         "enableUICop"                                   = $false
         "enableCodeAnalyzersOnTestApps"                 = $false
         "customCodeCops"                                = @()
+        "trackCodeCopIssuesInGitHub"                    = $false    
         "failOn"                                        = "error"
         "treatTestFailuresAsWarnings"                   = $false
         "rulesetFile"                                   = ""

--- a/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
+++ b/Actions/CalculateArtifactNames/CalculateArtifactNames.ps1
@@ -49,7 +49,7 @@ else {
     $suffix = "$($repoVersion.Major).$($repoVersion.Minor).$($appBuild).$($settings.appRevision)"
 }
 
-'Apps', 'Dependencies', 'TestApps', 'TestResults', 'BcptTestResults', 'PageScriptingTestResults', 'PageScriptingTestResultDetails', 'BuildOutput', 'ContainerEventLog', 'PowerPlatformSolution' | ForEach-Object {
+'Apps', 'Dependencies', 'TestApps', 'TestResults', 'BcptTestResults', 'PageScriptingTestResults', 'PageScriptingTestResultDetails', 'BuildOutput', 'ContainerEventLog', 'PowerPlatformSolution', 'ErrorLogs' | ForEach-Object {
     $name = "$($_)ArtifactsName"
     $value = "$($projectName)-$($branchName)-$buildMode$_-$suffix"
     Set-OutputVariable -name $name -value $value

--- a/Actions/CalculateArtifactNames/action.yaml
+++ b/Actions/CalculateArtifactNames/action.yaml
@@ -46,6 +46,9 @@ outputs:
   ContainerEventLogArtifactsName:
     description: Artifacts name for ContainerEventLog
     value: ${{ steps.calculateartifactnames.outputs.ContainerEventLogArtifactsName }}
+  ErrorLogsArtifactsName:
+    description: Artifacts name for ErrorLogs
+    value: ${{ steps.calculateartifactnames.outputs.ErrorLogsArtifactsName }}
   BuildMode:
     description: Build mode used when building the artifacts
     value: ${{ steps.calculateartifactnames.outputs.BuildMode }}

--- a/Actions/ProcessALCodeAnalysisLogs/ProcessALCodeAnalysisLogs.ps1
+++ b/Actions/ProcessALCodeAnalysisLogs/ProcessALCodeAnalysisLogs.ps1
@@ -1,0 +1,76 @@
+$errorLogsFolder = Join-Path $ENV:GITHUB_WORKSPACE "ErrorLogs"
+$errorLogFiles = Get-ChildItem -Path $errorLogsFolder -Filter "*.errorLog.json" -File -Recurse
+
+# Base SARIF structure
+$sarif = @{
+    version = "2.1.0"
+    '$schema' = "https://json.schemastore.org/sarif-2.1.0.json"
+    runs = @(@{
+        tool = @{
+            driver = @{
+                name = 'ALCodeAnalysis'
+                informationUri = 'https://aka.ms/AL-Go'
+                rules = @()
+            }
+        }     
+        results = @()
+    })
+}
+
+
+function GenerateSARIFJson {
+    param(
+        [PSCustomObject] $errorLogContent
+    )
+
+    foreach ($issue in $errorLogContent.issues) {
+        # Add rule if not already added
+        if (-not ($sarif.runs[0].tool.driver.rules | Where-Object { $_.id -eq $issue.ruleId })) {
+            $sarif.runs[0].tool.driver.rules += @{
+                id = $issue.ruleId
+                shortDescription = @{ text = $issue.fullMessage }
+                fullDescription = @{ text = $issue.fullMessage }
+                helpUri = $issue.properties.helpLink
+                properties = @{
+                    category = $issue.properties.category
+                    severity = $issue.properties.severity
+                }
+            }
+        }
+
+        # Convert absolute path to relative path from repository root
+        $absolutePath = $issue.locations[0].analysisTarget[0].uri
+        $workspacePath = $ENV:GITHUB_WORKSPACE
+        $relativePath = $absolutePath.Replace($workspacePath, '').TrimStart('\').Replace('\', '/')
+
+        # Add result
+        $sarif.runs[0].results += @{
+            ruleId = $issue.ruleId
+            message = @{ text = $issue.shortMessage }
+            locations = @(@{
+                physicalLocation = @{
+                    artifactLocation = @{ uri = $relativePath }
+                    region = $issue.locations[0].analysisTarget[0].region
+                }
+            })
+            level = ($issue.properties.severity).ToLower()
+        }
+    }
+}
+
+$errorLogFiles | ForEach-Object {
+    OutputDebug -message "Found error log file: $($_.FullName)"
+    $fileName = $_.Name
+    try {
+        $errorLogContent = Get-Content -Path $_.FullName -Raw | ConvertFrom-Json
+        GenerateSARIFJson -errorLogContent $errorLogContent
+    }
+    catch {
+        Write-Host "Failed to process $fileName"
+        OutputDebug -message "Failed to read error log file: $_"
+    }
+}
+
+$sarifJson = $sarif | ConvertTo-Json -Depth 10 -Compress
+Write-Host ($sarifJson)
+Set-Content -Path "$errorLogsFolder/output.sarif.json" -Value $sarifJson

--- a/Actions/ProcessALCodeAnalysisLogs/action.yaml
+++ b/Actions/ProcessALCodeAnalysisLogs/action.yaml
@@ -1,0 +1,19 @@
+name: Analyze Diagnostic Logs
+author: Microsoft Corporation
+inputs:
+  shell:
+    description: Shell in which you want to run the action (powershell or pwsh)
+    required: false
+    default: powershell
+runs:
+  using: composite
+  steps:
+    - name: run
+      shell: ${{ inputs.shell }}
+      run: |
+        ${{ github.action_path }}/../Invoke-AlGoAction.ps1 -ActionName "ProcessALCodeAnalysisLogs" -Action {
+          ${{ github.action_path }}/ProcessALCodeAnalysisLogs.ps1
+        }
+branding:
+  icon: terminal
+  color: blue

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -506,6 +506,7 @@ try {
         -failOn $settings.failOn `
         -treatTestFailuresAsWarnings:$settings.treatTestFailuresAsWarnings `
         -rulesetFile $settings.rulesetFile `
+        -generateErrorLog:$settings.trackCodeCopIssuesInGitHub `
         -enableExternalRulesets:$settings.enableExternalRulesets `
         -appSourceCopMandatoryAffixes $settings.appSourceCopMandatoryAffixes `
         -additionalCountries $additionalCountries `

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,9 @@
+### AL Code Analysis tracked in GitHub
+
+AL-Go already supports AL code analysis, but up until now this was not tracked in GitHub. It is now possible to track code analysis issues automatically in the GitHub security tab, as well as having any new issues posted as a comment in Pull Requests. 
+
+Please note that some automated features are premium and require the use of [GitHub Code Security](https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security)
+
 ### AL-Go Telemetry
 
 AL-Go now offers a dataexplorer dashboard to get started with AL-Go telemetry. Additionally, we've updated the documentation to include a couple of kusto queries if you would rather build your own reports.

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -18,6 +18,7 @@ permissions:
   contents: read
   id-token: write
   pages: read
+  security-events: write
 
 env:
   workflowDepth: 1
@@ -196,6 +197,43 @@ jobs:
       signArtifacts: true
       useArtifactCache: true
       needsContext:  ${{ toJson(needs) }}
+
+  CodeAnalysisUpload:
+    needs: [ Initialization, Build ]
+    if: (!cancelled())
+    runs-on: [ windows-latest ]
+    name: Code Analysis Processing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
+        with:
+          shell: powershell
+          get: trackCodeCopIssuesInGitHub
+
+      - name: Download artifacts - ErrorLogs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        if: (success() || failure()) && env.trackCodeCopIssuesInGitHub == 'True'
+        with:
+          pattern: '*-ErrorLogs-*'
+          path: '${{ github.workspace }}/ErrorLogs/'
+          merge_multiple: true
+
+      - name: Process AL Code Analysis Logs
+        id: ProcessALCodeAnalysisLogs
+        if: (success() || failure()) && env.trackCodeCopIssuesInGitHub == 'True'
+        uses: microsoft/AL-Go-Actions/ProcessALCodeAnalysisLogs@main
+        with:
+          shell: ${{ inputs.shell }}
+
+      - name: Upload SARIF file to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        if: always() && env.trackCodeCopIssuesInGitHub == 'True'
+        with:
+          sarif_file: '${{ github.workspace }}/ErrorLogs/output.sarif.json'
+          category: "ALCodeAnalysis"
 
   DeployALDoc:
     needs: [ Initialization, Build ]

--- a/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/AppSource App/.github/workflows/PullRequestHandler.yaml
@@ -17,6 +17,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  security-events: write
 
 env:
   workflowDepth: 1
@@ -107,8 +108,49 @@ jobs:
       needsContext:  ${{ toJson(needs) }}
       useArtifactCache: true
 
-  StatusCheck:
+  CodeAnalysisUpload:
     needs: [ Initialization, Build ]
+    if: (!cancelled())
+    runs-on: [ windows-latest ]
+    name: Code Analysis Processing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ format('refs/pull/{0}/head', github.event.pull_request.number) }}
+
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
+        with:
+          shell: powershell
+          get: trackCodeCopIssuesInGitHub
+
+      - name: Download artifacts - ErrorLogs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        if: (success() || failure()) && env.trackCodeCopIssuesInGitHub == 'True'
+        with:
+          pattern: '*-ErrorLogs-*'
+          path: '${{ github.workspace }}/ErrorLogs/'
+          merge_multiple: true
+
+      - name: Process AL Code Analysis Logs
+        id: ProcessALCodeAnalysisLogs
+        if: (success() || failure()) && env.trackCodeCopIssuesInGitHub == 'True'
+        uses: microsoft/AL-Go-Actions/ProcessALCodeAnalysisLogs@main
+        with:
+          shell: ${{ inputs.shell }}
+
+      - name: Upload SARIF file to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        if: always() && env.trackCodeCopIssuesInGitHub == 'True'
+        with:
+          sarif_file: '${{ github.workspace }}/ErrorLogs/output.sarif.json'
+          category: "ALCodeAnalysis"
+          ref: ${{ format('refs/pull/{0}/head', github.event.pull_request.number) }}
+          sha: ${{ github.event.pull_request.head.sha }}
+
+  StatusCheck:
+    needs: [ Initialization, Build, CodeAnalysisUpload ]
     if: (!cancelled())
     runs-on: [ windows-latest ]
     name: Pull Request Status Check

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -276,6 +276,15 @@ jobs:
           path: '${{ inputs.project }}/.buildartifacts/PageScriptingTestResultDetails/'
           if-no-files-found: ignore
 
+      - name: Publish artifacts - ErrorLogs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: inputs.artifactsRetentionDays >= 0 && (hashFiles(format('{0}/.buildartifacts/ErrorLogs/*',inputs.project)) != '')
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.ErrorLogsArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/ErrorLogs/'
+          if-no-files-found: ignore
+          retention-days: ${{ inputs.artifactsRetentionDays }}
+
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -18,6 +18,7 @@ permissions:
   contents: read
   id-token: write
   pages: read
+  security-events: write
 
 env:
   workflowDepth: 1
@@ -210,6 +211,43 @@ jobs:
       project: ${{ needs.Initialization.outputs.powerPlatformSolutionFolder }}
       projectName: ${{ needs.Initialization.outputs.powerPlatformSolutionFolder }}
       publishArtifacts: ${{ github.ref_name == 'main' || startswith(github.ref_name, 'release/') || startswith(github.ref_name, 'releases/') || needs.Initialization.outputs.deliveryTargetsJson != '[]' || needs.Initialization.outputs.environmentCount > 0 }}
+
+  CodeAnalysisUpload:
+    needs: [ Initialization, Build ]
+    if: (!cancelled())
+    runs-on: [ windows-latest ]
+    name: Code Analysis Processing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
+        with:
+          shell: powershell
+          get: trackCodeCopIssuesInGitHub
+
+      - name: Download artifacts - ErrorLogs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        if: (success() || failure()) && env.trackCodeCopIssuesInGitHub == 'True'
+        with:
+          pattern: '*-ErrorLogs-*'
+          path: '${{ github.workspace }}/ErrorLogs/'
+          merge_multiple: true
+
+      - name: Process AL Code Analysis Logs
+        id: ProcessALCodeAnalysisLogs
+        if: (success() || failure()) && env.trackCodeCopIssuesInGitHub == 'True'
+        uses: microsoft/AL-Go-Actions/ProcessALCodeAnalysisLogs@main
+        with:
+          shell: ${{ inputs.shell }}
+
+      - name: Upload SARIF file to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        if: always() && env.trackCodeCopIssuesInGitHub == 'True'
+        with:
+          sarif_file: '${{ github.workspace }}/ErrorLogs/output.sarif.json'
+          category: "ALCodeAnalysis"
 
   DeployALDoc:
     needs: [ Initialization, Build ]

--- a/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PullRequestHandler.yaml
@@ -17,6 +17,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  security-events: write
 
 env:
   workflowDepth: 1
@@ -107,8 +108,49 @@ jobs:
       needsContext:  ${{ toJson(needs) }}
       useArtifactCache: true
 
-  StatusCheck:
+  CodeAnalysisUpload:
     needs: [ Initialization, Build ]
+    if: (!cancelled())
+    runs-on: [ windows-latest ]
+    name: Code Analysis Processing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ format('refs/pull/{0}/head', github.event.pull_request.number) }}
+
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
+        with:
+          shell: powershell
+          get: trackCodeCopIssuesInGitHub
+
+      - name: Download artifacts - ErrorLogs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        if: (success() || failure()) && env.trackCodeCopIssuesInGitHub == 'True'
+        with:
+          pattern: '*-ErrorLogs-*'
+          path: '${{ github.workspace }}/ErrorLogs/'
+          merge_multiple: true
+
+      - name: Process AL Code Analysis Logs
+        id: ProcessALCodeAnalysisLogs
+        if: (success() || failure()) && env.trackCodeCopIssuesInGitHub == 'True'
+        uses: microsoft/AL-Go-Actions/ProcessALCodeAnalysisLogs@main
+        with:
+          shell: ${{ inputs.shell }}
+
+      - name: Upload SARIF file to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        if: always() && env.trackCodeCopIssuesInGitHub == 'True'
+        with:
+          sarif_file: '${{ github.workspace }}/ErrorLogs/output.sarif.json'
+          category: "ALCodeAnalysis"
+          ref: ${{ format('refs/pull/{0}/head', github.event.pull_request.number) }}
+          sha: ${{ github.event.pull_request.head.sha }}
+
+  StatusCheck:
+    needs: [ Initialization, Build, CodeAnalysisUpload ]
     if: (!cancelled())
     runs-on: [ windows-latest ]
     name: Pull Request Status Check

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -276,6 +276,15 @@ jobs:
           path: '${{ inputs.project }}/.buildartifacts/PageScriptingTestResultDetails/'
           if-no-files-found: ignore
 
+      - name: Publish artifacts - ErrorLogs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: inputs.artifactsRetentionDays >= 0 && (hashFiles(format('{0}/.buildartifacts/ErrorLogs/*',inputs.project)) != '')
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.ErrorLogsArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/ErrorLogs/'
+          if-no-files-found: ignore
+          retention-days: ${{ inputs.artifactsRetentionDays }}
+
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'

--- a/Tests/CalculateArtifactNames.Test.ps1
+++ b/Tests/CalculateArtifactNames.Test.ps1
@@ -44,6 +44,7 @@ Describe 'CalculateArtifactNames Action Tests' {
         $generatedOutPut | Should -Contain "PageScriptingTestResultDetailsArtifactsName=ALGOProject-main-CleanPageScriptingTestResultDetails-22.0.123.0"
         $generatedOutPut | Should -Contain "BuildOutputArtifactsName=ALGOProject-main-CleanBuildOutput-22.0.123.0"
         $generatedOutPut | Should -Contain "ContainerEventLogArtifactsName=ALGOProject-main-CleanContainerEventLog-22.0.123.0"
+        $generatedOutPut | Should -Contain "ErrorLogsArtifactsName=ALGOProject-main-CleanErrorLogs-22.0.123.0"
         $generatedOutPut | Should -Contain "BuildMode=Clean"
 
     }
@@ -65,6 +66,7 @@ Describe 'CalculateArtifactNames Action Tests' {
         $generatedOutPut | Should -Contain "PageScriptingTestResultDetailsArtifactsName=ALGOProject-main-PageScriptingTestResultDetails-22.0.123.0"
         $generatedOutPut | Should -Contain "BuildOutputArtifactsName=ALGOProject-main-BuildOutput-22.0.123.0"
         $generatedOutPut | Should -Contain "ContainerEventLogArtifactsName=ALGOProject-main-ContainerEventLog-22.0.123.0"
+        $generatedOutPut | Should -Contain "ErrorLogsArtifactsName=ALGOProject-main-ErrorLogs-22.0.123.0"
     }
 
     It 'should escape slashes and backslashes in artifact name' {
@@ -84,6 +86,7 @@ Describe 'CalculateArtifactNames Action Tests' {
         $generatedOutPut | Should -Contain "PageScriptingTestResultDetailsArtifactsName=ALGOProject-releases_1.0-PageScriptingTestResultDetails-22.0.123.0"
         $generatedOutPut | Should -Contain "BuildOutputArtifactsName=ALGOProject-releases_1.0-BuildOutput-22.0.123.0"
         $generatedOutPut | Should -Contain "ContainerEventLogArtifactsName=ALGOProject-releases_1.0-ContainerEventLog-22.0.123.0"
+        $generatedOutPut | Should -Contain "ErrorLogsArtifactsName=ALGOProject-releases_1.0-ErrorLogs-22.0.123.0"
     }
 
     It 'should use the specified suffix if provided' {
@@ -108,6 +111,7 @@ Describe 'CalculateArtifactNames Action Tests' {
         $generatedOutPut | Should -Contain "PageScriptingTestResultDetailsArtifactsName=ALGOProject-releases_1.0-PageScriptingTestResultDetails-Current-$currentDate"
         $generatedOutPut | Should -Contain "BuildOutputArtifactsName=ALGOProject-releases_1.0-BuildOutput-Current-$currentDate"
         $generatedOutPut | Should -Contain "ContainerEventLogArtifactsName=ALGOProject-releases_1.0-ContainerEventLog-Current-$currentDate"
+        $generatedOutPut | Should -Contain "ErrorLogsArtifactsName=ALGOProject-releases_1.0-ErrorLogs-Current-$currentDate"
     }
 
     It 'handles special characters in project name' {
@@ -133,6 +137,7 @@ Describe 'CalculateArtifactNames Action Tests' {
         $generatedOutPut | Should -Contain "PageScriptingTestResultDetailsArtifactsName=ALGOProject_øåæ-releases_1.0-PageScriptingTestResultDetails-Current-$currentDate"
         $generatedOutPut | Should -Contain "BuildOutputArtifactsName=ALGOProject_øåæ-releases_1.0-BuildOutput-Current-$currentDate"
         $generatedOutPut | Should -Contain "ContainerEventLogArtifactsName=ALGOProject_øåæ-releases_1.0-ContainerEventLog-Current-$currentDate"
+        $generatedOutPut | Should -Contain "ErrorLogsArtifactsName=ALGOProject_øåæ-releases_1.0-ErrorLogs-Current-$currentDate"
     }
 
     It 'Compile Action' {
@@ -151,6 +156,7 @@ Describe 'CalculateArtifactNames Action Tests' {
             "PageScriptingTestResultDetailsArtifactsName" = "Artifacts name for PageScriptingTestResultDetails"
             "BuildOutputArtifactsName" = "Artifacts name for BuildOutput"
             "ContainerEventLogArtifactsName" = "Artifacts name for ContainerEventLog"
+            "ErrorLogsArtifactsName" = "Artifacts name for ErrorLogs"
             "BuildMode" = "Build mode used when building the artifacts"
         }
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript -outputs $outputs

--- a/Tests/ProcessALCodeAnalysisLogs.Test.ps1
+++ b/Tests/ProcessALCodeAnalysisLogs.Test.ps1
@@ -1,0 +1,208 @@
+Get-Module TestActionsHelper | Remove-Module -Force
+Import-Module (Join-Path $PSScriptRoot 'TestActionsHelper.psm1')
+$errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
+
+Describe 'ProcessALCodeAnalysisLogs Action Tests' {
+
+    BeforeAll {
+        $actionName = "ProcessALCodeAnalysisLogs"
+        $scriptRoot = Join-Path $PSScriptRoot "..\Actions\$actionName" -Resolve
+        $scriptName = "$actionName.ps1"
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'scriptPath', Justification = 'False positive.')]
+        $scriptPath = Join-Path $scriptRoot $scriptName
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'actionScript', Justification = 'False positive.')]
+        $actionScript = GetActionScript -scriptRoot $scriptRoot -scriptName $scriptName
+
+        Mock Write-Host {}
+    }
+
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'alErrorLogSchema', Justification = 'False positive.')]
+        $alErrorLogSchema = @{
+            "version" = "0.2"
+            "toolInfo" = @{
+                "toolName" = "Microsoft (R) AL Compiler"
+                "productVersion" = "14.3.26"
+                "fileVersion" = "14.3.26"
+            }
+            "issues" = @()
+        }
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'sampleIssue1', Justification = 'False positive.')]
+        $sampleIssue1 = @{
+            "ruleId"=  "AA001"
+            "locations" = @(
+                @{
+                    "analysisTarget" = @(
+                        @{
+                            "uri" = "D:\\a\\repo\\repo\\projectName\\appName\\ALFileName.al"
+                            "region" = @{
+                                "startLine" = 1
+                                "startColumn" = 1
+                                "endLine" = 1
+                                "endColumn" = 1
+                            }
+                        }
+                    )
+                }
+            )
+            "shortMessage" = "Issue short message"
+            "fullMessage" = "Issue full message"
+            "properties" = @{
+                "severity" = "Warning"
+                "warningLevel" = "1"
+                "defaultSeverity" = "Warning"
+                "title" = "title"
+                "category" = "category"
+                "helpLink" = "helplink"
+                "isEnabledByDefault" = "True"
+                "isSuppressedInSource" = "False"
+            }
+        }
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'sampleIssue2', Justification = 'False positive.')]
+        $sampleIssue2 = @{
+            "ruleId"=  "AA001"
+            "locations" = @(
+                @{
+                    "analysisTarget" = @(
+                        @{
+                            "uri" = "D:\\a\\repo\\repo\\projectName\\appName\\ALFileName.al"
+                            "region" = @{
+                                "startLine" = 2
+                                "startColumn" = 1
+                                "endLine" = 2
+                                "endColumn" = 1
+                            }
+                        }
+                    )
+                }
+            )
+            "shortMessage" = "Issue short message"
+            "fullMessage" = "Issue full message"
+            "properties" = @{
+                "severity" = "Warning"
+                "warningLevel" = "1"
+                "defaultSeverity" = "Warning"
+                "title" = "title"
+                "category" = "category"
+                "helpLink" = "helplink"
+                "isEnabledByDefault" = "True"
+                "isSuppressedInSource" = "False"
+            }
+        }
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'sampleIssue3', Justification = 'False positive.')]
+        $sampleIssue3 = @{
+            "ruleId"=  "AA002"
+            "locations" = @(
+                @{
+                    "analysisTarget" = @(
+                        @{
+                            "uri" = "D:\\a\\repo\\repo\\projectName\\appName\\ALFileName.al"
+                            "region" = @{
+                                "startLine" = 3
+                                "startColumn" = 1
+                                "endLine" = 3
+                                "endColumn" = 1
+                            }
+                        }
+                    )
+                }
+            )
+            "shortMessage" = "Issue short message"
+            "fullMessage" = "Issue full message"
+            "properties" = @{
+                "severity" = "Warning"
+                "warningLevel" = "1"
+                "defaultSeverity" = "Warning"
+                "title" = "title"
+                "category" = "category"
+                "helpLink" = "helplink"
+                "isEnabledByDefault" = "True"
+                "isSuppressedInSource" = "False"
+            }
+        }
+        $ENV:GITHUB_WORKSPACE = [System.IO.Path]::GetTempPath()
+        $errorLogsFolder = Join-Path $ENV:GITHUB_WORKSPACE "ErrorLogs"
+        if (!(Test-Path $errorLogsFolder)) {
+            New-Item -Path $errorLogsFolder -ItemType Directory -Force
+        }
+    }
+
+    AfterEach {
+        $errorLogsFolder = Join-Path $ENV:GITHUB_WORKSPACE "ErrorLogs"
+
+        if (Test-Path $errorLogsFolder) {
+            Remove-Item -Path "$errorLogsFolder\*" -Recurse -Force
+        }
+    }
+
+    It 'SARIF file should be created' {
+        # Create 1 error log file with 1 issue
+        $errorLogFile = Join-Path $errorLogsFolder "sample.errorLog.json"
+        $baseIssueContent = $alErrorLogSchema
+        $baseIssueContent.issues += $sampleIssue1
+        $baseIssueContent | ConvertTo-Json -Depth 10 | Set-Content -Path $errorLogFile
+
+        & $scriptPath
+
+        $sarifFile = Join-Path $errorLogsFolder "output.sarif.json"
+        $sarifFile | Should -Exist
+    }
+
+    It 'All issues added from single error log file' {
+        # Create 1 error log file with 2 issues
+        $errorLogFile = Join-Path $errorLogsFolder "sample.errorLog.json"
+        $baseIssueContent = $alErrorLogSchema
+        $baseIssueContent.issues += $sampleIssue1
+        $baseIssueContent.issues += $sampleIssue3
+        $baseIssueContent | ConvertTo-Json -Depth 10 | Set-Content -Path $errorLogFile
+
+        & $scriptPath
+
+        $sarifFile = Join-Path $errorLogsFolder "output.sarif.json"
+        $sarifContent = Get-Content -Path $sarifFile -Raw | ConvertFrom-Json
+        $sarifContent.runs[0].results.Count | Should -Be 2
+    }
+
+    It 'All issues added from multiple error log files' {
+        # Create 2 error log file with 2 issues
+        $errorLogFile1 = Join-Path $errorLogsFolder "sample1.errorLog.json"
+        $baseIssueContent1 = $alErrorLogSchema.clone()
+        $baseIssueContent1.issues += $sampleIssue1
+        $baseIssueContent1 | ConvertTo-Json -Depth 10 | Set-Content -Path $errorLogFile1
+
+        $errorLogFile2 = Join-Path $errorLogsFolder "sample2.errorLog.json"
+        $baseIssueContent2 = $alErrorLogSchema.clone()
+        $baseIssueContent2.issues += $sampleIssue3
+        $baseIssueContent2 | ConvertTo-Json -Depth 10 | Set-Content -Path $errorLogFile2
+
+        & $scriptPath
+
+        $sarifFile = Join-Path $errorLogsFolder "output.sarif.json"
+        $sarifContent = Get-Content -Path $sarifFile -Raw | ConvertFrom-Json
+        $sarifContent.runs[0].results.Count | Should -Be 2
+    }
+
+    It 'Multiple issues with same ruleId results in SARIF with single rule' {
+        # Create 2 error log file with 2 issues
+        $errorLogFile = Join-Path $errorLogsFolder "sample.errorLog.json"
+        $baseIssueContent = $alErrorLogSchema
+        $baseIssueContent.issues += $sampleIssue1 #Issue 1 and 2 share the same ruleId, hence the output should have 2 rules in total.
+        $baseIssueContent.issues += $sampleIssue2
+        $baseIssueContent.issues += $sampleIssue3
+        $baseIssueContent | ConvertTo-Json -Depth 10 | Set-Content -Path $errorLogFile
+
+        & $scriptPath
+
+        $sarifFile = Join-Path $errorLogsFolder "output.sarif.json"
+        $sarifContent = Get-Content -Path $sarifFile -Raw | ConvertFrom-Json
+        $sarifContent.runs[0].tool.driver.rules.Count | Should -Be 2
+    }
+
+    It 'Compile Action' {
+        Invoke-Expression $actionScript
+    }
+
+    It 'Test action.yaml matches script' {
+        YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript
+    }
+}


### PR DESCRIPTION
Adding new feature to track AL code analysis results in GitHub.

We already have existing CodeCop features for AL in AL-Go, but this builds on top of that and integrates any code scan issues with GitHub security.

This allows alerts to appear in the Security tab of GitHub, and as automated comments on PRs if new alerts are detected.
