### PR TITLE
Fix workspace compilation with external dependencies

### DIFF
--- a/Actions/CompileApps/Compile.ps1
+++ b/Actions/CompileApps/Compile.ps1
@@ -104,12 +104,15 @@ try {
     $compilerFolder = New-BcCompilerFolder -artifactUrl $artifact -vsixFile $settings.vsixFile -containerName "$($containerName)compiler" -cacheFolder $cacheFolder
     $packageCachePath = Join-Path $compilerFolder "symbols"
 
-    # Copy dependency apps to the package cache so the compiler can resolve them
-    foreach ($appFile in $dependencyApps) {
+    # Copy dependency apps and test apps to the package cache so the compiler can resolve them
+    foreach ($appFile in ($dependencyApps + $dependencyTestApps)) {
         $appFile = $appFile.Trim('()')
         if ($appFile -and (Test-Path $appFile)) {
             Copy-Item -Path $appFile -Destination $packageCachePath -Force
             OutputDebug "Copied dependency app to package cache: $(Split-Path $appFile -Leaf)"
+        }
+        elseif ($appFile) {
+            OutputWarning -message "Dependency app file not found: $appFile"
         }
     }
 

--- a/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
+++ b/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
@@ -27,17 +27,7 @@ function DownloadDependenciesFromProbingPaths {
 
         # GetDependencies may return .zip files (from DownloadArtifact/DownloadRelease).
         # Extract .app files from any zips so downstream consumers receive clean .app paths.
-        return @($dependencies | ForEach-Object {
-            $isTestApp = $_.StartsWith('(')
-            $filePath = $_.Trim('()')
-            if ($filePath -and (Test-Path $filePath) -and (Test-IsZipFile -Path $filePath)) {
-                $appFiles = Expand-ZipFileToAppFiles -ZipFile $filePath -DestinationPath $destinationPath
-                if ($isTestApp) { $appFiles | ForEach-Object { "($_)" } } else { $appFiles }
-            }
-            else {
-                $_
-            }
-        })
+        return Resolve-DependencyFiles -Dependencies $dependencies -DestinationPath $destinationPath
     }
 }
 

--- a/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
+++ b/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
@@ -111,7 +111,7 @@ function DownloadDependenciesFromCurrentBuild {
         }
     }
 
-    return $downloadedDependencies
+    return Resolve-DependencyFiles -Dependencies $downloadedDependencies -DestinationPath $destinationPath
 }
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)

--- a/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
+++ b/Actions/DownloadProjectDependencies/DownloadProjectDependencies.Action.ps1
@@ -23,7 +23,21 @@ function DownloadDependenciesFromProbingPaths {
     $settings = AnalyzeRepo -settings $settings -baseFolder $baseFolder -project $project -doNotCheckArtifactSetting -doNotIssueWarnings
     $settings = CheckAppDependencyProbingPaths -settings $settings -token $token -baseFolder $baseFolder -project $project
     if ($settings.ContainsKey('appDependencyProbingPaths') -and $settings.appDependencyProbingPaths) {
-        return GetDependencies -probingPathsJson $settings.appDependencyProbingPaths -saveToPath $destinationPath | Where-Object { $_ }
+        $dependencies = GetDependencies -probingPathsJson $settings.appDependencyProbingPaths -saveToPath $destinationPath | Where-Object { $_ }
+
+        # GetDependencies may return .zip files (from DownloadArtifact/DownloadRelease).
+        # Extract .app files from any zips so downstream consumers receive clean .app paths.
+        return @($dependencies | ForEach-Object {
+            $isTestApp = $_.StartsWith('(')
+            $filePath = $_.Trim('()')
+            if ($filePath -and (Test-Path $filePath) -and (Test-IsZipFile -Path $filePath)) {
+                $appFiles = Expand-ZipFileToAppFiles -ZipFile $filePath -DestinationPath $destinationPath
+                if ($isTestApp) { $appFiles | ForEach-Object { "($_)" } } else { $appFiles }
+            }
+            else {
+                $_
+            }
+        })
     }
 }
 
@@ -148,7 +162,7 @@ $downloadedDependencies | ForEach-Object {
     }
 }
 
-# Add dependencies from settings
+# Add dependencies from settings (these are already resolved to .app files)
 $downloadedApps += $settingsDependencies.Apps
 $downloadedTestApps += $settingsDependencies.TestApps
 

--- a/Actions/DownloadProjectDependencies/DownloadProjectDependencies.psm1
+++ b/Actions/DownloadProjectDependencies/DownloadProjectDependencies.psm1
@@ -328,4 +328,45 @@ function Get-DependenciesFromInstallApps {
     return $install
 }
 
