### PR TITLE
Refactor logic for determining deployment environments and deployment script

### DIFF
--- a/Actions/Deploy/action.yaml
+++ b/Actions/Deploy/action.yaml
@@ -19,9 +19,6 @@ inputs:
     description: Type of deployment (CD or Publish)
     required: false
     default: 'CD'
-  deploymentEnvironmentsJson:
-    description: The settings for all Deployment Environments
-    required: true
   artifactsVersion:
     description: Artifacts version. Used to check if this is a deployment from a PR
     required: false
@@ -41,11 +38,10 @@ runs:
         _environmentName: ${{ inputs.environmentName }}
         _artifactsFolder: ${{ inputs.artifactsFolder }}
         _type: ${{ inputs.type }}
-        _deploymentEnvironmentsJson: ${{ inputs.deploymentEnvironmentsJson }}
         _artifactsVersion: ${{ inputs.artifactsVersion }}
       run: |
         ${{ github.action_path }}/../Invoke-AlGoAction.ps1 -ActionName "Deploy" -Action {
-          ${{ github.action_path }}/Deploy.ps1 -token $ENV:_token -environmentName $ENV:_environmentName -artifactsFolder $ENV:_artifactsFolder -type $ENV:_type -deploymentEnvironmentsJson $ENV:_deploymentEnvironmentsJson -artifactsVersion $ENV:_artifactsVersion
+          ${{ github.action_path }}/Deploy.ps1 -token $ENV:_token -environmentName $ENV:_environmentName -artifactsFolder $ENV:_artifactsFolder -type $ENV:_type -artifactsVersion $ENV:_artifactsVersion
         }
 branding:
   icon: terminal

--- a/Actions/DeployPowerPlatform/README.md
+++ b/Actions/DeployPowerPlatform/README.md
@@ -19,7 +19,6 @@ Deploy the Power Platform solution from the artifacts folder
 | environmentName | Yes | Name of environment to deploy to |
 | artifactsFolder | | Path to the downloaded artifacts to deploy (when deploying from a build) | |
 | solutionFolder | | Path to the unpacked solutions to deploy (when deploying from branch) | |
-| deploymentEnvironmentsJson | Yes | The settings for all Deployment Environments | |
 
 Either artifactsFolder or solutionFolder needs to be specified
 

--- a/Actions/DeployPowerPlatform/action.yaml
+++ b/Actions/DeployPowerPlatform/action.yaml
@@ -16,9 +16,6 @@ inputs:
     description: Path to the unpacked solution to deploy (when deploying from branch)
     required: false
     default: ''
-  deploymentEnvironmentsJson:
-    description: The settings for all Deployment Environments
-    required: true
 runs:
   using: composite
   steps:
@@ -47,7 +44,6 @@ runs:
       uses: ./_AL-Go/Actions/ReadPowerPlatformSettings
       with:
         shell: ${{ inputs.shell }}
-        deploymentEnvironmentsJson: ${{ inputs.deploymentEnvironmentsJson }}
         environmentName: ${{ inputs.environmentName }}
 
     - name: Determine Power Platform solution location

--- a/Actions/DetermineDeploymentEnvironments/README.md
+++ b/Actions/DetermineDeploymentEnvironments/README.md
@@ -21,9 +21,7 @@ Determines the environments to be used for a build or a publish
 
 ## OUTPUT
 
-| EnvironmentsMatrixJson | The Environment matrix to use for the Deploy step in compressed JSON format |
-| DeploymentEnvironmentsJson | Deployment Environments with settings in compressed JSON format |
-| EnvironmentCount | Number of Deployment Environments |
+| DeploymentEnvironmentsJson | The JSON representation of the environment that are suitable for deployment. |
 | UnknownEnvironment | Flag determining whether we try to publish to an unknown environment (invoke device code flow) |
 | GenerateALDocArtifact | Flag determining whether to generate the ALDoc artifact |
 | DeployALDocArtifact | Flag determining whether to deploy the ALDoc artifact to GitHub Pages |

--- a/Actions/DetermineDeploymentEnvironments/action.yaml
+++ b/Actions/DetermineDeploymentEnvironments/action.yaml
@@ -12,15 +12,9 @@ inputs:
     description: Type of deployment (CD, Publish or All)
     required: true
 outputs:
