### PR TITLE
Download Dependencies: include BuildOutput to avoid single dependency download.

### DIFF
--- a/Actions/DownloadProjectDependencies/DownloadProjectDependencies.psm1
+++ b/Actions/DownloadProjectDependencies/DownloadProjectDependencies.psm1
@@ -333,11 +333,14 @@ function Get-DependenciesFromInstallApps {
     Computes a minimatch-compatible glob pattern for downloading only dependency-project artifacts.
     .DESCRIPTION
     Given a project and its dependency map (from projectDependenciesJson), constructs a brace-expansion
-    pattern that matches only the Apps, TestApps, and Dependencies artifacts for the dependency projects.
+    pattern that matches only the Apps, TestApps, Dependencies, and BuildOutput artifacts for the dependency projects.
     This pattern is designed for use with the actions/download-artifact 'pattern' input (which uses minimatch).
 
     The pattern uses '*Apps' to match both 'Apps' and 'TestApps' as well as build-mode-prefixed variants
     (e.g. 'CleanApps', 'CleanTestApps'). Similarly '*Dependencies' matches 'Dependencies' and variants.
+    '*BuildOutput' is included to ensure the pattern matches multiple artifacts, preventing download-artifact
+    v8 from flattening a single artifact directly into the destination path (which breaks the subdirectory
+    structure that GetDependencies expects).
     .PARAMETER Project
     The name of the current AL-Go project.
     .PARAMETER ProjectDependencies
@@ -364,12 +367,17 @@ function Get-DependencyArtifactPattern {
 
     $branchName = Get-CurrentBranchName
 
-    # Build brace-expansion entries: 2 per dependency project (*Apps covers Apps+TestApps+buildMode variants)
+    # Build brace-expansion entries per dependency project.
+    # *Apps covers Apps+TestApps+buildMode variants; *Dependencies covers Dependencies.
+    # *BuildOutput is included to ensure the pattern always matches ≥2 artifacts,
+    # preventing download-artifact v8 from flattening a single artifact into the
+    # destination root (which breaks the subdirectory structure GetDependencies expects).
     $entries = @()
     foreach ($dep in $dependencyProjects) {
         $sanitizedDep = $dep.Replace('\', '_').Replace('/', '_')
         $entries += "$sanitizedDep-$branchName-*Apps-*"
         $entries += "$sanitizedDep-$branchName-*Dependencies-*"
+        $entries += "$sanitizedDep-$branchName-*BuildOutput-*"
     }
 
     return "{$($entries -join ',')}"

--- a/Actions/DownloadProjectDependencies/DownloadProjectDependencies.psm1
+++ b/Actions/DownloadProjectDependencies/DownloadProjectDependencies.psm1
@@ -369,7 +369,7 @@ function Get-DependencyArtifactPattern {
 
     # Build brace-expansion entries per dependency project.
     # *Apps covers Apps+TestApps+buildMode variants; *Dependencies covers Dependencies.
-    # *BuildOutput is included to ensure the pattern always matches ≥2 artifacts,
+    # *BuildOutput is included to ensure the pattern always matches >=2 artifacts,
     # preventing download-artifact v8 from flattening a single artifact into the
     # destination root (which breaks the subdirectory structure GetDependencies expects).
     $entries = @()

--- a/Tests/DownloadProjectDependencies.Test.ps1
+++ b/Tests/DownloadProjectDependencies.Test.ps1
@@ -576,7 +576,7 @@ Describe "DownloadProjectDependencies - Get-DependencyArtifactPattern Tests" {
         InModuleScope DownloadProjectDependencies -Parameters @{ Project = 'App'; ProjectDependencies = $projectDependencies } {
             param($Project, $ProjectDependencies)
             $result = Get-DependencyArtifactPattern -Project $Project -ProjectDependencies $ProjectDependencies
-            $result | Should -Be '{Base-main-*Apps-*,Base-main-*Dependencies-*}'
+            $result | Should -Be '{Base-main-*Apps-*,Base-main-*Dependencies-*,Base-main-*BuildOutput-*}'
         }
     }
 
@@ -588,7 +588,7 @@ Describe "DownloadProjectDependencies - Get-DependencyArtifactPattern Tests" {
         InModuleScope DownloadProjectDependencies -Parameters @{ Project = 'App'; ProjectDependencies = $projectDependencies } {
             param($Project, $ProjectDependencies)
             $result = Get-DependencyArtifactPattern -Project $Project -ProjectDependencies $ProjectDependencies
-            $result | Should -Be '{Base-feature_auth-*Apps-*,Base-feature_auth-*Dependencies-*}'
+            $result | Should -Be '{Base-feature_auth-*Apps-*,Base-feature_auth-*Dependencies-*,Base-feature_auth-*BuildOutput-*}'
         }
     }
 }
@@ -609,16 +609,16 @@ Describe "DownloadProjectDependencies - Get-DependencyArtifactPattern Advanced T
         $ENV:GITHUB_REF_NAME = $originalRefName
     }
 
-    It 'Returns pattern with 4 brace entries for two dependencies' {
+    It 'Returns pattern with 6 brace entries for two dependencies' {
         $projectDependencies = @{ "App" = @("Base", "Common") }
         InModuleScope DownloadProjectDependencies -Parameters @{ Project = "App"; ProjectDependencies = $projectDependencies } {
             param($Project, $ProjectDependencies)
             $result = Get-DependencyArtifactPattern -Project $Project -ProjectDependencies $ProjectDependencies
-            $result | Should -Be "{Base-main-*Apps-*,Base-main-*Dependencies-*,Common-main-*Apps-*,Common-main-*Dependencies-*}"
+            $result | Should -Be "{Base-main-*Apps-*,Base-main-*Dependencies-*,Base-main-*BuildOutput-*,Common-main-*Apps-*,Common-main-*Dependencies-*,Common-main-*BuildOutput-*}"
         }
     }
 
-    It 'Returns pattern with 6 brace entries for three flattened transitive dependencies' {
+    It 'Returns pattern with 9 brace entries for three flattened transitive dependencies' {
         $projectDependencies = @{ "App" = @("Base", "Common", "Core") }
         InModuleScope DownloadProjectDependencies -Parameters @{ Project = "App"; ProjectDependencies = $projectDependencies } {
             param($Project, $ProjectDependencies)
@@ -627,8 +627,8 @@ Describe "DownloadProjectDependencies - Get-DependencyArtifactPattern Advanced T
             $result | Should -BeLike "*Base-main-*"
             $result | Should -BeLike "*Common-main-*"
             $result | Should -BeLike "*Core-main-*"
-            # 3 deps x 2 entries each = 6 entries = 5 commas
-            ($result.ToCharArray() | Where-Object { $_ -eq ',' }).Count | Should -Be 5
+            # 3 deps x 3 entries each = 9 entries = 8 commas
+            ($result.ToCharArray() | Where-Object { $_ -eq ',' }).Count | Should -Be 8
         }
     }
 


### PR DESCRIPTION
### ❔What, Why & How

When using the download_artifact v8 action, downloaded artifacts are put into subfolders within some specified root folder. However, if only a single artifact is downloaded, its contents are extracted directly to the root folder instead of a subfolder, breaking our filtering logic. To fix this short term, I include BuildOutput in downloaded artifacts, as that ensures we always have at least 2 artifacts to download.

Related to issue: #

### ✅ Checklist

- [ ] Add tests (E2E, unit tests)
- [ ] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
