### PR TITLE
deliverToAppSource.ProductId needs to be specified (Library app)

### DIFF
--- a/Actions/Deliver/Deliver.ps1
+++ b/Actions/Deliver/Deliver.ps1
@@ -355,9 +355,7 @@ foreach ($thisProject in $sortedProjectList) {
             Write-Host "deliverToAppSource.ProductId is not specified, project is a library apps project"
             continue
         }
-        else {
-            Write-Host "deliverToAppSource.ProductId is $($projectSettings.deliverToAppSource.ProductId)"
-        }
+        Write-Host "deliverToAppSource.ProductId is $($projectSettings.deliverToAppSource.ProductId)"
         # if type is Release, we only get here with the projects that needs to be delivered to AppSource
         # if type is CD, we get here for all projects, but should only deliver to AppSource if AppSourceContinuousDelivery is set to true
         if ($type -eq 'Release' -or $projectSettings.deliverToAppSource.continuousDelivery) {

--- a/Actions/Deliver/Deliver.ps1
+++ b/Actions/Deliver/Deliver.ps1
@@ -352,7 +352,7 @@ foreach ($thisProject in $sortedProjectList) {
         }
         # Check whether project has a ProductId defined (needs to be submitted) or it is a library project
         if (!$projectSettings.deliverToAppSource.ProductId) {
-            Write-Host "deliverToAppSource.ProductId is not specified, project is a library apps project"
+            Write-Host "deliverToAppSource.ProductId is not specified, project is a library project"
             continue
         }
         Write-Host "deliverToAppSource.ProductId is $($projectSettings.deliverToAppSource.ProductId)"

--- a/Actions/Deliver/Deliver.ps1
+++ b/Actions/Deliver/Deliver.ps1
@@ -350,6 +350,14 @@ foreach ($thisProject in $sortedProjectList) {
                 $projectSettings.deliverToAppSource."$_" = $projectSettings."AppSource$_"
             }
         }
+        # Check whether project has a ProductId defined (needs to be submitted) or it is a library project
+        if (!$projectSettings.deliverToAppSource.ProductId) {
+            Write-Host "deliverToAppSource.ProductId is not specified, project is a library apps project"
+            continue
+        }
+        else {
+            Write-Host "deliverToAppSource.ProductId is $($projectSettings.deliverToAppSource.ProductId)"
+        }
         # if type is Release, we only get here with the projects that needs to be delivered to AppSource
         # if type is CD, we get here for all projects, but should only deliver to AppSource if AppSourceContinuousDelivery is set to true
         if ($type -eq 'Release' -or $projectSettings.deliverToAppSource.continuousDelivery) {
@@ -371,9 +379,6 @@ foreach ($thisProject in $sortedProjectList) {
                 catch {
                     throw "Unable to determine main App folder"
                 }
-            }
-            if (!$projectSettings.deliverToAppSource.ProductId) {
-                throw "deliverToAppSource.ProductId needs to be specified in $thisProject/.AL-Go/settings.json in order to deliver to AppSource"
             }
             Write-Host "AppSource MainAppFolder $AppSourceMainAppFolder"
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,6 @@
 ### Issues
 
+- Issue 2095 DeliverToAppSource.ProductId needs to be specified (Library app)
 - Issue 2082 Sign action no longer fails when repository is empty or no artifacts are generated
 - Issue 2078 Workflows run since January 14th '26 have space before CI/CD removed
 - Issue 2070 Support public GitHub Packages feeds without requiring a Personal Access Token (PAT)


### PR DESCRIPTION
### ❔What, Why & How

Deliver to AppSource will try to submit all projects to AppSource even though no ProductId is defined and hence fail when library projects exists

Related to issue: #2095 

Fixes #2095 

### ✅ Checklist

- [ ] Add tests (E2E, unit tests)
- [x] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