-  EnvironmentsMatrixJson:
-    description: The Environment matrix to use for the Deploy step in compressed JSON format
-    value: ${{ steps.determineDeploymentEnvironments.outputs.EnvironmentsMatrixJson }}
   DeploymentEnvironmentsJson:
-    description: Deployment Environments with settings in compressed JSON format
+    description: The JSON representation of the environment that are suitable for deployment.
     value: ${{ steps.determineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson }}
-  EnvironmentCount:
-    description: Number of Deployment Environments
-    value: ${{ steps.determineDeploymentEnvironments.outputs.EnvironmentCount }}
   UnknownEnvironment:
     description: Flag determining whether the environment is unknown
     value: ${{ steps.determineDeploymentEnvironments.outputs.UnknownEnvironment }}

--- a/Templates/AppSource App/.github/workflows/CICD.yaml
+++ b/Templates/AppSource App/.github/workflows/CICD.yaml
@@ -31,9 +31,7 @@ jobs:
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-      environmentsMatrixJson: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentsMatrixJson }}
-      environmentCount: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount }}
-      deploymentEnvironmentsJson: ${{ steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson }}
+      DeploymentEnvironmentsJson: ${{ steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson }}
       generateALDocArtifact: ${{ steps.DetermineDeploymentEnvironments.outputs.GenerateALDocArtifact }}
       deployALDocArtifact: ${{ steps.DetermineDeploymentEnvironments.outputs.DeployALDocArtifact }}
       deliveryTargetsJson: ${{ steps.DetermineDeliveryTargets.outputs.DeliveryTargetsJson }}
@@ -285,19 +283,22 @@ jobs:
 
   Deploy:
     needs: [ Initialization, Build ]
-    if: (!cancelled()) && (needs.Build.result == 'success' || needs.Build.result == 'skipped') && needs.Initialization.outputs.environmentCount > 0
-    strategy: ${{ fromJson(needs.Initialization.outputs.environmentsMatrixJson) }}
-    runs-on: ${{ fromJson(matrix.os) }}
-    name: Deploy to ${{ matrix.environment }}
+    if: (!cancelled()) && (needs.Build.result == 'success' || needs.Build.result == 'skipped') && fromJson(needs.Initialization.outputs.DetermineDeploymentEnvironments).environmentCount > 0
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.Initialization.outputs.DeploymentEnvironmentsJson).environments }}
+      fail-fast: false
+    runs-on: ${{ fromJson(matrix.runs-on) }}
+    name: Deploy to ${{ matrix.environmentName }}
     defaults:
       run:
         shell: ${{ matrix.shell }}
     environment:
-      name: ${{ matrix.environment }}
+      name: ${{ matrix.environmentName }}
       url: ${{ steps.Deploy.outputs.environmentUrl }}
     env:
       ALGoEnvSettings: ${{ vars.ALGoEnvironmentSettings }}
-      ALGoEnvName: ${{ matrix.environment }}
+      ALGoEnvName: ${{ matrix.environmentName }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/PublishToEnvironment.yaml
@@ -31,8 +31,6 @@ jobs:
     needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
-      environmentsMatrixJson: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentsMatrixJson }}
-      environmentCount: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount }}
       deploymentEnvironmentsJson: ${{ steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson }}
       deviceCode: ${{ steps.Authenticate.outputs.deviceCode }}
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -72,7 +70,7 @@ jobs:
         if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $envName = '${{ fromJson(steps.DetermineDeploymentEnvironments.outputs.environmentsMatrixJson).matrix.include[0].environment }}'.split(' ')[0]
+          $envName = '${{ fromJson(steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson).environments[0].name }}'.split(' ')[0]
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read secrets
@@ -119,20 +117,20 @@ jobs:
 
   Deploy:
     needs: [ Initialization ]
-    if: needs.Initialization.outputs.environmentCount > 0
+    if: fromJson(needs.Initialization.outputs.deploymentEnvironmentsJson).environmentCount > 0
     strategy: ${{ fromJson(needs.Initialization.outputs.environmentsMatrixJson) }}
-    runs-on: ${{ fromJson(matrix.os) }}
-    name: Deploy to ${{ matrix.environment }}
+    runs-on: ${{ fromJson(matrix.runs-on) }}
+    name: Deploy to ${{ matrix.environmentName }}
     defaults:
       run:
         shell: ${{ matrix.shell }}
     environment:
-      name: ${{ matrix.environment }}
+      name: ${{ matrix.environmentName }}
       url: ${{ steps.Deploy.outputs.environmentUrl }}
     env:
       deviceCode: ${{ needs.Initialization.outputs.deviceCode }}
       ALGoEnvSettings: ${{ vars.ALGoEnvironmentSettings }}
-      ALGoEnvName: ${{ matrix.environment }}
+      ALGoEnvName: ${{ matrix.environmentName }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -141,7 +139,7 @@ jobs:
         id: envName
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $envName = '${{ matrix.environment }}'.split(' ')[0]
+          $envName = '${{ matrix.environmentName }}'.split(' ')[0]
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
@@ -172,10 +170,9 @@ jobs:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: ${{ matrix.shell }}
-          environmentName: ${{ matrix.environment }}
+          environmentName: ${{ matrix.environmentName }}
           artifactsFolder: '.artifacts'
           type: 'Publish'
-          deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
           artifactsVersion: ${{ github.event.inputs.appVersion }}
 
       - name: Deploy to Power Platform
@@ -185,7 +182,7 @@ jobs:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: ${{ matrix.shell }}
-          environmentName: ${{ matrix.environment }}
+          environmentName: ${{ matrix.environmentName }}
           artifactsFolder: '.artifacts'
           deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
 

--- a/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CICD.yaml
@@ -31,8 +31,6 @@ jobs:
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-      environmentsMatrixJson: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentsMatrixJson }}
-      environmentCount: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount }}
       deploymentEnvironmentsJson: ${{ steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson }}
       generateALDocArtifact: ${{ steps.DetermineDeploymentEnvironments.outputs.GenerateALDocArtifact }}
       deployALDocArtifact: ${{ steps.DetermineDeploymentEnvironments.outputs.DeployALDocArtifact }}
@@ -217,7 +215,7 @@ jobs:
       parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
       project: ${{ needs.Initialization.outputs.powerPlatformSolutionFolder }}
       projectName: ${{ needs.Initialization.outputs.powerPlatformSolutionFolder }}
-      publishArtifacts: ${{ github.ref_name == 'main' || startswith(github.ref_name, 'release/') || startswith(github.ref_name, 'releases/') || needs.Initialization.outputs.deliveryTargetsJson != '[]' || needs.Initialization.outputs.environmentCount > 0 }}
+      publishArtifacts: ${{ github.ref_name == 'main' || startswith(github.ref_name, 'release/') || startswith(github.ref_name, 'releases/') || needs.Initialization.outputs.deliveryTargetsJson != '[]' || fromJson(needs.Initialization.outputs.deploymentEnvironmentsJson).environmentCount > 0 }}
 
   CodeAnalysisUpload:
     needs: [ Initialization, Build ]
@@ -299,19 +297,22 @@ jobs:
 
   Deploy:
     needs: [ Initialization, Build, BuildPP ]
-    if: (!cancelled()) && (needs.Build.result == 'success' || needs.Build.result == 'skipped') && (needs.BuildPP.result == 'success' || needs.BuildPP.result == 'skipped') && needs.Initialization.outputs.environmentCount > 0
-    strategy: ${{ fromJson(needs.Initialization.outputs.environmentsMatrixJson) }}
-    runs-on: ${{ fromJson(matrix.os) }}
-    name: Deploy to ${{ matrix.environment }}
+    if: (!cancelled()) && (needs.Build.result == 'success' || needs.Build.result == 'skipped') && (needs.BuildPP.result == 'success' || needs.BuildPP.result == 'skipped') && fromJson(needs.Initialization.outputs.determineDeploymentEnvironments).environmentCount > 0
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.Initialization.outputs.deploymentEnvironmentsJson).environments }}
+      fail-fast: false
+    runs-on: ${{ fromJson(matrix.runs-on) }}
+    name: Deploy to ${{ matrix.environmentName }}
     defaults:
       run:
         shell: ${{ matrix.shell }}
     environment:
-      name: ${{ matrix.environment }}
+      name: ${{ matrix.environmentName }}
       url: ${{ steps.Deploy.outputs.environmentUrl }}
     env:
       ALGoEnvSettings: ${{ vars.ALGoEnvironmentSettings }}
