### PR TITLE
Avoid fetching tags when getting the branches for multi-branches workflow run

### DIFF
--- a/Actions/GetWorkflowMultiRunBranches/GetWorkflowMultiRunBranches.ps1
+++ b/Actions/GetWorkflowMultiRunBranches/GetWorkflowMultiRunBranches.ps1
@@ -33,7 +33,7 @@ if (-not $branchPatterns) {
 
 Write-Host "Filtering branches by: $($branchPatterns -join ', ')"
 
-invoke-git fetch --quiet
+invoke-git fetch --quiet --no-tags
 $allBranches = @(invoke-git -returnValue for-each-ref --format="%(refname:short)" refs/remotes/origin | ForEach-Object { $_ -replace 'origin/', '' })
 $branches = @()
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -16,6 +16,7 @@ Please note that some automated features are premium and require the use of [Git
 
 - Discussion 1885 Conditional settings for CI/CD are not applied
 - Discussion 1899 Remove optional properties from "required" list in settings.schema.json
+- Issue 1905 AL-Go system files update fails (Get Workflow Multi-Run Branches action fails when there are tags with same value but different casing)
 
 ## v7.3
 


### PR DESCRIPTION
### ❔What, Why & How

Avoid fetching tags when getting the branches for multi-branches workflow run.

_Issue_: "Get Workflow Multi-Run Branches" action fails when there are tags with same value but different casing.
_Solution_: Avoid fetching tags when invoking `git fetch`

Related to issue: #1905 

### ✅ Checklist

- [x] Update RELEASENOTES.md
