### PR TITLE
Fixing 'Publish to Environment' fails with build modes

### DIFF
--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -1026,7 +1026,7 @@ function GetArtifactsFromWorkflowRun {
         }
 
         foreach($project in $projectArr) {
-            $artifactPattern = "$project-*-*$mask-*" # e.g. "MyProject-*-Apps-*", format is: "project-branch-mask-version"
+            $artifactPattern = "$project-*-*$mask-*" # e.g. "MyProject-*-(BuildMode)Apps-*", format is: "project-branch-mask-version"
             $matchingArtifacts = @($artifacts.artifacts | Where-Object { $_.name -like $artifactPattern })
 
             if ($matchingArtifacts.Count -eq 0) {


### PR DESCRIPTION
### ❔What, Why & How

The mask used in the Publish to Environment action did not take the name of artifacts made with build modes into account.

Related to issue: #

### ✅ Checklist

- [ ] Add tests (E2E, unit tests)
- [ ] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
