### PR TITLE
Add GH_TOKEN env variable to Build step in _BuildALGoProject workflow

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+### GH_TOKEN environment variable available during build
+
+The `_BuildALGoProject` workflow now passes `github.token` as the `GH_TOKEN` environment variable to the RunPipeline action. This allows script overrides (e.g. `RunTestsInBcContainer`) to use the GitHub CLI (`gh`) for repository operations during the build step.
+
 ### Conditional settings now support workflow trigger events
 
 `ConditionalSettings` now supports a `triggers` condition, allowing you to apply settings based on `GITHUB_EVENT_NAME` values such as `push`, `pull_request`, `schedule`, and `workflow_dispatch`.

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -200,6 +200,7 @@ jobs:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           BuildMode: ${{ inputs.buildMode }}
           NeedsContext: ${{ env.NeedsContext }}
+          GH_TOKEN: ${{ github.token }}
         with:
           shell: ${{ inputs.shell }}
           artifact: ${{ env.artifact }}

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -200,6 +200,7 @@ jobs:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           BuildMode: ${{ inputs.buildMode }}
           NeedsContext: ${{ env.NeedsContext }}
+          GH_TOKEN: ${{ github.token }}
         with:
           shell: ${{ inputs.shell }}
           artifact: ${{ env.artifact }}


### PR DESCRIPTION
Pass `github.token` as `GH_TOKEN` environment variable to the RunPipeline action in the `_BuildALGoProject` workflow template.

This allows script overrides (e.g. `RunTestsInBcContainer`) to use the GitHub CLI (`gh`) to access repository artifacts during the build step — for example, to download unstable test lists for test tolerance checks.

Changes made to both templates:
- `Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml`
- `Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml`