### PR TITLE
Fix e2e tests logs with debug messages

### DIFF
--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -291,15 +291,15 @@ function WaitWorkflow {
         $url = "https://api.github.com/repos/$repository/actions/runs/$runid"
         $run = ((InvokeWebRequest -Method Get -Headers $headers -Uri $url).Content | ConvertFrom-Json)
         if ($run.status -ne $status) {
-            if ($status) { Write-Host }
             $status = $run.status
-            Write-Host -NoNewline "$status"
         }
-        Write-Host -NoNewline "."
+        Write-Host "Workflow run is in status $status"
+
         $delay = $true
     } while ($run.status -eq "queued" -or $run.status -eq "in_progress")
-    Write-Host
-    Write-Host $run.conclusion
+
+    Write-Host "Workflow conclusion: $($run.conclusion)"
+
     if ($run.conclusion -ne "Success" -and $run.conclusion -ne "cancelled") {
         if (-not $noError.IsPresent) { throw "Workflow $($run.name), conclusion $($run.conclusion), url = $($run.html_url)" }
     }


### PR DESCRIPTION
Fix debug messages output in e2e tests logs:

<img width="1136" height="385" alt="image" src="https://github.com/user-attachments/assets/ebb26d9c-d8b3-4767-aeca-7601779eaaaa" />

