### PR TITLE
Fix PSReviewUnusedParameter code scanning alerts

### DIFF
--- a/Actions/.Modules/CompileFromWorkspace.psm1
+++ b/Actions/.Modules/CompileFromWorkspace.psm1
@@ -169,12 +169,6 @@ function Get-ALTool {
     Path to the output folder for compiled .app files. Defaults to PackageCachePath.
 .PARAMETER LogDirectory
     Path to the directory for compilation log files.
-.PARAMETER MajorMinorVersion
-    Major.Minor version to stamp into the compiled apps.
-.PARAMETER BuildNumber
-    Build number to stamp into the compiled apps.
-.PARAMETER RevisionNumber
-    Revision number to stamp into the compiled apps.
 .PARAMETER MaxCpuCount
     Maximum number of parallel compilation processes. Defaults to 1.
 .PARAMETER AssemblyProbingPaths
@@ -220,12 +214,6 @@ function Build-AppsInWorkspace {
         [Parameter(Mandatory = $false)]
         [string]$LogDirectory,
         # Optional parameters
-        [Parameter(Mandatory = $false)]
-        [string]$MajorMinorVersion = "",
-        [Parameter(Mandatory = $false)]
-        [int] $BuildNumber = 0,
-        [Parameter(Mandatory = $false)]
-        [int] $RevisionNumber = 0,
         [Parameter(Mandatory = $false)]
         [int]$MaxCpuCount = 1,
         # Optional compiler parameters

--- a/Actions/.Modules/CompileFromWorkspace.psm1
+++ b/Actions/.Modules/CompileFromWorkspace.psm1
@@ -593,7 +593,7 @@ function Get-DotnetRuntimeVersionInstalled {
                 }
                 $runtimes[$runtime.name] += $version
             } catch {
-                # Skip versions that can't be parsed
+                OutputDebug -message "Skipping runtime version '$($runtime.version)' that could not be parsed: $_"
             }
         }
 