-      ALGoEnvName: ${{ matrix.environment }}
+      ALGoEnvName: ${{ matrix.environmentName }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -331,7 +332,7 @@ jobs:
         id: envName
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $envName = '${{ matrix.environment }}'.split(' ')[0]
+          $envName = '${{ matrix.environmentName }}'.split(' ')[0]
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read secrets
@@ -349,10 +350,9 @@ jobs:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: ${{ matrix.shell }}
-          environmentName: ${{ matrix.environment }}
+          environmentName: ${{ matrix.environmentName }}
           artifactsFolder: '.artifacts'
           type: 'CD'
-          deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
@@ -361,7 +361,7 @@ jobs:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
-          environmentName: ${{ matrix.environment }}
+          environmentName: ${{ matrix.environmentName }}
           artifactsFolder: '.artifacts'
           deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
 

--- a/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/PublishToEnvironment.yaml
@@ -31,8 +31,6 @@ jobs:
     needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
-      environmentsMatrixJson: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentsMatrixJson }}
-      environmentCount: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount }}
       deploymentEnvironmentsJson: ${{ steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson }}
       deviceCode: ${{ steps.Authenticate.outputs.deviceCode }}
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -72,7 +70,7 @@ jobs:
         if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $envName = '${{ fromJson(steps.DetermineDeploymentEnvironments.outputs.environmentsMatrixJson).matrix.include[0].environment }}'.split(' ')[0]
+          $envName = '${{ fromJson(steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson).environments[0].name }}'.split(' ')[0]
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read secrets
@@ -119,20 +117,22 @@ jobs:
 
   Deploy:
     needs: [ Initialization ]
-    if: needs.Initialization.outputs.environmentCount > 0
-    strategy: ${{ fromJson(needs.Initialization.outputs.environmentsMatrixJson) }}
+    if: fromJson(needs.Initialization.outputs.deploymentEnvironmentsJson).environmentCount > 0
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.Initialization.outputs.deploymentEnvironmentsJson).environments }}
     runs-on: ${{ fromJson(matrix.os) }}
-    name: Deploy to ${{ matrix.environment }}
+    name: Deploy to ${{ matrix.environmentName }}
     defaults:
       run:
         shell: ${{ matrix.shell }}
     environment:
-      name: ${{ matrix.environment }}
+      name: ${{ matrix.environmentName }}
       url: ${{ steps.Deploy.outputs.environmentUrl }}
     env:
       deviceCode: ${{ needs.Initialization.outputs.deviceCode }}
       ALGoEnvSettings: ${{ vars.ALGoEnvironmentSettings }}
-      ALGoEnvName: ${{ matrix.environment }}
+      ALGoEnvName: ${{ matrix.environmentName }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -141,7 +141,7 @@ jobs:
         id: envName
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $envName = '${{ matrix.environment }}'.split(' ')[0]
+          $envName = '${{ matrix.environmentName }}'.split(' ')[0]
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
@@ -172,10 +172,9 @@ jobs:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: ${{ matrix.shell }}
-          environmentName: ${{ matrix.environment }}
+          environmentName: ${{ matrix.environmentName }}
           artifactsFolder: '.artifacts'
           type: 'Publish'
-          deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
           artifactsVersion: ${{ github.event.inputs.appVersion }}
 
       - name: Deploy to Power Platform
@@ -185,9 +184,8 @@ jobs:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: ${{ matrix.shell }}
-          environmentName: ${{ matrix.environment }}
+          environmentName: ${{ matrix.environmentName }}
           artifactsFolder: '.artifacts'
-          deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
 
   PostProcess:
     needs: [ Initialization, Deploy ]


### PR DESCRIPTION
### ❔What, Why & How

_**What**_: Refactor logic for determining deployment environments and deployment script

_**Why**_: Currently, environment settings `deployTo<envName>` isn't taken into account during deployment.

_**How**_: Applying the following logic:
- _DetermineDeploymentsEnvironments_ action should not calculate deployment settings: they should be calculated in the _Deploy_ action per environment.
- _DetermineDeploymentsEnvironments_ should only calculate `shell`, `runs-on` and `enviromentName`, as they are needed runtime to construct the deployment matrix.
- Settings that are read during the deployment jobs should be taken into account when calculating the deployment configuration.

Related to issue: _no active issue at the moment_

### ✅ Checklist

- [ ] Add tests (E2E, unit tests)
- [ ] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry
- [ ] Test on a sample repository
