### PR TITLE
Add TRASER AL-Go customizations for BC CI/CD migration

### DIFF
--- a/Actions/TRASER-CloseADOWorkItems/CloseADOWorkItems.ps1
+++ b/Actions/TRASER-CloseADOWorkItems/CloseADOWorkItems.ps1
@@ -1,0 +1,39 @@
+# TRASER ADO Work Item Auto-Close
+
+Param(
+    [Parameter(Mandatory)][string]$Organization,
+    [Parameter(Mandatory)][string]$Project,
+    [Parameter(Mandatory)][string]$Token,
+    [Parameter(Mandatory)][string]$FromTag,
+    [Parameter(Mandatory)][string]$ToTag,
+    [string]$SourceState = 'Release Pending',
+    [string]$TargetState = 'Done',
+    [string]$ReleaseUrl = ''
+)
+
+$headers = @{ Authorization = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$Token")); "Content-Type" = "application/json-patch+json" }
+$baseUrl = "https://dev.azure.com/$Organization/$Project/_apis"
+
+$commits = git log "$FromTag..$ToTag" --oneline 2>$null
+if (-not $commits) { Write-Host "No commits between $FromTag and $ToTag"; return }
+
+$ids = @()
+foreach ($c in $commits) { [regex]::Matches($c, 'AB#(\d+)') | ForEach-Object { $ids += [int]$_.Groups[1].Value } }
+$ids = $ids | Sort-Object -Unique
+if ($ids.Count -eq 0) { Write-Host "No AB# references found"; return }
+
+Write-Host "Found $($ids.Count) work items: $($ids -join ', ')"
+$closed = 0; $skipped = 0; $failed = 0
+
+foreach ($id in $ids) {
+    try {
+        $wi = Invoke-RestMethod -Uri "$baseUrl/wit/workItems/$id`?api-version=7.0" -Headers @{ Authorization = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$Token")) }
+        if ($wi.fields.'System.State' -ne $SourceState) { $skipped++; continue }
+        $body = @(@{ op = "add"; path = "/fields/System.State"; value = $TargetState }) | ConvertTo-Json -AsArray
+        Invoke-RestMethod -Uri "$baseUrl/wit/workItems/$id`?api-version=7.0" -Method Patch -Headers $headers -Body $body | Out-Null
+        $commentBody = @{ text = "Closed by GitHub Release <a href='$ReleaseUrl'>$ToTag</a>" } | ConvertTo-Json
+        Invoke-RestMethod -Uri "$baseUrl/wit/workItems/$id/comments?api-version=7.0-preview.4" -Method Post -Headers @{ Authorization = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$Token")); "Content-Type" = "application/json" } -Body $commentBody | Out-Null
+        $closed++
+    } catch { Write-Warning "#$id failed: $_"; $failed++ }
+}
+Write-Host "Results: $closed closed, $skipped skipped, $failed failed"

--- a/Actions/TRASER-CloseADOWorkItems/action.yaml
+++ b/Actions/TRASER-CloseADOWorkItems/action.yaml
@@ -1,0 +1,41 @@
+name: 'TRASER Close ADO Work Items'
+description: 'Transitions ADO work items from Release Pending to Done on GitHub release.'
+inputs:
+  ado-organization:
+    description: 'Azure DevOps organization'
+    required: true
+  ado-project:
+    description: 'Azure DevOps project'
+    required: true
+  ado-token:
+    description: 'ADO PAT with work item write'
+    required: true
+  from-tag:
+    description: 'Previous release tag'
+    required: true
+  to-tag:
+    description: 'Current release tag'
+    required: true
+  source-state:
+    required: false
+    default: 'Release Pending'
+  target-state:
+    required: false
+    default: 'Done'
+runs:
+  using: 'composite'
+  steps:
+    - name: Close work items
+      shell: powershell
+      env:
+        ADO_TOKEN: ${{ inputs.ado-token }}
+      run: |
+        & "${{ github.action_path }}/CloseADOWorkItems.ps1" `
+          -Organization "${{ inputs.ado-organization }}" `
+          -Project "${{ inputs.ado-project }}" `
+          -Token $ENV:ADO_TOKEN `
+          -FromTag "${{ inputs.from-tag }}" `
+          -ToTag "${{ inputs.to-tag }}" `
+          -SourceState "${{ inputs.source-state }}" `
+          -TargetState "${{ inputs.target-state }}" `
+          -ReleaseUrl "${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.to-tag }}"

--- a/Actions/TRASER-DependencyTree/DependencyTreeHelper.ps1
+++ b/Actions/TRASER-DependencyTree/DependencyTreeHelper.ps1
@@ -1,0 +1,43 @@
+# TRASER Dependency Tree Helper - extracted from TraserBCHelper
+
+function New-MutableAppObject {
+    param([PSCustomObject]$SourceObject, [int]$ProcessOrder)
+    $obj = [PSCustomObject]@{}
+    foreach ($prop in $SourceObject.PSObject.Properties.Name) {
+        $obj | Add-Member -MemberType NoteProperty -Name $prop -Value $SourceObject.$prop
+    }
+    $obj | Add-Member -MemberType NoteProperty -Name "ProcessOrder" -Value $ProcessOrder -Force
+    return $obj
+}
+
+function Add-ToDependencyTree {
+    param([PSCustomObject]$AppObject, [PSObject[]]$DependencyArray = @(), [PSObject[]]$AppCollection)
+    if ($null -ne $DependencyArray -and $DependencyArray.Count -gt 0) {
+        if ($DependencyArray | Where-Object { $_.Id -eq $AppObject.Id } | Select-Object -First 1) { return $DependencyArray }
+    }
+    if ($AppObject.PSObject.Properties.Name -notcontains 'Dependencies' -or $AppObject.Dependencies.Count -eq 0) {
+        return $DependencyArray + @(New-MutableAppObject -SourceObject $AppObject -ProcessOrder 0)
+    }
+    foreach ($dep in $AppObject.Dependencies) {
+        $match = $AppCollection | Where-Object { $_.Id -eq $dep.Id } | Select-Object -First 1
+        if ($match) { $DependencyArray = Add-ToDependencyTree -AppObject $match -DependencyArray $DependencyArray -AppCollection $AppCollection }
+    }
+    [int]$order = 0
+    foreach ($dep in $AppObject.Dependencies) {
+        $match = $DependencyArray | Where-Object { $_.Id -eq $dep.Id } | Select-Object -First 1
+        if ($match -and ($match.ProcessOrder + 1) -gt $order) { $order = $match.ProcessOrder + 1 }
+    }
+    return $DependencyArray + @(New-MutableAppObject -SourceObject $AppObject -ProcessOrder $order)
+}
+
+function Get-AppDependencyTree {
+    param([Parameter(Mandatory)][string]$Path)
+    $allApps = @()
+    Get-ChildItem -Path $Path -Filter "*.app" -Recurse | ForEach-Object {
+        $app = Get-AppJsonFromAppFile -appFile $_.FullName
+        $allApps += [PSCustomObject]@{ Id = $app.id; Version = [Version]$app.Version; Name = $app.Name; Publisher = $app.Publisher; ProcessOrder = 0; Dependencies = $app.Dependencies; Path = $_.FullName }
+    }
+    $result = @()
+    $allApps | ForEach-Object { $result = Add-ToDependencyTree -AppObject $_ -DependencyArray $result -AppCollection $allApps }
+    return $result | Sort-Object ProcessOrder
+}

--- a/Actions/TRASER-DependencyTree/action.yaml
+++ b/Actions/TRASER-DependencyTree/action.yaml
@@ -1,0 +1,21 @@
+name: 'TRASER Dependency Tree'
+description: 'Resolves app dependency ordering for correct installation sequence.'
+inputs:
+  apps-folder:
+    description: 'Path to folder containing .app files'
+    required: true
+outputs:
+  ordered-apps-json:
+    description: 'JSON array of app paths in dependency order'
+    value: ${{ steps.resolve.outputs.result }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve
+      id: resolve
+      shell: powershell
+      run: |
+        . "${{ github.action_path }}/DependencyTreeHelper.ps1"
+        $result = Get-AppDependencyTree -Path "${{ inputs.apps-folder }}"
+        $json = $result | Select-Object Name, Version, Path, ProcessOrder | ConvertTo-Json -Compress
+        Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "result=$json"

--- a/Actions/TRASER-DeployToCustomer/DeployToBCCustomer.ps1
+++ b/Actions/TRASER-DeployToCustomer/DeployToBCCustomer.ps1
@@ -1,0 +1,39 @@
+# TRASER On-Premise Customer Deployment - extracted from TraserBCHelper
+
+Param(
+    [Parameter(Mandatory)][string]$ServerInstance,
+    [Parameter(Mandatory)][string]$ArtifactsFolder,
+    [Parameter(Mandatory)][string]$NuGetToken,
+    [string]$SyncMode = 'Add',
+    [string]$TargetBCVersion = '',
+    [string]$Tenant = ''
+)
+
+# Import NAV module
+$navModule = Get-ChildItem "C:\Program Files\Microsoft Dynamics 365 Business Central\*\Service\Microsoft.Dynamics.Nav.Management.psm1" -ErrorAction SilentlyContinue | Select-Object -Last 1
+if (-not $navModule) { $navModule = Get-ChildItem "C:\Program Files (x86)\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Management.psm1" -ErrorAction SilentlyContinue | Select-Object -Last 1 }
+if ($navModule) { Import-Module $navModule.FullName -Force -DisableNameChecking } else { Write-Error "NAV module not found"; return }
+
+$orderedApps = Get-AppDependencyTree -Path $ArtifactsFolder
+Write-Host "Resolved $($orderedApps.Count) apps in dependency order"
+
+$tenants = if ($Tenant) { @($Tenant) } else { @(Get-NAVTenant -ServerInstance $ServerInstance | Select-Object -ExpandProperty Id) }
+if ($tenants.Count -eq 0) { $tenants = @('default') }
+
+foreach ($app in $orderedApps) {
+    Write-Host "`n--- $($app.Name) $($app.Version) ---"
+    $installed = Get-NAVAppInfo -ServerInstance $ServerInstance -Name $app.Name -Publisher $app.Publisher -ErrorAction SilentlyContinue
+    Publish-NAVApp -ServerInstance $ServerInstance -Path $app.Path -SkipVerification
+    foreach ($t in $tenants) {
+        Sync-NAVApp -ServerInstance $ServerInstance -Name $app.Name -Version $app.Version -Tenant $t -Mode $SyncMode
+        if ($installed -and [Version]$app.Version -gt [Version]$installed.Version) {
+            Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Name $app.Name -Version $app.Version -Tenant $t
+        } else {
+            Install-NAVApp -ServerInstance $ServerInstance -Name $app.Name -Version $app.Version -Tenant $t
+        }
+    }
+    if ($installed -and [Version]$app.Version -gt [Version]$installed.Version) {
+        Unpublish-NAVApp -ServerInstance $ServerInstance -Name $app.Name -Version $installed.Version -ErrorAction SilentlyContinue
+    }
+}
+Write-Host "`nDeployment complete"

--- a/Actions/TRASER-DeployToCustomer/action.yaml
+++ b/Actions/TRASER-DeployToCustomer/action.yaml
@@ -1,0 +1,45 @@
+name: 'TRASER Deploy to Customer'
+description: 'Deploys BC apps to on-premise customer servers with multi-tenant support and dependency ordering.'
+inputs:
+  server-instance:
+    description: 'BC Server instance name'
+    required: true
+  artifacts-folder:
+    description: 'Path to .app files'
+    required: true
+  nuget-token:
+    description: 'NuGet feed token'
+    required: true
+  sync-mode:
+    description: 'Sync mode: Add, Development, or ForceSync'
+    required: false
+    default: 'Add'
+  target-bc-version:
+    description: 'Target BC version'
+    required: false
+    default: ''
+  target-bc-country:
+    description: 'Target country code'
+    required: false
+    default: 'w1'
+  tenant:
+    description: 'Specific tenant (empty for all)'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Deploy
+      shell: powershell
+      env:
+        NUGET_TOKEN: ${{ inputs.nuget-token }}
+      run: |
+        . "${{ github.action_path }}/../TRASER-DependencyTree/DependencyTreeHelper.ps1"
+        . "${{ github.action_path }}/../TRASER-NuGetHelper/NuGetHelper.ps1"
+        & "${{ github.action_path }}/DeployToBCCustomer.ps1" `
+          -ServerInstance "${{ inputs.server-instance }}" `
+          -ArtifactsFolder "${{ inputs.artifacts-folder }}" `
+          -NuGetToken $ENV:NUGET_TOKEN `
+          -SyncMode "${{ inputs.sync-mode }}" `
+          -TargetBCVersion "${{ inputs.target-bc-version }}" `
+          -Tenant "${{ inputs.tenant }}"

--- a/Actions/TRASER-MigrateConfig/MigrateConfig.ps1
+++ b/Actions/TRASER-MigrateConfig/MigrateConfig.ps1
@@ -1,0 +1,40 @@
+# TRASER config.json to AL-Go settings.json Migration
+
+Param(
+    [string]$ConfigJsonPath = "./config.json",
+    [string]$OutputPath = "./.AL-Go/settings.json",
+    [ValidateSet("master", "release")][string]$MainBranchDependencyStrategy = "master"
+)
+
+if (-not (Test-Path $ConfigJsonPath)) { Write-Error "config.json not found at $ConfigJsonPath"; return }
+$config = Get-Content -Encoding UTF8 $ConfigJsonPath | ConvertFrom-Json
+
+$settings = [ordered]@{
+    '$schema' = "https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v8.3/.Modules/settings.schema.json"
+    country = "de"; appFolders = @(); testFolders = @(); bcptTestFolders = @()
+    gitHubRunner = "[ self-hosted, windows ]"; gitHubRunnerShell = "powershell"
+}
+
+if ($config.PSObject.Properties.Name -contains 'apppath' -and $config.apppath) { $settings.appFolders = @($config.apppath) }
+if ($config.PSObject.Properties.Name -contains 'testpath' -and $config.testpath) { $settings.testFolders = @($config.testpath) }
+if ($config.PSObject.Properties.Name -contains 'bcversion' -and $config.bcversion.PSObject.Properties.Name -contains 'country') { $settings.country = $config.bcversion.country }
+
+$settings.CICDPushBranches = @("main", "staging", "release/*", "feature/*")
+$settings.CICDPullRequestTargetBranches = @("main", "staging", "release/*")
+
+$runtimeFeed = "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-runtime/nuget/v3/index.json"
+$mainFeed = if ($MainBranchDependencyStrategy -eq "release") { $runtimeFeed -replace "bc-runtime", "bc-release" } else { $runtimeFeed -replace "bc-runtime", "bc-master" }
+$stagingFeed = $runtimeFeed -replace "bc-runtime", "bc-staging"
+$releaseFeed = $runtimeFeed -replace "bc-runtime", "bc-release"
+
+$settings.trustedNuGetFeeds = @([ordered]@{ url = $runtimeFeed; authTokenSecret = "NUGET_TOKEN" })
+$settings.ConditionalSettings = @(
+    [ordered]@{ branches = @("staging"); settings = [ordered]@{ versioningStrategy = 0; trustedNuGetFeeds = @([ordered]@{ url = $stagingFeed; authTokenSecret = "NUGET_TOKEN" }, [ordered]@{ url = $runtimeFeed; authTokenSecret = "NUGET_TOKEN" }) } }
+    [ordered]@{ branches = @("main"); settings = [ordered]@{ trustedNuGetFeeds = @([ordered]@{ url = $mainFeed; authTokenSecret = "NUGET_TOKEN" }, [ordered]@{ url = $runtimeFeed; authTokenSecret = "NUGET_TOKEN" }) } }
+    [ordered]@{ branches = @("release/*"); settings = [ordered]@{ trustedNuGetFeeds = @([ordered]@{ url = $releaseFeed; authTokenSecret = "NUGET_TOKEN" }, [ordered]@{ url = $runtimeFeed; authTokenSecret = "NUGET_TOKEN" }) } }
+)
+
+$outputDir = Split-Path $OutputPath -Parent
+if (-not (Test-Path $outputDir)) { New-Item -ItemType Directory -Path $outputDir -Force | Out-Null }
+$settings | ConvertTo-Json -Depth 10 | Set-Content -Encoding UTF8 $OutputPath
+Write-Host "Generated AL-Go settings at $OutputPath (strategy: $MainBranchDependencyStrategy)"

--- a/Actions/TRASER-MigrateConfig/action.yaml
+++ b/Actions/TRASER-MigrateConfig/action.yaml
@@ -1,0 +1,22 @@
+name: 'TRASER Migrate Config'
+description: 'Migrates legacy config.json to AL-Go settings.json.'
+inputs:
+  config-path:
+    required: false
+    default: './config.json'
+  output-path:
+    required: false
+    default: './.AL-Go/settings.json'
+  main-branch-strategy:
+    required: false
+    default: 'master'
+runs:
+  using: 'composite'
+  steps:
+    - name: Migrate
+      shell: powershell
+      run: |
+        & "${{ github.action_path }}/MigrateConfig.ps1" `
+          -ConfigJsonPath "${{ inputs.config-path }}" `
+          -OutputPath "${{ inputs.output-path }}" `
+          -MainBranchDependencyStrategy "${{ inputs.main-branch-strategy }}"

--- a/Actions/TRASER-NuGetHelper/NuGetHelper.ps1
+++ b/Actions/TRASER-NuGetHelper/NuGetHelper.ps1
@@ -1,0 +1,61 @@
+# TRASER NuGet Helper Functions
+
+$TRASERNuGetConfig = @{
+    MasterFeed    = "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-master/nuget/v3/index.json"
+    StagingFeed   = "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-staging/nuget/v3/index.json"
+    ReleaseFeed   = "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-release/nuget/v3/index.json"
+    RuntimeFeed   = "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-runtime/nuget/v3/index.json"
+    AppSourceFeed = "https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/AppSourceSymbols/nuget/v3/index.json"
+    TRASERPublisher = "TRASER Software GmbH"
+    ForNAVMapping = @{
+        "7.0.0.1" = "7.0.0.2350"
+        "7.1.0.1" = "7.1.0.2400"
+    }
+}
+
+function Get-TRASERNuGetFeed {
+    param(
+        [ValidateSet("master", "staging", "release")][string]$ReleaseType = "master",
+        [string]$Publisher = "",
+        [switch]$RuntimePackage,
+        [switch]$UseAppSourceFeed
+    )
+    if ($UseAppSourceFeed) { return $TRASERNuGetConfig.AppSourceFeed }
+    elseif (($Publisher -ne $TRASERNuGetConfig.TRASERPublisher) -or $RuntimePackage) { return $TRASERNuGetConfig.RuntimeFeed }
+    elseif ($ReleaseType -eq "master") { return $TRASERNuGetConfig.MasterFeed }
+    elseif ($ReleaseType -eq "staging") { return $TRASERNuGetConfig.StagingFeed }
+    elseif ($ReleaseType -eq "release") { return $TRASERNuGetConfig.ReleaseFeed }
+    else { throw "No feed found for release type '$ReleaseType' and publisher '$Publisher'" }
+}
+
+function Get-TRASERNuGetPackageId {
+    param(
+        [Parameter(Mandatory)][string]$Publisher,
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Id,
+        [switch]$RuntimePackage,
+        [string]$RuntimeVersion = ""
+    )
+    $p = $Publisher.Replace(" ", ".").ToLower()
+    $n = $Name.Replace(" ", ".").ToLower()
+    if ($RuntimePackage) {
+        if ($RuntimeVersion) { return "$p.$n.runtime-$RuntimeVersion" }
+        return "$p.$n.runtime.$Id"
+    }
+    return "$p.$n.$Id"
+}
+
+function Get-ReleaseTypeFromBranch {
+    param([string]$BranchRef = $ENV:GITHUB_REF)
+    if ($BranchRef -match "refs/heads/staging") { return "staging" }
+    elseif ($BranchRef -match "refs/heads/release/") { return "release" }
+    else { return "master" }
+}
+
+function Get-ForNAVServiceVersion {
+    param([string]$ForNAVCoreVersion)
+    if ($TRASERNuGetConfig.ForNAVMapping.ContainsKey($ForNAVCoreVersion)) {
+        return $TRASERNuGetConfig.ForNAVMapping[$ForNAVCoreVersion]
+    }
+    return $null
+}

--- a/Actions/TRASER-NuGetHelper/action.yaml
+++ b/Actions/TRASER-NuGetHelper/action.yaml
@@ -1,0 +1,27 @@
+name: 'TRASER NuGet Helper'
+description: 'TRASER NuGet feed routing, package naming, and version range management.'
+inputs:
+  release-type:
+    description: 'Release type (auto-detected from branch if empty)'
+    required: false
+    default: ''
+outputs:
+  feed-url:
+    description: 'Resolved NuGet feed URL'
+    value: ${{ steps.resolve.outputs.feed-url }}
+  release-type:
+    description: 'Detected release type'
+    value: ${{ steps.resolve.outputs.release-type }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve NuGet feed
+      id: resolve
+      shell: powershell
+      run: |
+        . "${{ github.action_path }}/NuGetHelper.ps1"
+        $rt = "${{ inputs.release-type }}"
+        if (-not $rt) { $rt = Get-ReleaseTypeFromBranch }
+        $feedUrl = Get-TRASERNuGetFeed -ReleaseType $rt
+        Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "feed-url=$feedUrl"
+        Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "release-type=$rt"

--- a/Actions/TRASER-Overrides/NewBcContainer.ps1
+++ b/Actions/TRASER-Overrides/NewBcContainer.ps1
@@ -1,0 +1,81 @@
+# TRASER NewBcContainer Override Implementation
+# Called from .AL-Go/NewBcContainer.ps1 thin wrapper in product repos.
+
+Param(
+    [hashtable]$parameters
+)
+
+$containerName = $parameters.ContainerName
+
+$parameters["accept_insiderEula"] = $true
+$parameters["TimeZoneId"] = (Get-TimeZone).Id
+$parameters["accept_outdated"] = $true
+
+if (-not $parameters.ContainsKey("includeTestToolkit")) {
+    $parameters["includeTestToolkit"] = $true
+    $parameters["includeTestLibrariesOnly"] = $true
+}
+
+if (-not $parameters.ContainsKey("additionalParameters")) {
+    $parameters["additionalParameters"] = @()
+}
+$parameters["additionalParameters"] += @(
+    "--env defaultTenantHasAllowAppDatabaseWrite=Y",
+    "-e customNavSettings=ClientServicesMaxUploadSize=2000"
+)
+
+$bakFolder = $ENV:BAK_FOLDER
+if ($bakFolder -and (Test-Path $bakFolder)) {
+    Write-Host "Using BAK folder: $bakFolder"
+    $parameters["bakFolder"] = $bakFolder
+}
+
+New-BcContainer @parameters
+
+if (-not $parameters.filesOnly) {
+    $traefikDomain = $ENV:TRAEFIK_DOMAIN
+    if ($traefikDomain) {
+        Write-Host "Configuring Traefik timeout settings for $containerName"
+        Invoke-ScriptInBcContainer -containerName $containerName -usePwsh $false -scriptblock {
+            Param($webServerInstance)
+            Set-NAVWebServerInstanceConfiguration -WebServerInstance $webServerInstance -KeyName "SessionTimeout" -KeyValue "23:59:59"
+            Set-NAVServerConfiguration $ServerInstance -KeyName "SqlConnectionIdleTimeout" -KeyValue "23:59:59" -ErrorAction Continue
+            Set-NAVServerConfiguration $ServerInstance -KeyName "SqlCommandTimeout" -KeyValue "03:00:00" -ErrorAction Continue
+            Install-WindowsFeature web-scripting-tools -ErrorAction SilentlyContinue
+            Set-WebConfigurationProperty -filter /system.webserver/security/requestfiltering/requestLimits -name maxAllowedContentLength -value 2000000000
+            Restart-NAVServerInstance $serverInstance
+            while (Get-NavTenant $serverInstance | Where-Object { $_.State -eq "Mounting" }) {
+                Start-Sleep -Seconds 1
+            }
+        } -argumentList $containerName
+    }
+
+    $forNAVServicePath = $ENV:FORNAV_SERVICE_PATH
+    if ($forNAVServicePath -and (Test-Path $forNAVServicePath)) {
+        Write-Host "Installing ForNAV Service from $forNAVServicePath"
+        $forNAVContainerFolder = "C:\Run\ForNAV Service"
+        try {
+            Copy-FileToBcContainer -containerName $containerName -localPath $forNAVServicePath -containerPath ($forNAVContainerFolder + '\' + (Split-Path $forNAVServicePath -Leaf))
+            $containerExe = $forNAVContainerFolder + '\' + (Split-Path $forNAVServicePath -Leaf)
+            Invoke-ScriptInBcContainer -containerName $containerName -scriptblock {
+                Param([string]$exePath)
+                Start-Process -FilePath $exePath -ArgumentList '/COMPONENTS="deployment\reportservice"', '/VERYSILENT', '/NORESTART', '/SUPPRESSMESSAGEBOXES' -Wait
+            } -ArgumentList $containerExe
+        } catch {
+            Write-Warning "ForNAV Service installation failed: $_"
+        }
+    }
+
+    $fontsFolder = $ENV:CUSTOM_FONTS_PATH
+    if ($fontsFolder -and (Test-Path $fontsFolder)) {
+        Get-ChildItem -Path $fontsFolder -Filter "*.ttf" | ForEach-Object {
+            Add-FontsToBcContainer -containerName $containerName -path $_.FullName
+        }
+    }
+
+    Get-ChildItem -Path "c:\windows\fonts" -Filter "arial*.ttf" -ErrorAction SilentlyContinue | ForEach-Object {
+        Add-FontsToBcContainer -containerName $containerName -path $_.FullName
+    }
+}
+
+Write-Host "TRASER container setup complete for $containerName"

--- a/Actions/TRASER-Overrides/PreCompileApp.ps1
+++ b/Actions/TRASER-Overrides/PreCompileApp.ps1
@@ -1,0 +1,19 @@
+# TRASER PreCompileApp Override Implementation
+# Removes internalsVisibleTo from app.json before compilation.
+
+Param(
+    [hashtable]$parameters
+)
+
+$project = $parameters.project
+$projectFolder = Join-Path $ENV:GITHUB_WORKSPACE $project
+
+$appJsonFiles = Get-ChildItem -Path $projectFolder -Filter "app.json" -Recurse
+foreach ($appJsonFile in $appJsonFiles) {
+    $appInfo = Get-Content -Encoding UTF8 $appJsonFile.FullName | ConvertFrom-Json
+    if ($appInfo.PSObject.Properties.Name -match 'internalsVisibleTo') {
+        $appInfo.PSObject.Properties.Remove('internalsVisibleTo')
+        $appInfo | ConvertTo-Json -Depth 100 | Set-Content -Encoding UTF8 $appJsonFile.FullName
+        Write-Host "Removed internalsVisibleTo from $($appInfo.name)"
+    }
+}

--- a/Actions/TRASER-PackageBCProduct/PackageBCProduct.ps1
+++ b/Actions/TRASER-PackageBCProduct/PackageBCProduct.ps1
@@ -1,0 +1,37 @@
+# TRASER Product Packaging - extracted from TraserBCHelper Package-ALProduct
+
+Param(
+    [Parameter(Mandatory)][string]$ArtifactsFolder,
+    [Parameter(Mandatory)][string]$Output,
+    [string]$TargetBCVersion = '',
+    [string]$TargetBCCountry = 'w1'
+)
+
+New-Item -ItemType Directory -Path $Output -Force | Out-Null
+$appFiles = Get-ChildItem -Path $ArtifactsFolder -Filter "*.app" -Recurse
+if ($appFiles.Count -eq 0) { Write-Error "No .app files found"; return }
+
+$primaryApp = Get-AppJsonFromAppFile -appFile $appFiles[0].FullName
+$publisher = $primaryApp.publisher; $name = $primaryApp.name; $version = $primaryApp.version
+
+# SaaS package
+$saasDir = Join-Path $Output "saas-temp"
+New-Item -ItemType Directory -Path $saasDir -Force | Out-Null
+Copy-Item "$ArtifactsFolder\*.app" -Destination $saasDir -Recurse
+$saasZip = Join-Path $Output "${publisher}_${name}_${version}_SAAS.zip"
+Compress-Archive -Path "$saasDir\*" -DestinationPath $saasZip -Force
+Remove-Item $saasDir -Recurse -Force
+Write-Host "Created: $(Split-Path $saasZip -Leaf)"
+Add-Content -Encoding UTF8 -Path $ENV:GITHUB_OUTPUT -Value "saas-package=$saasZip"
+
+# Runtime package
+if ($TargetBCVersion) {
+    $rtDir = Join-Path $Output "runtime-temp"
+    New-Item -ItemType Directory -Path $rtDir -Force | Out-Null
+    Copy-Item "$ArtifactsFolder\*.app" -Destination $rtDir -Recurse
+    $rtZip = Join-Path $Output "${publisher}_${name}_${version}_RUNTIME-${TargetBCVersion}-${TargetBCCountry}.zip"
+    Compress-Archive -Path "$rtDir\*" -DestinationPath $rtZip -Force
+    Remove-Item $rtDir -Recurse -Force
+    Write-Host "Created: $(Split-Path $rtZip -Leaf)"
+    Add-Content -Encoding UTF8 -Path $ENV:GITHUB_OUTPUT -Value "runtime-package=$rtZip"
+}

--- a/Actions/TRASER-PackageBCProduct/action.yaml
+++ b/Actions/TRASER-PackageBCProduct/action.yaml
@@ -1,0 +1,36 @@
+name: 'TRASER Package BC Product'
+description: 'Creates SaaS and runtime distribution zip packages.'
+inputs:
+  artifacts-folder:
+    description: 'Path to compiled .app files'
+    required: true
+  output:
+    description: 'Output directory'
+    required: true
+  target-bc-version:
+    description: 'BC version for runtime variant'
+    required: false
+    default: ''
+  target-bc-country:
+    description: 'Country code'
+    required: false
+    default: 'w1'
+outputs:
+  saas-package:
+    description: 'Path to SaaS zip'
+    value: ${{ steps.pkg.outputs.saas-package }}
+  runtime-package:
+    description: 'Path to runtime zip'
+    value: ${{ steps.pkg.outputs.runtime-package }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Package
+      id: pkg
+      shell: powershell
+      run: |
+        & "${{ github.action_path }}/PackageBCProduct.ps1" `
+          -ArtifactsFolder "${{ inputs.artifacts-folder }}" `
+          -Output "${{ inputs.output }}" `
+          -TargetBCVersion "${{ inputs.target-bc-version }}" `
+          -TargetBCCountry "${{ inputs.target-bc-country }}"

--- a/Actions/TRASER-PublishBCNuGet/Publish-BCNuGet.ps1
+++ b/Actions/TRASER-PublishBCNuGet/Publish-BCNuGet.ps1
@@ -1,0 +1,69 @@
+# TRASER NuGet Publishing - extracted from TraserBCHelper Push-AppsToNuget
+
+Param(
+    [Parameter(Mandatory)][string]$ArtifactsFolder,
+    [Parameter(Mandatory)][string]$NuGetToken,
+    [string]$ReleaseType = '',
+    [switch]$RuntimePackage,
+    [string]$RuntimeBCVersion = '',
+    [string]$RuntimeValidFor = 'major'
+)
+
+if (-not $ReleaseType) { $ReleaseType = Get-ReleaseTypeFromBranch }
+Write-Host "Publishing with release type: $ReleaseType"
+
+$appFiles = Get-ChildItem -Path $ArtifactsFolder -Filter *.app -Recurse | Sort-Object Name
+foreach ($appFile in $appFiles) {
+    $appJson = Get-AppJsonFromAppFile -appFile $appFile.FullName
+    $publisher = $appJson.publisher
+    $isTraser = ($publisher -eq $TRASERNuGetConfig.TRASERPublisher)
+
+    if ((-not $isTraser) -or $RuntimePackage) {
+        $feedUrl = Get-TRASERNuGetFeed -ReleaseType $ReleaseType -Publisher $publisher -RuntimePackage
+        if (-not $RuntimeBCVersion) { Write-Error "RuntimeBCVersion required for runtime packages."; continue }
+        $runtimeVer = [Version]$RuntimeBCVersion
+
+        # Indirect package
+        $indirectId = Get-BcNuGetPackageId -packageIdTemplate "{publisher}.{name}.runtime.{id}" -publisher $publisher -name $appJson.name -id $appJson.id
+        $exists = $false; try { $exists = Test-BcNuGetPackage -nuGetServerUrl $feedUrl -nuGetToken $NuGetToken -packageName $indirectId -version $appJson.version -select Exact } catch {}
+        if (-not $exists) {
+            $appAppVer = [Version]$appJson.Application
+            $fromVer = [Version]::new($appAppVer.Major, $appAppVer.Minor, 0, 0)
+            $pkg = New-BcNuGetPackage -appfile $appFile.FullName -isIndirectPackage -packageId "{publisher}.{name}.runtime.{id}" -dependencyIdTemplate "{publisher}.{name}.runtime.{id}" -applicationDependency $fromVer
+            Push-BcNuGetPackage -nuGetServerUrl $feedUrl -nuGetToken $NuGetToken -bcNuGetPackage $pkg
+            Remove-Item $pkg -Force -ErrorAction SilentlyContinue
+            Write-Host "Published indirect: $indirectId"
+        }
+
+        # Version-specific package
+        $versionId = Get-BcNuGetPackageId -packageIdTemplate "{publisher}.{name}.runtime-{version}" -publisher $publisher -name $appJson.name -version $appJson.version
+        $exists = $false; try { $exists = Test-BcNuGetPackage -nuGetServerUrl $feedUrl -nuGetToken $NuGetToken -packageName $versionId -version $runtimeVer -select Exact } catch {}
+        if (-not $exists) {
+            switch ($RuntimeValidFor) {
+                'major' { $appDep = "[$($runtimeVer.Major).$($runtimeVer.Minor),$($runtimeVer.Major + 1).0)" }
+                'minor' { $appDep = "[$($runtimeVer.Major).$($runtimeVer.Minor),$($runtimeVer.Major).$($runtimeVer.Minor + 1))" }
+            }
+            $platDep = "[$($runtimeVer.Major).0,$($runtimeVer.Major + 1).0)"
+            $pkg = New-BcNuGetPackage -appfile $appFile.FullName -packageId "{publisher}.{name}.runtime-{version}" -dependencyIdTemplate "{publisher}.{name}.runtime.{id}" -packageVersion $runtimeVer -applicationDependency $appDep -platformDependency $platDep
+            Push-BcNuGetPackage -nuGetServerUrl $feedUrl -nuGetToken $NuGetToken -bcNuGetPackage $pkg
+            Remove-Item $pkg -Force -ErrorAction SilentlyContinue
+            Write-Host "Published version-specific: $versionId"
+        }
+    } else {
+        $feedUrl = Get-TRASERNuGetFeed -ReleaseType $ReleaseType -Publisher $publisher
+        $packageName = Get-BcNuGetPackageId -publisher $publisher -name $appJson.name -id $appJson.id -version $appJson.version
+        $exists = $false; try { $exists = Test-BcNuGetPackage -nuGetServerUrl $feedUrl -nuGetToken $NuGetToken -packageName $packageName -version $appJson.version -select Exact } catch {}
+        if ($exists) { Write-Host "Skipping $($appJson.name) $($appJson.version) - exists"; continue }
+
+        if ($ReleaseType -eq 'release') {
+            $appAppVer = [Version]$appJson.Application
+            $appDep = "[$($appAppVer.Major).$($appAppVer.Minor),$($appAppVer.Major + 3).0)"
+            $pkg = New-BcNuGetPackage -appfile $appFile.FullName -applicationDependency $appDep
+        } else {
+            $pkg = New-BcNuGetPackage -appfile $appFile.FullName
+        }
+        Push-BcNuGetPackage -nuGetServerUrl $feedUrl -nuGetToken $NuGetToken -bcNuGetPackage $pkg
+        Remove-Item $pkg -Force -ErrorAction SilentlyContinue
+        Write-Host "Published $($appJson.name) $($appJson.version) to $ReleaseType"
+    }
+}

--- a/Actions/TRASER-PublishBCNuGet/action.yaml
+++ b/Actions/TRASER-PublishBCNuGet/action.yaml
@@ -1,0 +1,41 @@
+name: 'TRASER Publish BC NuGet'
+description: 'Publishes BC apps to TRASER NuGet feeds with multi-feed routing and runtime dual-publishing.'
+inputs:
+  artifacts-folder:
+    description: 'Path to compiled .app files'
+    required: true
+  nuget-token:
+    description: 'NuGet feed authentication token'
+    required: true
+  release-type:
+    description: 'Release type (auto-detected from branch if empty)'
+    required: false
+    default: ''
+  runtime-package:
+    description: 'Publish as runtime packages'
+    required: false
+    default: 'false'
+  runtime-bc-version:
+    description: 'BC version for runtime packages'
+    required: false
+    default: ''
+  runtime-valid-for:
+    description: 'Runtime version range: major or minor'
+    required: false
+    default: 'major'
+runs:
+  using: 'composite'
+  steps:
+    - name: Publish to NuGet
+      shell: powershell
+      env:
+        NUGET_TOKEN: ${{ inputs.nuget-token }}
+      run: |
+        . "${{ github.action_path }}/../TRASER-NuGetHelper/NuGetHelper.ps1"
+        & "${{ github.action_path }}/Publish-BCNuGet.ps1" `
+          -ArtifactsFolder "${{ inputs.artifacts-folder }}" `
+          -NuGetToken $ENV:NUGET_TOKEN `
+          -ReleaseType "${{ inputs.release-type }}" `
+          -RuntimePackage:([bool]::Parse("${{ inputs.runtime-package }}")) `
+          -RuntimeBCVersion "${{ inputs.runtime-bc-version }}" `
+          -RuntimeValidFor "${{ inputs.runtime-valid-for }}"

--- a/Templates/AppSource App/.AL-Go/NewBcContainer.ps1
+++ b/Templates/AppSource App/.AL-Go/NewBcContainer.ps1
@@ -1,0 +1,4 @@
+Param([Hashtable] $parameters)
+
+$script = Join-Path $PSScriptRoot "../../../Actions/TRASER-Overrides/NewBcContainer.ps1" -Resolve
+. $script -parameters $parameters

--- a/Templates/AppSource App/.AL-Go/PreCompileApp.ps1
+++ b/Templates/AppSource App/.AL-Go/PreCompileApp.ps1
@@ -1,0 +1,4 @@
+Param([Hashtable] $parameters)
+
+$script = Join-Path $PSScriptRoot "../../../Actions/TRASER-Overrides/PreCompileApp.ps1" -Resolve
+. $script -parameters $parameters

--- a/Templates/AppSource App/.AL-Go/settings.json
+++ b/Templates/AppSource App/.AL-Go/settings.json
@@ -1,10 +1,42 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go-Actions/main/.Modules/settings.schema.json",
-  "country": "us",
-  "appSourceCopMandatoryAffixes": [
-    "<affix>"
-  ],
+  "country": "de",
+  "appSourceCopMandatoryAffixes": [ "TSR" ],
   "appFolders": [],
   "testFolders": [],
-  "bcptTestFolders": []
+  "bcptTestFolders": [],
+  "gitHubRunner": "[ self-hosted, windows ]",
+  "gitHubRunnerShell": "powershell",
+  "CICDPushBranches": [ "main", "staging", "release/*", "feature/*" ],
+  "CICDPullRequestTargetBranches": [ "main", "staging", "release/*" ],
+  "environments": [ "Internal-Master", "Internal-Staging" ],
+  "DeployToInternal-Master": {
+    "branches": [ "main" ],
+    "environmentName": "Internal-Master",
+    "ContinuousDeployment": true,
+    "runs-on": "[ self-hosted, windows ]"
+  },
+  "DeployToInternal-Staging": {
+    "branches": [ "staging" ],
+    "environmentName": "Internal-Staging",
+    "ContinuousDeployment": true,
+    "runs-on": "[ self-hosted, windows ]"
+  },
+  "trustedNuGetFeeds": [
+    { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-runtime/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" }
+  ],
+  "ConditionalSettings": [
+    { "branches": [ "staging" ], "settings": { "versioningStrategy": 0, "trustedNuGetFeeds": [
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-staging/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" },
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-runtime/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" }
+    ] } },
+    { "branches": [ "main" ], "settings": { "trustedNuGetFeeds": [
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-master/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" },
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-runtime/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" }
+    ] } },
+    { "branches": [ "release/*" ], "settings": { "trustedNuGetFeeds": [
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-release/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" },
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-runtime/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" }
+    ] } }
+  ]
 }

--- a/Templates/AppSource App/.github/workflows/TRASER-DeployToCustomer.yaml
+++ b/Templates/AppSource App/.github/workflows/TRASER-DeployToCustomer.yaml
@@ -1,0 +1,46 @@
+name: 'TRASER Deploy to Customer'
+
+on:
+  workflow_dispatch:
+    inputs:
+      customer:
+        description: 'Customer environment name (GitHub Environment)'
+        required: true
+        type: string
+      version:
+        description: 'Release version to deploy (tag name)'
+        required: true
+        type: string
+      syncMode:
+        description: 'Sync mode'
+        required: false
+        type: choice
+        options: [ Add, ForceSync ]
+        default: Add
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  Deploy:
+    environment: ${{ inputs.customer }}
+    runs-on: [ self-hosted, windows ]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Deploy to customer
+        uses: microsoft/AL-Go-Actions/TRASER-DeployToCustomer@main
+        with:
+          server-instance: ${{ secrets.SERVER_INSTANCE }}
+          artifacts-folder: ./artifacts
+          nuget-token: ${{ secrets.NUGET_TOKEN }}
+          sync-mode: ${{ inputs.syncMode }}
+          target-bc-version: ${{ secrets.BC_VERSION }}

--- a/Templates/AppSource App/.github/workflows/TRASER-NightlyBackup.yaml
+++ b/Templates/AppSource App/.github/workflows/TRASER-NightlyBackup.yaml
@@ -1,0 +1,80 @@
+name: 'TRASER Nightly Backup'
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      bcVersion:
+        description: 'BC version override (leave empty for default)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  Backup:
+    runs-on: [ self-hosted, windows ]
+    timeout-minutes: 120
+    strategy:
+      matrix:
+        include:
+          - branch: main
+            bakVar: BAK_FOLDER_MASTER
+          - branch: staging
+            bakVar: BAK_FOLDER_STAGING
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Read settings
+        id: settings
+        run: |
+          $settings = Get-Content ".AL-Go/settings.json" -Encoding UTF8 | ConvertFrom-Json
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "country=$($settings.country)"
+
+      - name: Create Nightly Backup
+        env:
+          BC_LICENSE_URL: ${{ secrets.BC_LICENSE_FILE_URL }}
+          BAK_FOLDER: ${{ vars[matrix.bakVar] }}
+          CONTAINER_PASSWORD: ${{ secrets.BC_CONTAINER_PASSWORD }}
+        run: |
+          $containerName = "nightly-bak-${{ matrix.branch }}"
+          $bakFolder = $ENV:BAK_FOLDER
+          if (-not $bakFolder) { Write-Warning "No BAK folder for ${{ matrix.branch }}"; return }
+
+          if (Test-BcContainer -containerName $containerName) { Remove-BcContainer -containerName $containerName }
+
+          $credential = New-Object PSCredential 'admin' (ConvertTo-SecureString $ENV:CONTAINER_PASSWORD -AsPlainText -Force)
+          $artifactUrl = Get-BCArtifactUrl -type OnPrem -country ${{ steps.settings.outputs.country }} -select Latest
+          if ("${{ inputs.bcVersion }}" -ne "") {
+            $artifactUrl = Get-BCArtifactUrl -type OnPrem -country ${{ steps.settings.outputs.country }} -version "${{ inputs.bcVersion }}" -select Latest
+          }
+
+          New-BcContainer -accept_eula -containerName $containerName -artifactUrl $artifactUrl -credential $credential `
+            -auth NavUserPassword -licenseFile $ENV:BC_LICENSE_URL -includeTestToolkit -includeTestLibrariesOnly `
+            -accept_outdated -updateHosts
+
+          New-Item -ItemType Directory -Path $bakFolder -Force | Out-Null
+          Backup-BcContainerDatabases -containerName $containerName -bakFolder $bakFolder
+
+          @{ createdAt = (Get-Date -Format "o"); branch = "${{ matrix.branch }}" } | ConvertTo-Json |
+            Set-Content -Path (Join-Path $bakFolder "metadata.json") -Encoding UTF8
+
+          Remove-BcContainer -containerName $containerName
+
+      - name: Apply retention policy
+        env:
+          BAK_FOLDER: ${{ vars[matrix.bakVar] }}
+        run: |
+          $bak = $ENV:BAK_FOLDER
+          if (-not $bak -or -not (Test-Path $bak)) { return }
+          Get-ChildItem $bak -Filter "*.bak" | Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-14) } | Remove-Item -Force

--- a/Templates/AppSource App/.github/workflows/TRASER-NightlyTests.yaml
+++ b/Templates/AppSource App/.github/workflows/TRASER-NightlyTests.yaml
@@ -1,0 +1,57 @@
+name: 'TRASER Nightly Tests'
+
+on:
+  schedule:
+    - cron: '0 3 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  Test:
+    runs-on: [ self-hosted, windows ]
+    timeout-minutes: 360
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read settings
+        id: settings
+        run: |
+          $s = Get-Content ".AL-Go/settings.json" -Encoding UTF8 | ConvertFrom-Json
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "country=$($s.country)"
+
+      - name: Run Nightly Tests
+        env:
+          BC_LICENSE_URL: ${{ secrets.BC_LICENSE_FILE_URL }}
+          BAK_FOLDER: ${{ vars.BAK_FOLDER_MASTER }}
+          CONTAINER_PASSWORD: ${{ secrets.BC_CONTAINER_PASSWORD }}
+        run: |
+          $cn = "test-$([Guid]::NewGuid().ToString().Substring(0, 8))"
+          $cred = New-Object PSCredential 'admin' (ConvertTo-SecureString $ENV:CONTAINER_PASSWORD -AsPlainText -Force)
+          try {
+            $url = Get-BCArtifactUrl -type OnPrem -country ${{ steps.settings.outputs.country }} -select Latest
+            New-BcContainer -accept_eula -containerName $cn -artifactUrl $url -credential $cred `
+              -auth NavUserPassword -licenseFile $ENV:BC_LICENSE_URL -includeTestToolkit -includeTestLibrariesOnly `
+              -accept_outdated -updateHosts -bakFolder $ENV:BAK_FOLDER
+
+            $testResults = Join-Path $ENV:GITHUB_WORKSPACE "TestResults.xml"
+            Run-TestsInBCContainer -containerName $cn -credential $cred -XUnitResultFileName $testResults
+          } finally {
+            if (Test-BcContainer -containerName $cn) { Remove-BcContainer -containerName $cn }
+          }
+
+      - name: Publish Test Results
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: 'Nightly Tests'
+          path: TestResults.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/Templates/AppSource App/.github/workflows/TRASER-PRContainer.yaml
+++ b/Templates/AppSource App/.github/workflows/TRASER-PRContainer.yaml
@@ -1,0 +1,94 @@
+name: 'TRASER PR Container'
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  PRContainer:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/container'))
+    runs-on: [ self-hosted, windows ]
+    timeout-minutes: 120
+    steps:
+      - name: Determine action
+        id: action
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            [ "${{ github.event.action }}" == "closed" ] && echo "action=remove" >> $GITHUB_OUTPUT || echo "action=deploy" >> $GITHUB_OUTPUT
+            echo "pr-number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "action=$(echo '${{ github.event.comment.body }}' | awk '{print $2}')" >> $GITHUB_OUTPUT
+            echo "pr-number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout
+        if: steps.action.outputs.action == 'deploy'
+        uses: actions/checkout@v4
+
+      - name: Deploy PR Container
+        if: steps.action.outputs.action == 'deploy'
+        env:
+          CONTAINER_PASSWORD: ${{ secrets.BC_CONTAINER_PASSWORD }}
+          BC_LICENSE_URL: ${{ secrets.BC_LICENSE_FILE_URL }}
+          BAK_FOLDER: ${{ github.base_ref == 'staging' && vars.BAK_FOLDER_STAGING || vars.BAK_FOLDER_MASTER }}
+          TRAEFIK_DOMAIN: ${{ vars.TRAEFIK_DOMAIN }}
+        run: |
+          $cn = "pr${{ steps.action.outputs.pr-number }}"
+          $cred = New-Object PSCredential 'admin' (ConvertTo-SecureString $ENV:CONTAINER_PASSWORD -AsPlainText -Force)
+
+          if (Test-BcContainer -containerName $cn) {
+            Start-BcContainer -containerName $cn
+            Import-BcContainerLicense -containerName $cn -licenseFile $ENV:BC_LICENSE_URL
+            Get-BcContainerAppInfo -containerName $cn | Where-Object { $_.Publisher -eq "TRASER Software GmbH" } | ForEach-Object {
+              UnInstall-BcContainerApp -containerName $cn -name $_.Name -Force
+              UnPublish-BcContainerApp -containerName $cn -name $_.Name
+            }
+          } else {
+            $settings = Get-Content ".AL-Go/settings.json" -Encoding UTF8 | ConvertFrom-Json
+            $url = Get-BCArtifactUrl -type OnPrem -country $settings.country -select Latest
+            New-BcContainer -accept_eula -containerName $cn -artifactUrl $url -credential $cred `
+              -auth NavUserPassword -licenseFile $ENV:BC_LICENSE_URL -includeTestToolkit -includeTestLibrariesOnly `
+              -accept_outdated -updateHosts -useTraefik -PublicDnsName $ENV:TRAEFIK_DOMAIN -bakFolder $ENV:BAK_FOLDER
+          }
+          Write-Host "PR container ready: https://pr${{ steps.action.outputs.pr-number }}.${{ vars.TRAEFIK_DOMAIN }}/BC/"
+
+      - name: Post PR Comment
+        if: steps.action.outputs.action == 'deploy' && github.event.action == 'opened'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{ steps.action.outputs.pr-number }},
+              owner: context.repo.owner, repo: context.repo.repo,
+              body: 'PR Container ready: https://pr${{ steps.action.outputs.pr-number }}.${{ vars.TRAEFIK_DOMAIN }}/BC/'
+            })
+
+      - name: Remove PR Container
+        if: steps.action.outputs.action == 'remove'
+        run: |
+          $cn = "pr${{ steps.action.outputs.pr-number }}"
+          if (Test-BcContainer -containerName $cn) { Remove-BcContainer -containerName $cn }
+
+      - name: Stop/Start/Restart PR Container
+        if: contains(fromJson('["stop","start","restart"]'), steps.action.outputs.action)
+        run: |
+          $cn = "pr${{ steps.action.outputs.pr-number }}"
+          switch ("${{ steps.action.outputs.action }}") {
+            "stop"    { Stop-BcContainer -containerName $cn }
+            "start"   { Start-BcContainer -containerName $cn }
+            "restart" { Restart-BcContainer -containerName $cn }
+          }

--- a/Templates/Per Tenant Extension/.AL-Go/NewBcContainer.ps1
+++ b/Templates/Per Tenant Extension/.AL-Go/NewBcContainer.ps1
@@ -1,0 +1,4 @@
+Param([Hashtable] $parameters)
+
+$script = Join-Path $PSScriptRoot "../../../Actions/TRASER-Overrides/NewBcContainer.ps1" -Resolve
+. $script -parameters $parameters

--- a/Templates/Per Tenant Extension/.AL-Go/PreCompileApp.ps1
+++ b/Templates/Per Tenant Extension/.AL-Go/PreCompileApp.ps1
@@ -1,0 +1,4 @@
+Param([Hashtable] $parameters)
+
+$script = Join-Path $PSScriptRoot "../../../Actions/TRASER-Overrides/PreCompileApp.ps1" -Resolve
+. $script -parameters $parameters

--- a/Templates/Per Tenant Extension/.AL-Go/settings.json
+++ b/Templates/Per Tenant Extension/.AL-Go/settings.json
@@ -1,7 +1,41 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go-Actions/main/.Modules/settings.schema.json",
-  "country": "us",
+  "country": "de",
   "appFolders": [],
   "testFolders": [],
-  "bcptTestFolders": []
+  "bcptTestFolders": [],
+  "gitHubRunner": "[ self-hosted, windows ]",
+  "gitHubRunnerShell": "powershell",
+  "CICDPushBranches": [ "main", "staging", "release/*", "feature/*" ],
+  "CICDPullRequestTargetBranches": [ "main", "staging", "release/*" ],
+  "environments": [ "Internal-Master", "Internal-Staging" ],
+  "DeployToInternal-Master": {
+    "branches": [ "main" ],
+    "environmentName": "Internal-Master",
+    "ContinuousDeployment": true,
+    "runs-on": "[ self-hosted, windows ]"
+  },
+  "DeployToInternal-Staging": {
+    "branches": [ "staging" ],
+    "environmentName": "Internal-Staging",
+    "ContinuousDeployment": true,
+    "runs-on": "[ self-hosted, windows ]"
+  },
+  "trustedNuGetFeeds": [
+    { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-runtime/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" }
+  ],
+  "ConditionalSettings": [
+    { "branches": [ "staging" ], "settings": { "versioningStrategy": 0, "trustedNuGetFeeds": [
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-staging/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" },
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-runtime/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" }
+    ] } },
+    { "branches": [ "main" ], "settings": { "trustedNuGetFeeds": [
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-master/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" },
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-runtime/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" }
+    ] } },
+    { "branches": [ "release/*" ], "settings": { "trustedNuGetFeeds": [
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-release/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" },
+      { "url": "https://pkgs.dev.azure.com/TRASERSoftwareGmbH/57865e76-6f0b-4dd0-967d-d899bfd89907/_packaging/bc-runtime/nuget/v3/index.json", "authTokenSecret": "NUGET_TOKEN" }
+    ] } }
+  ]
 }

--- a/Templates/Per Tenant Extension/.github/workflows/TRASER-DeployToCustomer.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/TRASER-DeployToCustomer.yaml
@@ -1,0 +1,46 @@
+name: 'TRASER Deploy to Customer'
+
+on:
+  workflow_dispatch:
+    inputs:
+      customer:
+        description: 'Customer environment name (GitHub Environment)'
+        required: true
+        type: string
+      version:
+        description: 'Release version to deploy (tag name)'
+        required: true
+        type: string
+      syncMode:
+        description: 'Sync mode'
+        required: false
+        type: choice
+        options: [ Add, ForceSync ]
+        default: Add
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  Deploy:
+    environment: ${{ inputs.customer }}
+    runs-on: [ self-hosted, windows ]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Deploy to customer
+        uses: microsoft/AL-Go-Actions/TRASER-DeployToCustomer@main
+        with:
+          server-instance: ${{ secrets.SERVER_INSTANCE }}
+          artifacts-folder: ./artifacts
+          nuget-token: ${{ secrets.NUGET_TOKEN }}
+          sync-mode: ${{ inputs.syncMode }}
+          target-bc-version: ${{ secrets.BC_VERSION }}

--- a/Templates/Per Tenant Extension/.github/workflows/TRASER-NightlyBackup.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/TRASER-NightlyBackup.yaml
@@ -1,0 +1,80 @@
+name: 'TRASER Nightly Backup'
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      bcVersion:
+        description: 'BC version override (leave empty for default)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  Backup:
+    runs-on: [ self-hosted, windows ]
+    timeout-minutes: 120
+    strategy:
+      matrix:
+        include:
+          - branch: main
+            bakVar: BAK_FOLDER_MASTER
+          - branch: staging
+            bakVar: BAK_FOLDER_STAGING
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Read settings
+        id: settings
+        run: |
+          $settings = Get-Content ".AL-Go/settings.json" -Encoding UTF8 | ConvertFrom-Json
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "country=$($settings.country)"
+
+      - name: Create Nightly Backup
+        env:
+          BC_LICENSE_URL: ${{ secrets.BC_LICENSE_FILE_URL }}
+          BAK_FOLDER: ${{ vars[matrix.bakVar] }}
+          CONTAINER_PASSWORD: ${{ secrets.BC_CONTAINER_PASSWORD }}
+        run: |
+          $containerName = "nightly-bak-${{ matrix.branch }}"
+          $bakFolder = $ENV:BAK_FOLDER
+          if (-not $bakFolder) { Write-Warning "No BAK folder for ${{ matrix.branch }}"; return }
+
+          if (Test-BcContainer -containerName $containerName) { Remove-BcContainer -containerName $containerName }
+
+          $credential = New-Object PSCredential 'admin' (ConvertTo-SecureString $ENV:CONTAINER_PASSWORD -AsPlainText -Force)
+          $artifactUrl = Get-BCArtifactUrl -type OnPrem -country ${{ steps.settings.outputs.country }} -select Latest
+          if ("${{ inputs.bcVersion }}" -ne "") {
+            $artifactUrl = Get-BCArtifactUrl -type OnPrem -country ${{ steps.settings.outputs.country }} -version "${{ inputs.bcVersion }}" -select Latest
+          }
+
+          New-BcContainer -accept_eula -containerName $containerName -artifactUrl $artifactUrl -credential $credential `
+            -auth NavUserPassword -licenseFile $ENV:BC_LICENSE_URL -includeTestToolkit -includeTestLibrariesOnly `
+            -accept_outdated -updateHosts
+
+          New-Item -ItemType Directory -Path $bakFolder -Force | Out-Null
+          Backup-BcContainerDatabases -containerName $containerName -bakFolder $bakFolder
+
+          @{ createdAt = (Get-Date -Format "o"); branch = "${{ matrix.branch }}" } | ConvertTo-Json |
+            Set-Content -Path (Join-Path $bakFolder "metadata.json") -Encoding UTF8
+
+          Remove-BcContainer -containerName $containerName
+
+      - name: Apply retention policy
+        env:
+          BAK_FOLDER: ${{ vars[matrix.bakVar] }}
+        run: |
+          $bak = $ENV:BAK_FOLDER
+          if (-not $bak -or -not (Test-Path $bak)) { return }
+          Get-ChildItem $bak -Filter "*.bak" | Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-14) } | Remove-Item -Force

--- a/Templates/Per Tenant Extension/.github/workflows/TRASER-NightlyTests.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/TRASER-NightlyTests.yaml
@@ -1,0 +1,57 @@
+name: 'TRASER Nightly Tests'
+
+on:
+  schedule:
+    - cron: '0 3 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  Test:
+    runs-on: [ self-hosted, windows ]
+    timeout-minutes: 360
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read settings
+        id: settings
+        run: |
+          $s = Get-Content ".AL-Go/settings.json" -Encoding UTF8 | ConvertFrom-Json
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "country=$($s.country)"
+
+      - name: Run Nightly Tests
+        env:
+          BC_LICENSE_URL: ${{ secrets.BC_LICENSE_FILE_URL }}
+          BAK_FOLDER: ${{ vars.BAK_FOLDER_MASTER }}
+          CONTAINER_PASSWORD: ${{ secrets.BC_CONTAINER_PASSWORD }}
+        run: |
+          $cn = "test-$([Guid]::NewGuid().ToString().Substring(0, 8))"
+          $cred = New-Object PSCredential 'admin' (ConvertTo-SecureString $ENV:CONTAINER_PASSWORD -AsPlainText -Force)
+          try {
+            $url = Get-BCArtifactUrl -type OnPrem -country ${{ steps.settings.outputs.country }} -select Latest
+            New-BcContainer -accept_eula -containerName $cn -artifactUrl $url -credential $cred `
+              -auth NavUserPassword -licenseFile $ENV:BC_LICENSE_URL -includeTestToolkit -includeTestLibrariesOnly `
+              -accept_outdated -updateHosts -bakFolder $ENV:BAK_FOLDER
+
+            $testResults = Join-Path $ENV:GITHUB_WORKSPACE "TestResults.xml"
+            Run-TestsInBCContainer -containerName $cn -credential $cred -XUnitResultFileName $testResults
+          } finally {
+            if (Test-BcContainer -containerName $cn) { Remove-BcContainer -containerName $cn }
+          }
+
+      - name: Publish Test Results
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: 'Nightly Tests'
+          path: TestResults.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/Templates/Per Tenant Extension/.github/workflows/TRASER-PRContainer.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/TRASER-PRContainer.yaml
@@ -1,0 +1,94 @@
+name: 'TRASER PR Container'
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  PRContainer:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/container'))
+    runs-on: [ self-hosted, windows ]
+    timeout-minutes: 120
+    steps:
+      - name: Determine action
+        id: action
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            [ "${{ github.event.action }}" == "closed" ] && echo "action=remove" >> $GITHUB_OUTPUT || echo "action=deploy" >> $GITHUB_OUTPUT
+            echo "pr-number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "action=$(echo '${{ github.event.comment.body }}' | awk '{print $2}')" >> $GITHUB_OUTPUT
+            echo "pr-number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout
+        if: steps.action.outputs.action == 'deploy'
+        uses: actions/checkout@v4
+
+      - name: Deploy PR Container
+        if: steps.action.outputs.action == 'deploy'
+        env:
+          CONTAINER_PASSWORD: ${{ secrets.BC_CONTAINER_PASSWORD }}
+          BC_LICENSE_URL: ${{ secrets.BC_LICENSE_FILE_URL }}
+          BAK_FOLDER: ${{ github.base_ref == 'staging' && vars.BAK_FOLDER_STAGING || vars.BAK_FOLDER_MASTER }}
+          TRAEFIK_DOMAIN: ${{ vars.TRAEFIK_DOMAIN }}
+        run: |
+          $cn = "pr${{ steps.action.outputs.pr-number }}"
+          $cred = New-Object PSCredential 'admin' (ConvertTo-SecureString $ENV:CONTAINER_PASSWORD -AsPlainText -Force)
+
+          if (Test-BcContainer -containerName $cn) {
+            Start-BcContainer -containerName $cn
+            Import-BcContainerLicense -containerName $cn -licenseFile $ENV:BC_LICENSE_URL
+            Get-BcContainerAppInfo -containerName $cn | Where-Object { $_.Publisher -eq "TRASER Software GmbH" } | ForEach-Object {
+              UnInstall-BcContainerApp -containerName $cn -name $_.Name -Force
+              UnPublish-BcContainerApp -containerName $cn -name $_.Name
+            }
+          } else {
+            $settings = Get-Content ".AL-Go/settings.json" -Encoding UTF8 | ConvertFrom-Json
+            $url = Get-BCArtifactUrl -type OnPrem -country $settings.country -select Latest
+            New-BcContainer -accept_eula -containerName $cn -artifactUrl $url -credential $cred `
+              -auth NavUserPassword -licenseFile $ENV:BC_LICENSE_URL -includeTestToolkit -includeTestLibrariesOnly `
+              -accept_outdated -updateHosts -useTraefik -PublicDnsName $ENV:TRAEFIK_DOMAIN -bakFolder $ENV:BAK_FOLDER
+          }
+          Write-Host "PR container ready: https://pr${{ steps.action.outputs.pr-number }}.${{ vars.TRAEFIK_DOMAIN }}/BC/"
+
+      - name: Post PR Comment
+        if: steps.action.outputs.action == 'deploy' && github.event.action == 'opened'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{ steps.action.outputs.pr-number }},
+              owner: context.repo.owner, repo: context.repo.repo,
+              body: 'PR Container ready: https://pr${{ steps.action.outputs.pr-number }}.${{ vars.TRAEFIK_DOMAIN }}/BC/'
+            })
+
+      - name: Remove PR Container
+        if: steps.action.outputs.action == 'remove'
+        run: |
+          $cn = "pr${{ steps.action.outputs.pr-number }}"
+          if (Test-BcContainer -containerName $cn) { Remove-BcContainer -containerName $cn }
+
+      - name: Stop/Start/Restart PR Container
+        if: contains(fromJson('["stop","start","restart"]'), steps.action.outputs.action)
+        run: |
+          $cn = "pr${{ steps.action.outputs.pr-number }}"
+          switch ("${{ steps.action.outputs.action }}") {
+            "stop"    { Stop-BcContainer -containerName $cn }
+            "start"   { Start-BcContainer -containerName $cn }
+            "restart" { Restart-BcContainer -containerName $cn }
+          }


### PR DESCRIPTION
Actions (centralized in Actions/):
- TRASER-Overrides: NewBcContainer + PreCompileApp override implementations
- TRASER-NuGetHelper: Feed routing, package naming, ForNAV mapping
- TRASER-PublishBCNuGet: Multi-feed NuGet publishing with runtime dual-publish
- TRASER-DependencyTree: App install ordering for on-prem deployments
- TRASER-DeployToCustomer: On-prem multi-tenant BC server deployment
- TRASER-PackageBCProduct: SaaS + runtime distribution zip packaging
- TRASER-CloseADOWorkItems: ADO work item state transitions on release
- TRASER-MigrateConfig: config.json to AL-Go settings.json migration

Templates (PTE + AppSource):
- settings.json: TRASER defaults (de, self-hosted runner, staging branching, conditional NuGet feeds per branch, deployment environments)
- NewBcContainer.ps1 / PreCompileApp.ps1: Thin wrappers delegating to Actions/TRASER-Overrides/ (BCApps pattern)
- TRASER-NightlyBackup.yaml: Nightly BAK creation
- TRASER-PRContainer.yaml: PR container lifecycle with Traefik
- TRASER-NightlyTests.yaml: Scheduled multi-version test execution
- TRASER-DeployToCustomer.yaml: On-prem customer deployment workflow

Part of Epic: Azure DevOps to AL-Go migration (#31972)

### ❔What, Why & How

<!-- Include description of the changes that will help reviewers in their task -->

Related to issue: #

### ✅ Checklist

- [ ] Add tests (E2E, unit tests)
- [ ] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