-Export-ModuleMember -Function Get-AppFilesFromUrl, Get-AppFilesFromLocalPath, Get-DependenciesFromInstallApps, Expand-ZipFileToAppFiles, Test-IsZipFile
+<#
+    .SYNOPSIS
+    Resolves dependency file paths by extracting .app files from any zip archives.
+    .DESCRIPTION
+    Takes an array of dependency file paths (which may be .app files or .zip archives)
+    and returns an array of .app file paths. Zip archives are extracted and the contained
+    .app files are copied to the destination path. Test app markers (parentheses wrapping)
+    are preserved through extraction.
+    .PARAMETER Dependencies
+    An array of dependency file paths. Test apps are wrapped in parentheses, e.g. "(path.zip)".
+    .PARAMETER DestinationPath
+    The path where extracted .app files should be placed.
+    .OUTPUTS
+    An array of resolved .app file paths, with test app markers preserved.
+#>
+function Resolve-DependencyFiles {
+    Param(
+        [Parameter(Mandatory = $false)]
+        [string[]] $Dependencies = @(),
+        [Parameter(Mandatory = $true)]
+        [string] $DestinationPath
+    )
+
+    if (-not $Dependencies -or $Dependencies.Count -eq 0) {
+        return @()
+    }
+
+    return @($Dependencies | ForEach-Object {
+        $isTestApp = $_.StartsWith('(')
+        $filePath = $_.Trim('()')
+        if ($filePath -and (Test-Path $filePath) -and (Test-IsZipFile -Path $filePath)) {
+            $appFiles = Expand-ZipFileToAppFiles -ZipFile $filePath -DestinationPath $DestinationPath
+            Remove-Item -Path $filePath -Force -ErrorAction SilentlyContinue
+            if ($isTestApp) { $appFiles | ForEach-Object { "($_)" } } else { $appFiles }
+        }
+        else {
+            $_
+        }
+    })
+}
+
+Export-ModuleMember -Function Get-AppFilesFromUrl, Get-AppFilesFromLocalPath, Get-DependenciesFromInstallApps, Resolve-DependencyFiles

--- a/Actions/DownloadProjectDependencies/DownloadProjectDependencies.psm1
+++ b/Actions/DownloadProjectDependencies/DownloadProjectDependencies.psm1
@@ -328,4 +328,4 @@ function Get-DependenciesFromInstallApps {
     return $install
 }
 
-Export-ModuleMember -Function Get-AppFilesFromUrl, Get-AppFilesFromLocalPath, Get-DependenciesFromInstallApps
+Export-ModuleMember -Function Get-AppFilesFromUrl, Get-AppFilesFromLocalPath, Get-DependenciesFromInstallApps, Expand-ZipFileToAppFiles, Test-IsZipFile

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 ### Issues
 
 - Issue 2204 - Workspace compilation ignores vsixFile setting
+- Issue 2214 - Workspace compilation not working with external dependencies
 
 ## v9.0
 

--- a/Tests/DownloadProjectDependencies.Test.ps1
+++ b/Tests/DownloadProjectDependencies.Test.ps1
@@ -530,3 +530,109 @@ Describe "DownloadProjectDependencies - Get-DependenciesFromInstallApps Tests" {
         { Get-DependenciesFromInstallApps -DestinationPath $downloadPath } | Should -Throw "*unknown secret 'missingSecret'*"
     }
 }