--- a/Actions/CompileApps/Compile.ps1
+++ b/Actions/CompileApps/Compile.ps1
@@ -1,3 +1,4 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'buildMode', Justification = 'Accepted from workflow; reserved for future incremental build support')]
 Param(
     [Parameter(HelpMessage = "The GitHub token running the action", Mandatory = $false)]
     [string] $token,
@@ -137,9 +138,6 @@ try {
         AssemblyProbingPaths        = (Get-AssemblyProbingPaths -CompilerFolder $compilerFolder)
         PreprocessorSymbols         = $settings.preprocessorSymbols
         Features                    = $settings.features
-        MajorMinorVersion           = $versionNumber.MajorMinorVersion
-        BuildNumber                 = $versionNumber.BuildNumber
-        RevisionNumber              = $versionNumber.RevisionNumber
         MaxCpuCount                 = $settings.workspaceCompilation.parallelism
         SourceRepositoryUrl         = $buildMetadata.SourceRepositoryUrl
         SourceCommit                = $buildMetadata.SourceCommit

--- a/Tests/AL-Go-Helper.Test.ps1
+++ b/Tests/AL-Go-Helper.Test.ps1
@@ -117,7 +117,7 @@
     Describe 'Get-VersionNumber' {
         # All tests share the same baseline settings to verify each strategy picks the correct source
         BeforeEach {
-            $baseSettings = @{
+            $script:baseSettings = @{
                 appBuild = 42
                 appRevision = 7
                 artifact = "https://bcartifacts.azureedge.net/sandbox/24.5.26928.27583/us"
@@ -126,76 +126,76 @@
         }
 
         It 'Default versioning strategy returns settings appBuild and appRevision' {
-            $baseSettings.versioningStrategy = 0
-            $result = Get-VersionNumber -Settings $baseSettings
+            $script:baseSettings.versioningStrategy = 0
+            $result = Get-VersionNumber -Settings $script:baseSettings
             $result.MajorMinorVersion | Should -Be ""
             $result.BuildNumber | Should -Be 42
             $result.RevisionNumber | Should -Be 7
         }
 
         It 'Strategy -1 extracts version from artifact URL' {
-            $baseSettings.versioningStrategy = -1
-            $result = Get-VersionNumber -Settings $baseSettings
+            $script:baseSettings.versioningStrategy = -1
+            $result = Get-VersionNumber -Settings $script:baseSettings
             $result.MajorMinorVersion | Should -Be "24.5"
             $result.BuildNumber | Should -Be 26928
             $result.RevisionNumber | Should -Be 27583
         }
 
         It 'Strategy 16 uses repoVersion for major.minor' {
-            $baseSettings.versioningStrategy = 16
-            $result = Get-VersionNumber -Settings $baseSettings
+            $script:baseSettings.versioningStrategy = 16
+            $result = Get-VersionNumber -Settings $script:baseSettings
             $result.MajorMinorVersion | Should -Be "3.1"
             $result.BuildNumber | Should -Be 42
             $result.RevisionNumber | Should -Be 7
         }
 
         It 'Strategy 19 (16+3) gets build number from repoVersion' {
-            $baseSettings.versioningStrategy = 19
-            $result = Get-VersionNumber -Settings $baseSettings
+            $script:baseSettings.versioningStrategy = 19
+            $result = Get-VersionNumber -Settings $script:baseSettings
             $result.MajorMinorVersion | Should -Be "3.1"
             $result.BuildNumber | Should -Be 200
             $result.RevisionNumber | Should -Be 7
         }
 
         It 'Strategy 19 with two-digit repoVersion defaults build to 0 with warning' {
-            $baseSettings.versioningStrategy = 19
-            $baseSettings.repoVersion = "2.4"
-            $result = Get-VersionNumber -Settings $baseSettings -WarningVariable warnings -WarningAction SilentlyContinue
+            $script:baseSettings.versioningStrategy = 19
+            $script:baseSettings.repoVersion = "2.4"
+            $result = Get-VersionNumber -Settings $script:baseSettings -WarningVariable warnings -WarningAction SilentlyContinue
             $result.MajorMinorVersion | Should -Be "2.4"
             $result.BuildNumber | Should -Be 0
         }
 
         It 'Strategy 17 (16+1) uses repoVersion for major.minor but does not override appBuild' {
-            $baseSettings.versioningStrategy = 17
-            $result = Get-VersionNumber -Settings $baseSettings
+            $script:baseSettings.versioningStrategy = 17
+            $result = Get-VersionNumber -Settings $script:baseSettings
             $result.MajorMinorVersion | Should -Be "3.1"
             $result.BuildNumber | Should -Be 42
             $result.RevisionNumber | Should -Be 7
         }
 
         It 'Strategy 3 without bit 16 behaves like default' {
-            $baseSettings.versioningStrategy = 3
-            $result = Get-VersionNumber -Settings $baseSettings
+            $script:baseSettings.versioningStrategy = 3
+            $result = Get-VersionNumber -Settings $script:baseSettings
             $result.MajorMinorVersion | Should -Be ""
             $result.BuildNumber | Should -Be 42
             $result.RevisionNumber | Should -Be 7
         }
 
         It 'Strategy 2 passes through date-based appBuild and appRevision' {
-            $baseSettings.versioningStrategy = 2
-            $baseSettings.appBuild = 20260313 # Simulate date-based build number
-            $baseSettings.appRevision = 141450 # Simulate time-based revision number
-            $result = Get-VersionNumber -Settings $baseSettings
+            $script:baseSettings.versioningStrategy = 2
+            $script:baseSettings.appBuild = 20260313 # Simulate date-based build number
+            $script:baseSettings.appRevision = 141450 # Simulate time-based revision number
+            $result = Get-VersionNumber -Settings $script:baseSettings
             $result.MajorMinorVersion | Should -Be ""
             $result.BuildNumber | Should -Be 20260313 # Build number should be passed through unchanged
             $result.RevisionNumber | Should -Be 141450 # Revision number should be passed through unchanged
         }
 
         It 'Strategy 15 passes through max build value' {
-            $baseSettings.versioningStrategy = 15
-            $baseSettings.appBuild = [Int32]::MaxValue # Simulate max build number
-            $baseSettings.appRevision = 100 # Simulate some revision number
-            $result = Get-VersionNumber -Settings $baseSettings
+            $script:baseSettings.versioningStrategy = 15
+            $script:baseSettings.appBuild = [Int32]::MaxValue # Simulate max build number
+            $script:baseSettings.appRevision = 100 # Simulate some revision number
+            $result = Get-VersionNumber -Settings $script:baseSettings
             $result.MajorMinorVersion | Should -Be ""
             $result.BuildNumber | Should -Be ([Int32]::MaxValue) # Build number should be passed through unchanged
             $result.RevisionNumber | Should -Be 100 # Revision number should be passed through unchanged

--- a/Tests/CompileFromWorkspace.Test.ps1
+++ b/Tests/CompileFromWorkspace.Test.ps1
@@ -1,4 +1,7 @@
-﻿$errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Mock/callback parameters must match function signatures')]
+param()
+
+$errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "../Actions/AL-Go-Helper.ps1" -Resolve)
 Import-Module (Join-Path $PSScriptRoot '../Actions/.Modules/CompileFromWorkspace.psm1' -Resolve) -DisableNameChecking -Force

--- a/Tests/DownloadProjectDependencies.Test.ps1
+++ b/Tests/DownloadProjectDependencies.Test.ps1
@@ -1,3 +1,6 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Mock/callback parameters must match function signatures')]
+param()
+
 Get-Module TestActionsHelper | Remove-Module -Force
 Import-Module (Join-Path $PSScriptRoot 'TestActionsHelper.psm1')
 $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0

--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -354,6 +354,7 @@ function CreateNewAppInFolder {
         "name" = $name
         "version" = $version
         "publisher" = $publisher
+        "runtime" = $runtime
         "dependencies" = $dependencies
         "application" = $application
         "idRanges" = @( @{ "from" = $objID; "to" = $objID } )


### PR DESCRIPTION
Addresses open PSScriptAnalyzer code scanning alerts

## Approach

The alerts fall into distinct categories, each handled differently:

**Production code - true fixes:**
- **`Build-AppsInWorkspace`**: Removed `MajorMinorVersion`, `BuildNumber`, and `RevisionNumber` parameters. These were accepted but never used - version stamping is handled by `Update-AppJsonProperties` which is called separately before compilation. Also removed the corresponding entries from the `\` splatting in `Compile.ps1`.
- **`e2eTestHelper.psm1`**: The `\` parameter was accepted by `CreateNewAppInFolder` but never written into the generated `app.json`. Added `runtime` to the output - this is a bug fix.
- **`CompileFromWorkspace.psm1`**: Replaced an empty catch block (for unparseable .NET runtime versions) with an `OutputDebug` call that logs the version string and error.

**Production code - suppressed:**
- **`Compile.ps1`**: `\` is passed by the action YAML workflow and cannot be removed without updating the action definition. It may also be needed for future incremental build support (see existing TODO). Added a targeted `SuppressMessageAttribute`.

**Test files - fixed:**
- **`AL-Go-Helper.Test.ps1`**: `\` was assigned in `BeforeEach` but PSScriptAnalyzer flagged it as unused since usage was in separate `It` blocks. Scoped it to `\` so the cross-block usage is explicit.

**Test files - suppressed:**
- **`CompileFromWorkspace.Test.ps1`** and **`DownloadProjectDependencies.Test.ps1`**: All 57 alerts are Pester mock scriptblock parameters that must match the mocked function's signature for positional binding. Added file-level `SuppressMessageAttribute` with justification.