### PR TITLE
Workflows run since January 14th '26 have space before CI/CD removed

### DIFF
--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -944,7 +944,7 @@ function FindLatestSuccessfulCICDRun {
             break
         }
 
-        $CICDRuns = @($workflowRuns.workflow_runs | Where-Object { $_.name -eq ' CI/CD' })
+        $CICDRuns = @($workflowRuns.workflow_runs | Where-Object { $_.name.Trim() -eq 'CI/CD' })
 
         foreach($CICDRun in $CICDRuns) {
             if($CICDRun.conclusion -eq 'success') {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,6 @@
 ### Issues
 
-- Issue 2078 Workflows run since Januari 14th '26 have space before CI/CD removed
+- Issue 2078 Workflows run since January 14th '26 have space before CI/CD removed
 - Issue 2070 Support public GitHub Packages feeds without requiring a Personal Access Token (PAT)
 - Issue 2004 PublishToAppSource workflow publishes multi-app repos in alphabetical order instead of dependency order
 - Issue 2045 DateTime parsing fails on non-US locale runners in WorkflowPostProcess.ps1

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,6 @@
 ### Issues
 
+- Issue 2078 Workflows run since Januari 14th '26 have space before CI/CD removed
 - Issue 2070 Support public GitHub Packages feeds without requiring a Personal Access Token (PAT)
 - Issue 2004 PublishToAppSource workflow publishes multi-app repos in alphabetical order instead of dependency order
 - Issue 2045 DateTime parsing fails on non-US locale runners in WorkflowPostProcess.ps1


### PR DESCRIPTION
### ❔What, Why & How

Workflows run since Januari 14th '26 have space before CI/CD removed

Fixes #2078

### ✅ Checklist

- [ ] Add tests (E2E, unit tests)
- [ ] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
