### PR TITLE
Fix ReleaseBranches e2e: point previous-release assertions at the new step

### DIFF
--- a/e2eTests/scenarios/ReleaseBranches/runtest.ps1
+++ b/e2eTests/scenarios/ReleaseBranches/runtest.ps1
@@ -89,7 +89,7 @@ $run = RunCICD -repository $repository -branch $branch -wait
 Test-ArtifactsFromRun -runid $run.id -folder 'artifacts' -expectedArtifacts @{"Apps"=1} -repoVersion '1.0' -appVersion '1.0'
 
 # Check that no previous release was found
-Test-LogContainsFromRun -runid $run.id -jobName 'Build . (Default)*(Default)' -stepName 'Build' -expectedText 'No previous release found'
+Test-LogContainsFromRun -runid $run.id -jobName 'Build . (Default)*(Default)' -stepName 'Download Previous Release' -expectedText 'No previous release found'
 
 # Release version 1.0
 $tag1 = '1.0.0'
@@ -106,7 +106,7 @@ $run = RunCICD -repository $repository -branch $branch -wait
 Test-ArtifactsFromRun -runid $run.id -folder 'artifacts' -expectedArtifacts @{"Apps"=1} -repoVersion '2.0' -appVersion '2.0'
 
 # Check that $tag1 was used as previous release
-Test-LogContainsFromRun -runid $run.id -jobName 'Build . (Default)*(Default)' -stepName 'Build' -expectedText "Using $ver1 (tag $tag1) as previous release"
+Test-LogContainsFromRun -runid $run.id -jobName 'Build . (Default)*(Default)' -stepName 'Download Previous Release' -expectedText "Using $ver1 (tag $tag1) as previous release"
 
 # Release version 2.0
 $tag2 = '2.0.0'
@@ -129,7 +129,7 @@ WaitWorkflow -runid $run.id -repository $repository -noDelay
 Test-ArtifactsFromRun -runid $run.id -folder 'artifacts' -expectedArtifacts @{"Apps"=1} -repoVersion '2.1' -appVersion '2.1'
 
 # Check that $tag2 was used as previous release
-Test-LogContainsFromRun -runid $run.id -jobName 'Build . (Default)*(Default)' -stepName 'Build' -expectedText "Using $ver2 (tag $tag2) as previous release"
+Test-LogContainsFromRun -runid $run.id -jobName 'Build . (Default)*(Default)' -stepName 'Download Previous Release' -expectedText "Using $ver2 (tag $tag2) as previous release"
 
 Test-ArtifactsFromRun -runid $runRelease1.id -folder 'artifacts1' -expectedArtifacts @{"Apps"=1} -repoVersion '1.0' -appVersion '1.0'
 $noOfReleaseArtifacts = @(get-childitem -path 'artifacts1' -filter '*-release_1.0-Apps-1.0.*').count
@@ -138,7 +138,7 @@ if ($noOfReleaseArtifacts -ne 1) {
 }
 
 # Check that $tag1 was used as previous release for builds in release branch 1.0
-Test-LogContainsFromRun -runid $runRelease1.id -jobName 'Build . (Default)*(Default)' -stepName 'Build' -expectedText "Using $ver1 (tag $tag1) as previous release"
+Test-LogContainsFromRun -runid $runRelease1.id -jobName 'Build . (Default)*(Default)' -stepName 'Download Previous Release' -expectedText "Using $ver1 (tag $tag1) as previous release"
 
 Test-ArtifactsFromRun -runid $runRelease2.id -folder 'artifacts2' -expectedArtifacts @{"Apps"=1} -repoVersion '2.0' -appVersion '2.0'
 $noOfReleaseArtifacts = @(get-childitem -path 'artifacts2' -filter '*-release_2.0-Apps-2.0.*').count
@@ -147,7 +147,7 @@ if ($noOfReleaseArtifacts -ne 1) {
 }
 
 # Check that $tag2 was used as previous release for builds in release branch 2.0
-Test-LogContainsFromRun -runid $runRelease2.id -jobName 'Build . (Default)*(Default)' -stepName 'Build' -expectedText "Using $ver2 (tag $tag2) as previous release"
+Test-LogContainsFromRun -runid $runRelease2.id -jobName 'Build . (Default)*(Default)' -stepName 'Download Previous Release' -expectedText "Using $ver2 (tag $tag2) as previous release"
 
 # Release hotfix from version 1.0
 $hotTag1 = "1.0.$($runRelease1.run_number)"
@@ -173,7 +173,7 @@ if ($noOfReleaseArtifacts -ne 1) {
 }
 
 # Check that $hotTag1 was used as previous release for builds in release branch 1.0
-Test-LogContainsFromRun -runid $runRelease1.id -jobName 'Build . (Default)*(Default)' -stepName 'Build' -expectedText "Using $hotVer1 (tag $hotTag1) as previous release"
+Test-LogContainsFromRun -runid $runRelease1.id -jobName 'Build . (Default)*(Default)' -stepName 'Download Previous Release' -expectedText "Using $hotVer1 (tag $hotTag1) as previous release"
 
 Set-Location $prevLocation
 


### PR DESCRIPTION
The `ReleaseBranches` scenario started failing after commit 12b6760 introduced a dedicated `DownloadPreviousRelease` action. The log messages the test searches for (`No previous release found` and `Using vX (tag X.Y.Z) as previous release`) used to be emitted from the `Build` step, but now come from the new `Download Previous Release` step. The test wasn't updated, so all six `Test-LogContainsFromRun` calls in `e2eTests/scenarios/ReleaseBranches/runtest.ps1` were looking at the wrong step and failing.

This updates those six assertions to use `-stepName 'Download Previous Release'`. No product code changes; test-only fix.

Failing run for reference: https://github.com/microsoft/AL-Go/actions/runs/25755372648/job/75749344161