### PR TITLE
Using basic parsing in CheckForUpdates WebCall

### DIFF
--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -25,7 +25,7 @@ function DownloadTemplateRepository {
     OutputDebug -message "Getting template repository ($templateRepository) with GITHUB_TOKEN"
     $headers = GetHeaders -token $env:GITHUB_TOKEN -repository $templateRepository
     try {
-        $response = Invoke-WebRequest -Headers $headers -Method Head -Uri $templateRepositoryUrl
+        $response = Invoke-WebRequest -UseBasicParsing -Headers $headers -Method Head -Uri $templateRepositoryUrl
         OutputDebug -message ($response | Format-List | Out-String)
     }
     catch {


### PR DESCRIPTION
### ❔What, Why & How

On some self-hosted runners, Internet Explorer engine might not be available. This appears to fail Invoke-WebRequest calls if -UseBasicParsing is not used.

Related to issue: #1895 

### ✅ Checklist

- [ ] Add tests (E2E, unit tests)
- [ ] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
