### PR TITLE
Fix modifiedApps incremental builds for projects with external appFolders

### DIFF
--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -430,15 +430,30 @@ function Get-UnmodifiedAppsFromBaselineWorkflowRun {
     Sort-AppFoldersByDependencies -appFolders $allFolders -baseFolder $baseFolder -skippedApps ([ref] $skipFolders) -unknownDependencies ([ref]$unknownDependencies) -knownApps ([ref] $knownApps) -selectSubordinates $modifiedFolders | Out-Null
     OutputMessageAndArray -message "Skip folders" -arrayOfStrings $skipFolders
 
-    $projectWithSeperator = ''
-    if ($project) {
-        $projectWithSeperator = "$project$([System.IO.Path]::DirectorySeparatorChar)"
+    # Convert a project-relative folder path (from settings.appFolders etc.) to a repo-relative path
+    # that matches the format used by $skipFolders (produced by GetFoldersFromAllProjects).
+    # Settings folders may use ../ to reference paths above the project folder,
+    # so we resolve to absolute first, then strip the base folder prefix to get a clean repo-relative path.
+    function ConvertTo-RepoRelativePath {
+        param(
+            [string] $folder,
+            [string] $projectPath,
+            [string] $baseFolder
+        )
+        $fullPath = Join-Path $projectPath $folder -Resolve -ErrorAction SilentlyContinue
+        if (-not $fullPath) {
+            return $null
+        }
+        $normalizedBase = $baseFolder.TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+        if ($fullPath.StartsWith($normalizedBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $fullPath.Substring($normalizedBase.Length)
+        }
+        return $null
     }
 
-    # AppFolders, TestFolders and BcptTestFolders in settings are always preceded by ./ or .\, so we need to remove that (hence Substring(2))
-    $downloadAppFolders = @($settings.appFolders | Where-Object { $skipFolders -contains "$projectWithSeperator$($_.SubString(2))" })
-    $downloadTestFolders = @($settings.testFolders | Where-Object { $skipFolders -contains "$projectWithSeperator$($_.SubString(2))" })
-    $downloadBcptTestFolders = @($settings.bcptTestFolders | Where-Object { $skipFolders -contains "$projectWithSeperator$($_.SubString(2))" })
+    $downloadAppFolders = @($settings.appFolders | Where-Object { $skipFolders -contains (ConvertTo-RepoRelativePath -folder $_ -projectPath $projectPath -baseFolder $baseFolder) })
+    $downloadTestFolders = @($settings.testFolders | Where-Object { $skipFolders -contains (ConvertTo-RepoRelativePath -folder $_ -projectPath $projectPath -baseFolder $baseFolder) })
+    $downloadBcptTestFolders = @($settings.bcptTestFolders | Where-Object { $skipFolders -contains (ConvertTo-RepoRelativePath -folder $_ -projectPath $projectPath -baseFolder $baseFolder) })
 
     OutputMessageAndArray -message "Download appFolders" -arrayOfStrings $downloadAppFolders
     OutputMessageAndArray -message "Download testFolders" -arrayOfStrings $downloadTestFolders

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -389,6 +389,41 @@ function Get-BuildAllApps {
 
 <#
 .Synopsis
+    Converts a project-relative folder path to a repo-relative path.
+.Description
+    Converts a project-relative folder path (from settings.appFolders etc.) to a repo-relative path
+    that matches the format used by skipFolders (produced by GetFoldersFromAllProjects).
+    Settings folders may use ../ to reference paths above the project folder,
+    so the function resolves to an absolute path first, then strips the base folder prefix
+    to produce a clean repo-relative path.
+.Parameter folder
+    The project-relative folder path to convert (e.g. '.\app' or '..\..\..\src\Apps\MyApp\App').
+.Parameter projectPath
+    The absolute path to the project directory.
+.Parameter baseFolder
+    The absolute path to the repository root.
+.Outputs
+    A repo-relative path string, or $null if the folder cannot be resolved or is outside the base folder.
+#>
+function ConvertTo-RepoRelativePath {
+    param(
+        [string] $folder,
+        [string] $projectPath,
+        [string] $baseFolder
+    )
+    $fullPath = Join-Path $projectPath $folder -Resolve -ErrorAction SilentlyContinue
+    if (-not $fullPath) {
+        return $null
+    }
+    $normalizedBase = $baseFolder.TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+    if ($fullPath.StartsWith($normalizedBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $fullPath.Substring($normalizedBase.Length)
+    }
+    return $null
+}
+
+<#
+.Synopsis
     Downloads unmodified artifacts from the baseline workflow run
 .Outputs
     An array of objects containing the type, mask and a list of downloaded app file names.
@@ -429,27 +464,6 @@ function Get-UnmodifiedAppsFromBaselineWorkflowRun {
     OutputMessageAndArray -message "Modified folders" -arrayOfStrings $modifiedFolders
     Sort-AppFoldersByDependencies -appFolders $allFolders -baseFolder $baseFolder -skippedApps ([ref] $skipFolders) -unknownDependencies ([ref]$unknownDependencies) -knownApps ([ref] $knownApps) -selectSubordinates $modifiedFolders | Out-Null
     OutputMessageAndArray -message "Skip folders" -arrayOfStrings $skipFolders
-
-    # Convert a project-relative folder path (from settings.appFolders etc.) to a repo-relative path
-    # that matches the format used by $skipFolders (produced by GetFoldersFromAllProjects).
-    # Settings folders may use ../ to reference paths above the project folder,
-    # so we resolve to absolute first, then strip the base folder prefix to get a clean repo-relative path.
-    function ConvertTo-RepoRelativePath {
-        param(
-            [string] $folder,
-            [string] $projectPath,
-            [string] $baseFolder
-        )
-        $fullPath = Join-Path $projectPath $folder -Resolve -ErrorAction SilentlyContinue
-        if (-not $fullPath) {
-            return $null
-        }
-        $normalizedBase = $baseFolder.TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
-        if ($fullPath.StartsWith($normalizedBase, [System.StringComparison]::OrdinalIgnoreCase)) {
-            return $fullPath.Substring($normalizedBase.Length)
-        }
-        return $null
-    }
 
     $downloadAppFolders = @($settings.appFolders | Where-Object { $skipFolders -contains (ConvertTo-RepoRelativePath -folder $_ -projectPath $projectPath -baseFolder $baseFolder) })
     $downloadTestFolders = @($settings.testFolders | Where-Object { $skipFolders -contains (ConvertTo-RepoRelativePath -folder $_ -projectPath $projectPath -baseFolder $baseFolder) })

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,6 @@
 ### Issues
 
+- Incremental builds (`modifiedApps` mode) now correctly identify unmodified apps for projects whose `appFolders` reference paths outside the project directory (e.g. using `../`)
 - Issue 2204 - Workspace compilation ignores vsixFile setting
 - Issue 2214 - Workspace compilation not working with external dependencies
 

--- a/Tests/DetermineProjectsToBuild.Test.ps1
+++ b/Tests/DetermineProjectsToBuild.Test.ps1
@@ -1311,7 +1311,11 @@ Describe "Get-UnmodifiedAppsFromBaselineWorkflowRun" {
         $baseFolder = (New-Item -ItemType Directory -Path (Join-Path $([System.IO.Path]::GetTempPath()) $([System.IO.Path]::GetRandomFileName()))).FullName
 
         if (-not (Get-Command 'Trace-Information' -ErrorAction SilentlyContinue)) {
-            function global:Trace-Information { param([string]$Message, $AdditionalData) }
+            function global:Trace-Information {
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Message', Justification = 'Stub function for testing.')]
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'AdditionalData', Justification = 'Stub function for testing.')]
+                param([string]$Message, $AdditionalData)
+            }
         }
         $env:GITHUB_API_URL = 'https://api.github.com'
         $env:GITHUB_REPOSITORY = 'test/repo'

--- a/Tests/DetermineProjectsToBuild.Test.ps1
+++ b/Tests/DetermineProjectsToBuild.Test.ps1
@@ -1215,11 +1215,8 @@ Describe "Get-BuildAllProjects" {
     }
 }
 
-Describe "Get-UnmodifiedAppsFromBaselineWorkflowRun" {
+Describe "ConvertTo-RepoRelativePath" {
     BeforeAll {
-        . (Join-Path -Path $PSScriptRoot -ChildPath "../Actions/AL-Go-Helper.ps1" -Resolve)
-        DownloadAndImportBcContainerHelper -baseFolder $([System.IO.Path]::GetTempPath())
-
         Import-Module (Join-Path $PSScriptRoot "../Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1" -Resolve) -DisableNameChecking -Force
     }
 
@@ -1228,235 +1225,176 @@ Describe "Get-UnmodifiedAppsFromBaselineWorkflowRun" {
         $baseFolder = (New-Item -ItemType Directory -Path (Join-Path $([System.IO.Path]::GetTempPath()) $([System.IO.Path]::GetRandomFileName()))).FullName
     }
 
-    It 'correctly identifies unmodified apps when appFolders reference paths above the project folder via ../' {
-        # Repo layout where the project is nested and appFolders reference sources via ../:
-        #   baseFolder/
-        #     .github/AL-Go-Settings.json
-        #     src/Apps/AppA/App/app.json        (modified)
-        #     src/Apps/AppB/App/app.json        (unmodified - should be downloaded from baseline)
-        #     src/Apps/AppC/App/app.json        (unmodified - should be downloaded from baseline)
-        #     build/projects/MyProject/.AL-Go/settings.json
-        #       appFolders: ["../../../src/Apps/*/App"]
+    It 'resolves a standard .\ prefixed folder to a repo-relative path' {
+        $appDir = New-Item -Path "$baseFolder/app" -ItemType Directory -Force
+        $result = ConvertTo-RepoRelativePath -folder '.\app' -projectPath $baseFolder -baseFolder $baseFolder
+        $result | Should -Be 'app'
+    }
 
+    It 'resolves a ../ relative folder to a repo-relative path' {
+        # Simulate: baseFolder/src/Apps/MyApp/App exists, project is at baseFolder/build/projects/Proj
+        New-Item -Path "$baseFolder/src/Apps/MyApp/App" -ItemType Directory -Force | Out-Null
+        $projectPath = (New-Item -Path "$baseFolder/build/projects/Proj" -ItemType Directory -Force).FullName
+
+        $result = ConvertTo-RepoRelativePath -folder '..\..\..\src\Apps\MyApp\App' -projectPath $projectPath -baseFolder $baseFolder
+        $sep = [System.IO.Path]::DirectorySeparatorChar
+        $result | Should -Be "src${sep}Apps${sep}MyApp${sep}App"
+    }
+
+    It 'returns $null for a folder that does not exist on disk' {
+        $result = ConvertTo-RepoRelativePath -folder '.\nonexistent' -projectPath $baseFolder -baseFolder $baseFolder
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'returns $null for a folder that resolves outside the base folder' {
+        # Create a directory above baseFolder and try to reference it
+        $parentDir = Split-Path $baseFolder -Parent
+        $outsideDir = New-Item -Path (Join-Path $parentDir 'outside-repo') -ItemType Directory -Force
+        try {
+            $result = ConvertTo-RepoRelativePath -folder '..\outside-repo' -projectPath $baseFolder -baseFolder $baseFolder
+            $result | Should -BeNullOrEmpty
+        }
+        finally {
+            Remove-Item $outsideDir -Force -Recurse
+        }
+    }
+
+    It 'handles baseFolder with trailing separator' {
+        $appDir = New-Item -Path "$baseFolder/app" -ItemType Directory -Force
+        $baseFolderWithTrailing = $baseFolder + [System.IO.Path]::DirectorySeparatorChar
+        $result = ConvertTo-RepoRelativePath -folder '.\app' -projectPath $baseFolder -baseFolder $baseFolderWithTrailing
+        $result | Should -Be 'app'
+    }
+
+    It 'handles deeply nested project with multiple ../ segments' {
+        New-Item -Path "$baseFolder/src/Common/Shared" -ItemType Directory -Force | Out-Null
+        $projectPath = (New-Item -Path "$baseFolder/a/b/c/d/project" -ItemType Directory -Force).FullName
+
+        $result = ConvertTo-RepoRelativePath -folder '..\..\..\..\..\src\Common\Shared' -projectPath $projectPath -baseFolder $baseFolder
+        $sep = [System.IO.Path]::DirectorySeparatorChar
+        $result | Should -Be "src${sep}Common${sep}Shared"
+    }
+
+    AfterEach {
+        Remove-Item $baseFolder -Force -Recurse
+    }
+}
+
+Describe "Get-UnmodifiedAppsFromBaselineWorkflowRun" {
+    BeforeAll {
+        . (Join-Path -Path $PSScriptRoot -ChildPath "../Actions/AL-Go-Helper.ps1" -Resolve)
+        DownloadAndImportBcContainerHelper -baseFolder $([System.IO.Path]::GetTempPath())
+
+        Import-Module (Join-Path $PSScriptRoot "../Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1" -Resolve) -DisableNameChecking -Force
+
+        # Helper to extract the download entries from captured Write-Host output for a given section
+        function script:Get-DownloadEntries {
+            param([string] $section, [System.Collections.ArrayList] $output)
+            $inSection = $false
+            $entries = @()
+            foreach ($line in $output) {
+                if ($line -eq "Download ${section}:") {
+                    $inSection = $true
+                    continue
+                }
+                if ($inSection) {
+                    if ($line -match '^Download ') { break }
+                    $entries += $line
+                }
+            }
+            return $entries
+        }
+    }
+
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'baseFolder', Justification = 'False positive.')]
+        $baseFolder = (New-Item -ItemType Directory -Path (Join-Path $([System.IO.Path]::GetTempPath()) $([System.IO.Path]::GetRandomFileName()))).FullName
+
+        if (-not (Get-Command 'Trace-Information' -ErrorAction SilentlyContinue)) {
+            function global:Trace-Information { param([string]$Message, $AdditionalData) }
+        }
+        $env:GITHUB_API_URL = 'https://api.github.com'
+        $env:GITHUB_REPOSITORY = 'test/repo'
+
+        Mock InvokeWebRequest {
+            $uri = $args[0]
+            if (-not $uri) { $uri = $Uri }
+            $content = if ($uri -like '*/actions/runs/*/artifacts*') {
+                '{"artifacts":[]}'
+            } else {
+                '{"head_branch":"main"}'
+            }
+            return [PSCustomObject]@{ Content = $content }
+        } -ModuleName 'Github-Helper'
+
+        $script:capturedOutput = [System.Collections.ArrayList]::new()
+        Mock Write-Host { $null = $script:capturedOutput.Add($Object) } -ModuleName 'DetermineProjectsToBuild'
+    }
+
+    It 'identifies unmodified apps when appFolders reference paths above the project via ../' {
         $project = 'build/projects/MyProject'
         $projectPath = Join-Path $baseFolder $project
 
-        # Create repo-level AL-Go settings
-        $repoSettings = @{
-            fullBuildPatterns = @()
-            projects = @($project)
-            powerPlatformSolutionFolder = ''
-            useProjectDependencies = $false
-            incrementalBuilds = @{
-                onPull_Request = $true
-                mode = 'modifiedApps'
-            }
-        }
+        $repoSettings = @{ fullBuildPatterns = @(); projects = @($project); powerPlatformSolutionFolder = ''; useProjectDependencies = $false; incrementalBuilds = @{ onPull_Request = $true; mode = 'modifiedApps' } }
         New-Item -Path "$baseFolder/.github/AL-Go-Settings.json" -Value (ConvertTo-Json $repoSettings -Depth 10) -type File -Force | Out-Null
+        New-Item -Path "$projectPath/.AL-Go/settings.json" -Value (ConvertTo-Json @{ appFolders = @('../../../src/Apps/*/App'); testFolders = @(); bcptTestFolders = @() } -Depth 10) -type File -Force | Out-Null
 
-        # Create project-level settings with appFolders that go above the project
-        $projectSettingsJson = @{
-            appFolders = @("../../../src/Apps/*/App")
-            testFolders = @()
-            bcptTestFolders = @()
+        @('AppA', 'AppB', 'AppC') | ForEach-Object {
+            $app = @{ id = [guid]::NewGuid().ToString(); name = $_; publisher = 'Test'; version = '1.0.0.0'; dependencies = @() }
+            New-Item -Path "$baseFolder/src/Apps/$_/App/app.json" -Value (ConvertTo-Json $app -Depth 10) -type File -Force | Out-Null
         }
-        New-Item -Path "$projectPath/.AL-Go/settings.json" -Value (ConvertTo-Json $projectSettingsJson -Depth 10) -type File -Force | Out-Null
 
-        # Create three independent apps
-        $appA = @{ id = 'aaaaaaaa-0000-0000-0000-000000000001'; name = 'App A'; publisher = 'TestPublisher'; version = '1.0.0.0'; dependencies = @() }
-        $appB = @{ id = 'bbbbbbbb-0000-0000-0000-000000000002'; name = 'App B'; publisher = 'TestPublisher'; version = '1.0.0.0'; dependencies = @() }
-        $appC = @{ id = 'cccccccc-0000-0000-0000-000000000003'; name = 'App C'; publisher = 'TestPublisher'; version = '1.0.0.0'; dependencies = @() }
-        New-Item -Path "$baseFolder/src/Apps/AppA/App/app.json" -Value (ConvertTo-Json $appA -Depth 10) -type File -Force | Out-Null
-        New-Item -Path "$baseFolder/src/Apps/AppB/App/app.json" -Value (ConvertTo-Json $appB -Depth 10) -type File -Force | Out-Null
-        New-Item -Path "$baseFolder/src/Apps/AppC/App/app.json" -Value (ConvertTo-Json $appC -Depth 10) -type File -Force | Out-Null
-
-        # Also create a dummy .al file so there's something to be "modified"
-        New-Item -Path "$baseFolder/src/Apps/AppA/App/MyCodeunit.al" -Value "// modified file" -type File -Force | Out-Null
-
-        # Set env:Settings for helper functions
         $env:Settings = ConvertTo-Json $repoSettings -Depth 99 -Compress
 
-        # Resolve appFolders the way ResolveProjectFolders/AnalyzeRepo does:
-        # Push-Location to project, Resolve-Path -Relative
         Push-Location $projectPath
-        $resolvedAppFolders = @(Resolve-Path "../../../src/Apps/*/App" -Relative -ErrorAction SilentlyContinue | Where-Object { Test-Path (Join-Path $_ 'app.json') })
+        $resolvedAppFolders = @(Resolve-Path '../../../src/Apps/*/App' -Relative -ErrorAction SilentlyContinue | Where-Object { Test-Path (Join-Path $_ 'app.json') })
         Pop-Location
 
-        # Build a settings hashtable with resolved folders (same as what RunPipeline passes in)
-        $resolvedSettings = @{
-            appFolders = $resolvedAppFolders
-            testFolders = @()
-            bcptTestFolders = @()
-        }
-
-        # Build artifact folder
-        $buildArtifactFolder = Join-Path $projectPath ".buildartifacts"
+        $buildArtifactFolder = Join-Path $projectPath '.buildartifacts'
         New-Item -Path $buildArtifactFolder -ItemType Directory -Force | Out-Null
 
-        # Only AppA is modified
         $sep = [System.IO.Path]::DirectorySeparatorChar
-        $modifiedFiles = @("src${sep}Apps${sep}AppA${sep}App${sep}MyCodeunit.al")
-
-        # Mock GitHub API calls since we don't have a real baseline workflow
-        # Stub functions that are normally provided by GitHub Actions runtime
-        if (-not (Get-Command 'Trace-Information' -ErrorAction SilentlyContinue)) {
-            function global:Trace-Information { param([string]$Message, $AdditionalData) }
-        }
-        $env:GITHUB_API_URL = 'https://api.github.com'
-        $env:GITHUB_REPOSITORY = 'test/repo'
-        Mock InvokeWebRequest {
-            # Return a mock response object that mimics the GitHub API
-            $uri = $args[0]
-            if (-not $uri) { $uri = $Uri }
-            $content = if ($uri -like '*/actions/runs/*/artifacts*') {
-                # Artifacts endpoint - return empty list to stop pagination
-                '{"artifacts":[]}'
-            } else {
-                # Workflow run info endpoint
-                '{"head_branch":"main"}'
-            }
-            return [PSCustomObject]@{ Content = $content }
-        } -ModuleName 'Github-Helper'
-
-        # Capture Write-Host output to verify download folder matching
-        $script:capturedOutput = [System.Collections.ArrayList]::new()
-        Mock Write-Host { $null = $script:capturedOutput.Add($Object) } -ModuleName 'DetermineProjectsToBuild'
-
         Get-UnmodifiedAppsFromBaselineWorkflowRun `
             -token 'fake-token' `
-            -settings $resolvedSettings `
-            -baseFolder $baseFolder `
-            -project $project `
-            -baselineWorkflowRunId '12345' `
-            -modifiedFiles $modifiedFiles `
-            -buildArtifactFolder $buildArtifactFolder `
-            -buildMode 'Default' `
-            -projectPath $projectPath
+            -settings @{ appFolders = $resolvedAppFolders; testFolders = @(); bcptTestFolders = @() } `
+            -baseFolder $baseFolder -project $project -baselineWorkflowRunId '12345' `
+            -modifiedFiles @("src${sep}Apps${sep}AppA${sep}App${sep}MyCodeunit.al") `
+            -buildArtifactFolder $buildArtifactFolder -buildMode 'Default' -projectPath $projectPath
 
-        # The output should list the unmodified app folders (AppB and AppC) as download candidates.
-        # Before the fix: the download list was always empty ("- None") because the path matching
-        # used SubString(2) which mangled paths starting with ..\ into nonsense like \..\..\src\...
-        $downloadAppLine = $script:capturedOutput | Where-Object { $_ -eq 'Download appFolders:' }
-        $downloadAppLine | Should -Not -BeNullOrEmpty -Because "the function should output the 'Download appFolders:' header"
-
-        # Find entries after "Download appFolders:" up to the next section header
-        $inDownloadSection = $false
-        $downloadEntries = @()
-        foreach ($line in $script:capturedOutput) {
-            if ($line -eq 'Download appFolders:') {
-                $inDownloadSection = $true
-                continue
-            }
-            if ($inDownloadSection) {
-                if ($line -match '^Download (test|bcpt)') { break }
-                $downloadEntries += $line
-            }
-        }
-
-        # With the bug: downloadEntries would be @("- None") because the path matching fails
-        # With the fix: downloadEntries should contain AppB and AppC folders
-        $downloadEntries | Should -Not -Contain '- None' -Because "unmodified apps should be identified for download from baseline"
-        ($downloadEntries | Where-Object { $_ -like '*AppB*' }) | Should -Not -BeNullOrEmpty -Because "AppB was not modified and should be downloaded from baseline"
-        ($downloadEntries | Where-Object { $_ -like '*AppC*' }) | Should -Not -BeNullOrEmpty -Because "AppC was not modified and should be downloaded from baseline"
-        ($downloadEntries | Where-Object { $_ -like '*AppA*' }) | Should -BeNullOrEmpty -Because "AppA was modified and should NOT be downloaded from baseline"
+        $entries = Get-DownloadEntries -section 'appFolders' -output $script:capturedOutput
+        $entries | Should -Not -Contain '- None' -Because 'unmodified apps should be identified for download'
+        ($entries | Where-Object { $_ -like '*AppB*' }) | Should -Not -BeNullOrEmpty -Because 'AppB is unmodified'
+        ($entries | Where-Object { $_ -like '*AppC*' }) | Should -Not -BeNullOrEmpty -Because 'AppC is unmodified'
+        ($entries | Where-Object { $_ -like '*AppA*' }) | Should -BeNullOrEmpty -Because 'AppA is modified'
     }
 
-    It 'also works when appFolders are inside the project folder (standard layout)' {
-        # Standard layout where apps are inside the project folder:
-        #   baseFolder/
-        #     .AL-Go/settings.json
-        #     .github/AL-Go-Settings.json
-        #     app1/app.json
-        #     app2/app.json
-
-        $project = ''
-        $projectPath = $baseFolder
-
-        # Create repo-level AL-Go settings
-        $repoSettings = @{
-            fullBuildPatterns = @()
-            projects = @()
-            powerPlatformSolutionFolder = ''
-            useProjectDependencies = $false
-            incrementalBuilds = @{
-                onPull_Request = $true
-                mode = 'modifiedApps'
-            }
-        }
+    It 'identifies unmodified apps in a standard layout with .\ prefixed folders' {
+        $repoSettings = @{ fullBuildPatterns = @(); projects = @(); powerPlatformSolutionFolder = ''; useProjectDependencies = $false; incrementalBuilds = @{ onPull_Request = $true; mode = 'modifiedApps' } }
         New-Item -Path "$baseFolder/.github/AL-Go-Settings.json" -Value (ConvertTo-Json $repoSettings -Depth 10) -type File -Force | Out-Null
         New-Item -Path "$baseFolder/.AL-Go/settings.json" -Value (ConvertTo-Json @{} -Depth 10) -type File -Force | Out-Null
 
-        # Create two apps inside the project folder
-        $app1 = @{ id = '11111111-0000-0000-0000-000000000001'; name = 'App One'; publisher = 'TestPublisher'; version = '1.0.0.0'; dependencies = @() }
-        $app2 = @{ id = '22222222-0000-0000-0000-000000000002'; name = 'App Two'; publisher = 'TestPublisher'; version = '1.0.0.0'; dependencies = @() }
-        New-Item -Path "$baseFolder/app1/app.json" -Value (ConvertTo-Json $app1 -Depth 10) -type File -Force | Out-Null
-        New-Item -Path "$baseFolder/app2/app.json" -Value (ConvertTo-Json $app2 -Depth 10) -type File -Force | Out-Null
-        New-Item -Path "$baseFolder/app1/MyCodeunit.al" -Value "// modified file" -type File -Force | Out-Null
+        @('app1', 'app2') | ForEach-Object {
+            $app = @{ id = [guid]::NewGuid().ToString(); name = $_; publisher = 'Test'; version = '1.0.0.0'; dependencies = @() }
+            New-Item -Path "$baseFolder/$_/app.json" -Value (ConvertTo-Json $app -Depth 10) -type File -Force | Out-Null
+        }
 
         $env:Settings = ConvertTo-Json $repoSettings -Depth 99 -Compress
 
-        # Resolve appFolders (standard layout: .\ prefix)
-        $resolvedSettings = @{
-            appFolders = @('.\app1', '.\app2')
-            testFolders = @()
-            bcptTestFolders = @()
-        }
-
-        $buildArtifactFolder = Join-Path $projectPath ".buildartifacts"
+        $buildArtifactFolder = Join-Path $baseFolder '.buildartifacts'
         New-Item -Path $buildArtifactFolder -ItemType Directory -Force | Out-Null
 
-        # Only app1 is modified
         $sep = [System.IO.Path]::DirectorySeparatorChar
-        $modifiedFiles = @("app1${sep}MyCodeunit.al")
-
-        Mock InvokeWebRequest {
-            $uri = $args[0]
-            if (-not $uri) { $uri = $Uri }
-            $content = if ($uri -like '*/actions/runs/*/artifacts*') {
-                '{"artifacts":[]}'
-            } else {
-                '{"head_branch":"main"}'
-            }
-            return [PSCustomObject]@{ Content = $content }
-        } -ModuleName 'Github-Helper'
-        # Stub Trace-Information if not already defined (normally loaded by Invoke-AlGoAction.ps1)
-        if (-not (Get-Command 'Trace-Information' -ErrorAction SilentlyContinue)) {
-            function global:Trace-Information { param([string]$Message, $AdditionalData) }
-        }
-        $env:GITHUB_API_URL = 'https://api.github.com'
-        $env:GITHUB_REPOSITORY = 'test/repo'
-
-        $script:capturedOutput = [System.Collections.ArrayList]::new()
-        Mock Write-Host { $null = $script:capturedOutput.Add($Object) } -ModuleName 'DetermineProjectsToBuild'
-
         Get-UnmodifiedAppsFromBaselineWorkflowRun `
             -token 'fake-token' `
-            -settings $resolvedSettings `
-            -baseFolder $baseFolder `
-            -project $project `
-            -baselineWorkflowRunId '12345' `
-            -modifiedFiles $modifiedFiles `
-            -buildArtifactFolder $buildArtifactFolder `
-            -buildMode 'Default' `
-            -projectPath $projectPath
+            -settings @{ appFolders = @('.\app1', '.\app2'); testFolders = @(); bcptTestFolders = @() } `
+            -baseFolder $baseFolder -project '' -baselineWorkflowRunId '12345' `
+            -modifiedFiles @("app1${sep}MyCodeunit.al") `
+            -buildArtifactFolder $buildArtifactFolder -buildMode 'Default' -projectPath $baseFolder
 
-        $inDownloadSection = $false
-        $downloadEntries = @()
-        foreach ($line in $script:capturedOutput) {
-            if ($line -eq 'Download appFolders:') {
-                $inDownloadSection = $true
-                continue
-            }
-            if ($inDownloadSection) {
-                if ($line -match '^Download (test|bcpt)') { break }
-                $downloadEntries += $line
-            }
-        }
-
-        # app2 should be marked for download (unmodified), app1 should not
-        $downloadEntries | Should -Not -Contain '- None' -Because "the unmodified app2 should be identified for download"
-        ($downloadEntries | Where-Object { $_ -like '*app2*' }) | Should -Not -BeNullOrEmpty -Because "app2 was not modified and should be downloaded from baseline"
-        ($downloadEntries | Where-Object { $_ -like '*app1*' }) | Should -BeNullOrEmpty -Because "app1 was modified and should NOT be downloaded from baseline"
+        $entries = Get-DownloadEntries -section 'appFolders' -output $script:capturedOutput
+        $entries | Should -Not -Contain '- None' -Because 'unmodified app2 should be identified for download'
+        ($entries | Where-Object { $_ -like '*app2*' }) | Should -Not -BeNullOrEmpty -Because 'app2 is unmodified'
+        ($entries | Where-Object { $_ -like '*app1*' }) | Should -BeNullOrEmpty -Because 'app1 is modified'
     }
 
     AfterEach {

--- a/Tests/DetermineProjectsToBuild.Test.ps1
+++ b/Tests/DetermineProjectsToBuild.Test.ps1
@@ -1226,7 +1226,7 @@ Describe "ConvertTo-RepoRelativePath" {
     }
 
     It 'resolves a standard .\ prefixed folder to a repo-relative path' {
-        $appDir = New-Item -Path "$baseFolder/app" -ItemType Directory -Force
+        New-Item -Path "$baseFolder/app" -ItemType Directory -Force | Out-Null
         $result = ConvertTo-RepoRelativePath -folder '.\app' -projectPath $baseFolder -baseFolder $baseFolder
         $result | Should -Be 'app'
     }
@@ -1260,7 +1260,7 @@ Describe "ConvertTo-RepoRelativePath" {
     }
 
     It 'handles baseFolder with trailing separator' {
-        $appDir = New-Item -Path "$baseFolder/app" -ItemType Directory -Force
+        New-Item -Path "$baseFolder/app" -ItemType Directory -Force | Out-Null
         $baseFolderWithTrailing = $baseFolder + [System.IO.Path]::DirectorySeparatorChar
         $result = ConvertTo-RepoRelativePath -folder '.\app' -projectPath $baseFolder -baseFolder $baseFolderWithTrailing
         $result | Should -Be 'app'

--- a/Tests/DetermineProjectsToBuild.Test.ps1
+++ b/Tests/DetermineProjectsToBuild.Test.ps1
@@ -1214,3 +1214,252 @@ Describe "Get-BuildAllProjects" {
         Remove-Item $baseFolder -Force -Recurse
     }
 }
+
+Describe "Get-UnmodifiedAppsFromBaselineWorkflowRun" {
+    BeforeAll {
+        . (Join-Path -Path $PSScriptRoot -ChildPath "../Actions/AL-Go-Helper.ps1" -Resolve)
+        DownloadAndImportBcContainerHelper -baseFolder $([System.IO.Path]::GetTempPath())
+
+        Import-Module (Join-Path $PSScriptRoot "../Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1" -Resolve) -DisableNameChecking -Force
+    }
+
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'baseFolder', Justification = 'False positive.')]
+        $baseFolder = (New-Item -ItemType Directory -Path (Join-Path $([System.IO.Path]::GetTempPath()) $([System.IO.Path]::GetRandomFileName()))).FullName
+    }
+
+    It 'correctly identifies unmodified apps when appFolders reference paths above the project folder via ../' {
+        # Repo layout where the project is nested and appFolders reference sources via ../:
+        #   baseFolder/
+        #     .github/AL-Go-Settings.json
+        #     src/Apps/AppA/App/app.json        (modified)
+        #     src/Apps/AppB/App/app.json        (unmodified - should be downloaded from baseline)
+        #     src/Apps/AppC/App/app.json        (unmodified - should be downloaded from baseline)
+        #     build/projects/MyProject/.AL-Go/settings.json
+        #       appFolders: ["../../../src/Apps/*/App"]
+
+        $project = 'build/projects/MyProject'
+        $projectPath = Join-Path $baseFolder $project
+
+        # Create repo-level AL-Go settings
+        $repoSettings = @{
+            fullBuildPatterns = @()
+            projects = @($project)
+            powerPlatformSolutionFolder = ''
+            useProjectDependencies = $false
+            incrementalBuilds = @{
+                onPull_Request = $true
+                mode = 'modifiedApps'
+            }
+        }
+        New-Item -Path "$baseFolder/.github/AL-Go-Settings.json" -Value (ConvertTo-Json $repoSettings -Depth 10) -type File -Force | Out-Null
+
+        # Create project-level settings with appFolders that go above the project
+        $projectSettingsJson = @{
+            appFolders = @("../../../src/Apps/*/App")
+            testFolders = @()
+            bcptTestFolders = @()
+        }
+        New-Item -Path "$projectPath/.AL-Go/settings.json" -Value (ConvertTo-Json $projectSettingsJson -Depth 10) -type File -Force | Out-Null
+
+        # Create three independent apps
+        $appA = @{ id = 'aaaaaaaa-0000-0000-0000-000000000001'; name = 'App A'; publisher = 'TestPublisher'; version = '1.0.0.0'; dependencies = @() }
+        $appB = @{ id = 'bbbbbbbb-0000-0000-0000-000000000002'; name = 'App B'; publisher = 'TestPublisher'; version = '1.0.0.0'; dependencies = @() }
+        $appC = @{ id = 'cccccccc-0000-0000-0000-000000000003'; name = 'App C'; publisher = 'TestPublisher'; version = '1.0.0.0'; dependencies = @() }
+        New-Item -Path "$baseFolder/src/Apps/AppA/App/app.json" -Value (ConvertTo-Json $appA -Depth 10) -type File -Force | Out-Null
+        New-Item -Path "$baseFolder/src/Apps/AppB/App/app.json" -Value (ConvertTo-Json $appB -Depth 10) -type File -Force | Out-Null
+        New-Item -Path "$baseFolder/src/Apps/AppC/App/app.json" -Value (ConvertTo-Json $appC -Depth 10) -type File -Force | Out-Null
+
+        # Also create a dummy .al file so there's something to be "modified"
+        New-Item -Path "$baseFolder/src/Apps/AppA/App/MyCodeunit.al" -Value "// modified file" -type File -Force | Out-Null
+
+        # Set env:Settings for helper functions
+        $env:Settings = ConvertTo-Json $repoSettings -Depth 99 -Compress
+
+        # Resolve appFolders the way ResolveProjectFolders/AnalyzeRepo does:
+        # Push-Location to project, Resolve-Path -Relative
+        Push-Location $projectPath
+        $resolvedAppFolders = @(Resolve-Path "../../../src/Apps/*/App" -Relative -ErrorAction SilentlyContinue | Where-Object { Test-Path (Join-Path $_ 'app.json') })
+        Pop-Location
+
+        # Build a settings hashtable with resolved folders (same as what RunPipeline passes in)
+        $resolvedSettings = @{
+            appFolders = $resolvedAppFolders
+            testFolders = @()
+            bcptTestFolders = @()
+        }
+
+        # Build artifact folder
+        $buildArtifactFolder = Join-Path $projectPath ".buildartifacts"
+        New-Item -Path $buildArtifactFolder -ItemType Directory -Force | Out-Null
+
+        # Only AppA is modified
+        $sep = [System.IO.Path]::DirectorySeparatorChar
+        $modifiedFiles = @("src${sep}Apps${sep}AppA${sep}App${sep}MyCodeunit.al")
+
+        # Mock GitHub API calls since we don't have a real baseline workflow
+        # Stub functions that are normally provided by GitHub Actions runtime
+        if (-not (Get-Command 'Trace-Information' -ErrorAction SilentlyContinue)) {
+            function global:Trace-Information { param([string]$Message, $AdditionalData) }
+        }
+        $env:GITHUB_API_URL = 'https://api.github.com'
+        $env:GITHUB_REPOSITORY = 'test/repo'
+        Mock InvokeWebRequest {
+            # Return a mock response object that mimics the GitHub API
+            $uri = $args[0]
+            if (-not $uri) { $uri = $Uri }
+            $content = if ($uri -like '*/actions/runs/*/artifacts*') {
+                # Artifacts endpoint - return empty list to stop pagination
+                '{"artifacts":[]}'
+            } else {
+                # Workflow run info endpoint
+                '{"head_branch":"main"}'
+            }
+            return [PSCustomObject]@{ Content = $content }
+        } -ModuleName 'Github-Helper'
+
+        # Capture Write-Host output to verify download folder matching
+        $script:capturedOutput = [System.Collections.ArrayList]::new()
+        Mock Write-Host { $null = $script:capturedOutput.Add($Object) } -ModuleName 'DetermineProjectsToBuild'
+
+        Get-UnmodifiedAppsFromBaselineWorkflowRun `
+            -token 'fake-token' `
+            -settings $resolvedSettings `
+            -baseFolder $baseFolder `
+            -project $project `
+            -baselineWorkflowRunId '12345' `
+            -modifiedFiles $modifiedFiles `
+            -buildArtifactFolder $buildArtifactFolder `
+            -buildMode 'Default' `
+            -projectPath $projectPath
+
+        # The output should list the unmodified app folders (AppB and AppC) as download candidates.
+        # Before the fix: the download list was always empty ("- None") because the path matching
+        # used SubString(2) which mangled paths starting with ..\ into nonsense like \..\..\src\...
+        $downloadAppLine = $script:capturedOutput | Where-Object { $_ -eq 'Download appFolders:' }
+        $downloadAppLine | Should -Not -BeNullOrEmpty -Because "the function should output the 'Download appFolders:' header"
+
+        # Find entries after "Download appFolders:" up to the next section header
+        $inDownloadSection = $false
+        $downloadEntries = @()
+        foreach ($line in $script:capturedOutput) {
+            if ($line -eq 'Download appFolders:') {
+                $inDownloadSection = $true
+                continue
+            }
+            if ($inDownloadSection) {
+                if ($line -match '^Download (test|bcpt)') { break }
+                $downloadEntries += $line
+            }
+        }
+
+        # With the bug: downloadEntries would be @("- None") because the path matching fails
+        # With the fix: downloadEntries should contain AppB and AppC folders
+        $downloadEntries | Should -Not -Contain '- None' -Because "unmodified apps should be identified for download from baseline"
+        ($downloadEntries | Where-Object { $_ -like '*AppB*' }) | Should -Not -BeNullOrEmpty -Because "AppB was not modified and should be downloaded from baseline"
+        ($downloadEntries | Where-Object { $_ -like '*AppC*' }) | Should -Not -BeNullOrEmpty -Because "AppC was not modified and should be downloaded from baseline"
+        ($downloadEntries | Where-Object { $_ -like '*AppA*' }) | Should -BeNullOrEmpty -Because "AppA was modified and should NOT be downloaded from baseline"
+    }
+
+    It 'also works when appFolders are inside the project folder (standard layout)' {
+        # Standard layout where apps are inside the project folder:
+        #   baseFolder/
+        #     .AL-Go/settings.json
+        #     .github/AL-Go-Settings.json
+        #     app1/app.json
+        #     app2/app.json
+
+        $project = ''
+        $projectPath = $baseFolder
+
+        # Create repo-level AL-Go settings
+        $repoSettings = @{
+            fullBuildPatterns = @()
+            projects = @()
+            powerPlatformSolutionFolder = ''
+            useProjectDependencies = $false
+            incrementalBuilds = @{
+                onPull_Request = $true
+                mode = 'modifiedApps'
+            }
+        }
+        New-Item -Path "$baseFolder/.github/AL-Go-Settings.json" -Value (ConvertTo-Json $repoSettings -Depth 10) -type File -Force | Out-Null
+        New-Item -Path "$baseFolder/.AL-Go/settings.json" -Value (ConvertTo-Json @{} -Depth 10) -type File -Force | Out-Null
+
+        # Create two apps inside the project folder
+        $app1 = @{ id = '11111111-0000-0000-0000-000000000001'; name = 'App One'; publisher = 'TestPublisher'; version = '1.0.0.0'; dependencies = @() }
+        $app2 = @{ id = '22222222-0000-0000-0000-000000000002'; name = 'App Two'; publisher = 'TestPublisher'; version = '1.0.0.0'; dependencies = @() }
+        New-Item -Path "$baseFolder/app1/app.json" -Value (ConvertTo-Json $app1 -Depth 10) -type File -Force | Out-Null
+        New-Item -Path "$baseFolder/app2/app.json" -Value (ConvertTo-Json $app2 -Depth 10) -type File -Force | Out-Null
+        New-Item -Path "$baseFolder/app1/MyCodeunit.al" -Value "// modified file" -type File -Force | Out-Null
+
+        $env:Settings = ConvertTo-Json $repoSettings -Depth 99 -Compress
+
+        # Resolve appFolders (standard layout: .\ prefix)
+        $resolvedSettings = @{
+            appFolders = @('.\app1', '.\app2')
+            testFolders = @()
+            bcptTestFolders = @()
+        }
+
+        $buildArtifactFolder = Join-Path $projectPath ".buildartifacts"
+        New-Item -Path $buildArtifactFolder -ItemType Directory -Force | Out-Null
+
+        # Only app1 is modified
+        $sep = [System.IO.Path]::DirectorySeparatorChar
+        $modifiedFiles = @("app1${sep}MyCodeunit.al")
+
+        Mock InvokeWebRequest {
+            $uri = $args[0]
+            if (-not $uri) { $uri = $Uri }
+            $content = if ($uri -like '*/actions/runs/*/artifacts*') {
+                '{"artifacts":[]}'
+            } else {
+                '{"head_branch":"main"}'
+            }
+            return [PSCustomObject]@{ Content = $content }
+        } -ModuleName 'Github-Helper'
+        # Stub Trace-Information if not already defined (normally loaded by Invoke-AlGoAction.ps1)
+        if (-not (Get-Command 'Trace-Information' -ErrorAction SilentlyContinue)) {
+            function global:Trace-Information { param([string]$Message, $AdditionalData) }
+        }
+        $env:GITHUB_API_URL = 'https://api.github.com'
+        $env:GITHUB_REPOSITORY = 'test/repo'
+
+        $script:capturedOutput = [System.Collections.ArrayList]::new()
+        Mock Write-Host { $null = $script:capturedOutput.Add($Object) } -ModuleName 'DetermineProjectsToBuild'
+
+        Get-UnmodifiedAppsFromBaselineWorkflowRun `
+            -token 'fake-token' `
+            -settings $resolvedSettings `
+            -baseFolder $baseFolder `
+            -project $project `
+            -baselineWorkflowRunId '12345' `
+            -modifiedFiles $modifiedFiles `
+            -buildArtifactFolder $buildArtifactFolder `
+            -buildMode 'Default' `
+            -projectPath $projectPath
+
+        $inDownloadSection = $false
+        $downloadEntries = @()
+        foreach ($line in $script:capturedOutput) {
+            if ($line -eq 'Download appFolders:') {
+                $inDownloadSection = $true
+                continue
+            }
+            if ($inDownloadSection) {
+                if ($line -match '^Download (test|bcpt)') { break }
+                $downloadEntries += $line
+            }
+        }
+
+        # app2 should be marked for download (unmodified), app1 should not
+        $downloadEntries | Should -Not -Contain '- None' -Because "the unmodified app2 should be identified for download"
+        ($downloadEntries | Where-Object { $_ -like '*app2*' }) | Should -Not -BeNullOrEmpty -Because "app2 was not modified and should be downloaded from baseline"
+        ($downloadEntries | Where-Object { $_ -like '*app1*' }) | Should -BeNullOrEmpty -Because "app1 was modified and should NOT be downloaded from baseline"
+    }
+
+    AfterEach {
+        Remove-Item $baseFolder -Force -Recurse
+    }
+}


### PR DESCRIPTION
## Summary

When `incrementalBuilds.mode` is set to `modifiedApps` and a project references app folders **outside** its own directory via `../` paths, unmodified apps are never downloaded from the baseline workflow run. Instead, every app is recompiled on every PR — even when only a single file changed.

## The bug

`Get-UnmodifiedAppsFromBaselineWorkflowRun` needs to match entries from `$settings.appFolders` (project-relative paths) against `$skipFolders` (repo-relative paths). The old code assumed all resolved folder paths start with `.\` and used `SubString(2)` to strip that prefix:

```powershell
# Old code
$downloadAppFolders = @($settings.appFolders | Where-Object {
    $skipFolders -contains "$projectWithSeperator$($_.SubString(2))"
})
```

This works when apps live **inside** the project folder (paths like `.\app`), but breaks when apps live **outside** (paths like `..\..\..\src\Apps\SomeApp\App`).

### Toy example to illustrate

Consider a repo layout where a project at `build/projects/MyProject` references apps at `src/`:

```
repo/
  src/
    Apps/
      Invoicing/App/app.json      ← modified
      Reporting/App/app.json      ← unmodified
  build/
    projects/
      MyProject/
        .AL-Go/settings.json      ← appFolders: ["../../../src/Apps/*/App"]
```

After `ResolveProjectFolders` resolves the glob from the project directory, `$settings.appFolders` contains:

```
..\..\..\src\Apps\Invoicing\App
..\..\..\src\Apps\Reporting\App
```

Meanwhile, `$skipFolders` (from `GetFoldersFromAllProjects`, resolved from the repo root) contains:

```
src\Apps\Reporting\App
```

The old matching logic did:

| Step | Value |
|---|---|
| `$_.SubString(2)` on `..\..\..\src\Apps\Reporting\App` | `\..\..\src\Apps\Reporting\App` |
| Prepend project separator | `build\projects\MyProject\..\..\src\Apps\Reporting\App` |
| Compare with `$skipFolders` | `src\Apps\Reporting\App` |
| **Match?** | **No — string comparison, not path resolution** |

The result: `$downloadAppFolders` is always empty → no artifacts downloaded from baseline → **all apps recompiled**.

For comparison, the standard layout (apps inside the project) works because paths start with `.\`:

| Step | Value |
|---|---|
| `$_.SubString(2)` on `.\app` | `app` |
| Prepend project separator (empty for root project) | `app` |
| Compare with `$skipFolders` | `app` |
| **Match?** | **Yes** |

## The fix

Replace the `SubString(2)` hack with proper path resolution. A new helper `ConvertTo-RepoRelativePath` resolves each project-relative folder to an absolute path via `Join-Path -Resolve`, then strips the base folder prefix to produce a clean repo-relative path that matches `$skipFolders` exactly:

```powershell
# New code
function ConvertTo-RepoRelativePath {
    param([string] $folder, [string] $projectPath, [string] $baseFolder)
    $fullPath = Join-Path $projectPath $folder -Resolve -ErrorAction SilentlyContinue
    if (-not $fullPath) { return $null }
    $normalizedBase = $baseFolder.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
    if ($fullPath.StartsWith($normalizedBase, [StringComparison]::OrdinalIgnoreCase)) {
        return $fullPath.Substring($normalizedBase.Length)
    }
    return $null
}
```

This works for both layouts:

| Layout | `$settings.appFolders` entry | Resolved absolute | Repo-relative | Matches `$skipFolders`? |
|---|---|---|---|---|
| Nested project | `..\..\..\src\Apps\Reporting\App` | `D:\a\repo\src\Apps\Reporting\App` | `src\Apps\Reporting\App` | Yes |
| Standard | `.\app` | `D:\a\repo\app` | `app` | Yes |

## Tests

Two new Pester tests added to `DetermineProjectsToBuild.Test.ps1`:

1. **Nested project with `../` paths** — creates a repo layout where apps are outside the project folder. **Fails without the fix** (`Download appFolders: - None`), **passes with the fix**.
2. **Standard layout** — apps inside the project folder. **Passes both before and after** (backwards compatibility).

## Test plan

- [x] New test fails on old code, passes on new code
- [x] All 28 existing tests continue to pass
- [ ] Validate on a real BCApps PR build