+
+Describe "DownloadProjectDependencies - Resolve-DependencyFiles Tests" {
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'testFolder', Justification = 'False positive.')]
+        $testFolder = (New-Item -ItemType Directory -Path (Join-Path $([System.IO.Path]::GetTempPath()) $([System.IO.Path]::GetRandomFileName()))).FullName
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'destFolder', Justification = 'False positive.')]
+        $destFolder = (New-Item -ItemType Directory -Path (Join-Path $testFolder "dest")).FullName
+    }
+
+    AfterEach {
+        if (Test-Path $testFolder) {
+            Remove-Item -Path $testFolder -Recurse -Force
+        }
+    }
+
+    It 'Returns empty array for empty input' {
+        $result = Resolve-DependencyFiles -Dependencies @() -DestinationPath $destFolder
+        $result | Should -HaveCount 0
+    }
+
+    It 'Returns empty array for null input' {
+        $result = Resolve-DependencyFiles -Dependencies $null -DestinationPath $destFolder
+        $result | Should -HaveCount 0
+    }
+
+    It 'Passes through .app file paths unchanged' {
+        $appFile = Join-Path $testFolder "myapp.app"
+        Set-Content -Path $appFile -Value "fake app content"
+
+        $result = @(Resolve-DependencyFiles -Dependencies @($appFile) -DestinationPath $destFolder)
+
+        $result | Should -HaveCount 1
+        $result[0] | Should -Be $appFile
+    }
+
+    It 'Passes through test app markers for .app files' {
+        $appFile = Join-Path $testFolder "testapp.app"
+        Set-Content -Path $appFile -Value "fake test app"
+
+        $result = @(Resolve-DependencyFiles -Dependencies @("($appFile)") -DestinationPath $destFolder)
+
+        $result | Should -HaveCount 1
+        $result[0] | Should -Be "($appFile)"
+    }
+
+    It 'Extracts .app files from zip archives' {
+        $appFile = Join-Path $testFolder "Foundation_1.0.0.0.app"
+        Set-Content -Path $appFile -Value "fake app content"
+        $zipFile = Join-Path $testFolder "Foundation-main-Apps-1.0.0.0.zip"
+        Compress-Archive -Path $appFile -DestinationPath $zipFile
+
+        $result = @(Resolve-DependencyFiles -Dependencies @($zipFile) -DestinationPath $destFolder)
+
+        $result | Should -HaveCount 1
+        $result[0] | Should -BeLike "*Foundation_1.0.0.0.app"
+        Test-Path $result[0] | Should -Be $true
+    }
+
+    It 'Removes source zip after extraction' {
+        $appFile = Join-Path $testFolder "app.app"
+        Set-Content -Path $appFile -Value "fake"
+        $zipFile = Join-Path $testFolder "deps.zip"
+        Compress-Archive -Path $appFile -DestinationPath $zipFile
+
+        Resolve-DependencyFiles -Dependencies @($zipFile) -DestinationPath $destFolder
+
+        Test-Path $zipFile | Should -Be $false
+    }
+
+    It 'Preserves test app markers when extracting zips' {
+        $appFile = Join-Path $testFolder "testlib.app"
+        Set-Content -Path $appFile -Value "fake test lib"
+        $zipFile = Join-Path $testFolder "TestApps-1.0.0.0.zip"
+        Compress-Archive -Path $appFile -DestinationPath $zipFile
+
+        $result = @(Resolve-DependencyFiles -Dependencies @("($zipFile)") -DestinationPath $destFolder)
+
+        $result | Should -HaveCount 1
+        $result[0] | Should -Match '^\('
+        $result[0] | Should -Match '\)$'
+        $result[0].Trim('()') | Should -BeLike "*testlib.app"
+    }
+
+    It 'Handles mixed .app and .zip dependencies' {
+        $appFile = Join-Path $testFolder "direct.app"
+        Set-Content -Path $appFile -Value "direct app"
+
+        $zippedApp = Join-Path $testFolder "zipped.app"
+        Set-Content -Path $zippedApp -Value "zipped app"
+        $zipFile = Join-Path $testFolder "deps.zip"
+        Compress-Archive -Path $zippedApp -DestinationPath $zipFile
+
+        $result = @(Resolve-DependencyFiles -Dependencies @($appFile, $zipFile) -DestinationPath $destFolder)
+
+        $result | Should -HaveCount 2
+        $result[0] | Should -Be $appFile
+        $result[1] | Should -BeLike "*zipped.app"
+    }
+
+    It 'Passes through non-existent paths unchanged' {
+        $result = @(Resolve-DependencyFiles -Dependencies @("C:\nonexistent\fake.zip") -DestinationPath $destFolder)
+
+        $result | Should -HaveCount 1
+        $result[0] | Should -Be "C:\nonexistent\fake.zip"
+    }
+}

--- a/Tests/DownloadProjectDependencies.Test.ps1
+++ b/Tests/DownloadProjectDependencies.Test.ps1
@@ -630,9 +630,11 @@ Describe "DownloadProjectDependencies - Resolve-DependencyFiles Tests" {
     }
 
     It 'Passes through non-existent paths unchanged' {
-        $result = @(Resolve-DependencyFiles -Dependencies @("C:\nonexistent\fake.zip") -DestinationPath $destFolder)
+        $nonExistentZipFile = Join-Path $testFolder "nonexistent-fake.zip"
+
+        $result = @(Resolve-DependencyFiles -Dependencies @($nonExistentZipFile) -DestinationPath $destFolder)
 
         $result | Should -HaveCount 1
-        $result[0] | Should -Be "C:\nonexistent\fake.zip"
+        $result[0] | Should -Be $nonExistentZipFile
     }
 }


### PR DESCRIPTION
## Problem

When `workspaceCompilation` is enabled, builds fail with AL1022 errors for external AL app dependencies from `appDependencyProbingPaths`. The same repository builds successfully with workspace compilation disabled. Fixes #2214.

The root cause is twofold:

1. **Zip files not extracted.** `GetDependencies` (via `DownloadArtifact`/`DownloadRelease`) returns raw `.zip` file paths for dependencies from `appDependencyProbingPaths`. Run-ALPipeline handles this today which is why everything works without workspace compilation. However, for workspace compilation to work we need to extract the .zip files first. 

2. **Test app dependencies not copied.** `Compile.ps1` only copied `$dependencyApps` to the package cache, ignoring `$dependencyTestApps` entirely. Test folders depending on external test app dependencies would fail with AL1022.

## Approach

- Added a `Resolve-DependencyFiles` helper in `DownloadProjectDependencies.psm1` that extracts `.app` files from zip archives while preserving test app markers (`(...)` wrapping). Source zips are cleaned up after extraction.
- Applied `Resolve-DependencyFiles` in both `DownloadDependenciesFromProbingPaths` and `DownloadDependenciesFromCurrentBuild` (which can also fall back to `latestBuild` and return zips).
- Updated `Compile.ps1` to copy both `$dependencyApps` and `$dependencyTestApps` to the package cache, with a warning when dependency file paths don't exist.

Related to #2214