### PR TITLE
Use artifact manifest.json dotNetVersion for assembly probing paths

### DIFF
--- a/Actions/.Modules/CompileFromWorkspace.psm1
+++ b/Actions/.Modules/CompileFromWorkspace.psm1
@@ -571,6 +571,19 @@ function CompileAppsInWorkspace {
 
 <#
 .SYNOPSIS
+    Returns the raw output of 'dotnet --list-runtimes'.
+.DESCRIPTION
+    Thin wrapper around the native dotnet CLI so the runtime detection logic in
+    Get-DotnetRuntimeVersionInstalled can be unit tested by mocking this function.
+.OUTPUTS
+    The lines emitted by 'dotnet --list-runtimes', or $null if the command produced no output.
+#>
+function Get-DotnetListRuntimes {
+    return dotnet --list-runtimes
+}
+
+<#
+.SYNOPSIS
     Gets the highest installed .NET runtime version matching the requested major.
 .DESCRIPTION
     Uses 'dotnet --list-runtimes' to detect installed .NET runtimes. Returns the highest
@@ -589,7 +602,7 @@ function Get-DotnetRuntimeVersionInstalled {
     )
 
     try {
-        $runtimeOutput = dotnet --list-runtimes
+        $runtimeOutput = Get-DotnetListRuntimes
 
         if (-not $runtimeOutput) {
             OutputDebug -message "Could not detect .NET runtimes. 'dotnet --list-runtimes' returned no output."
@@ -664,9 +677,19 @@ function Get-RequiredDotnetMajorVersionFromManifest {
     }
 
     try {
-        $manifest = Get-Content -Path $manifestFile -Encoding UTF8 -Raw | ConvertFrom-Json
-        if ($manifest.dotNetVersion) {
-            return ([System.Version]$manifest.dotNetVersion).Major
+        $manifest = Get-Content -Path $manifestFile -Encoding UTF8 -Raw | ConvertFrom-Json | ConvertTo-HashTable -recurse
+        if ($manifest.ContainsKey('dotNetVersion') -and $manifest.dotNetVersion) {
+            try {
+                return ([System.Version]$manifest.dotNetVersion).Major
+            }
+            catch {
+                # [System.Version] requires at least major.minor; fall back to extracting
+                # the leading integer so single-segment values like "8" still resolve to a major.
+                if ($manifest.dotNetVersion -match '^(\d+)') {
+                    return [int]$Matches[1]
+                }
+                throw
+            }
         }
     }
     catch {

--- a/Actions/.Modules/CompileFromWorkspace.psm1
+++ b/Actions/.Modules/CompileFromWorkspace.psm1
@@ -571,24 +571,21 @@ function CompileAppsInWorkspace {
 
 <#
 .SYNOPSIS
-    Gets the highest compatible .NET runtime version installed on the system.
+    Gets the highest installed .NET runtime version matching the requested major.
 .DESCRIPTION
     Uses 'dotnet --list-runtimes' to detect installed .NET runtimes. Returns the highest
-    version that is within the supported major version range. Requires both Microsoft.NETCore.App
-    and Microsoft.AspNetCore.App runtimes to be installed for a version to be considered.
-.PARAMETER MinimumSupportedMajorVersion
-    The minimum major version of .NET runtime to consider.
-.PARAMETER MaximumSupportedMajorVersion
-    The maximum major version of .NET runtime to consider.
+    installed version whose major equals RequiredMajorVersion and where both
+    Microsoft.NETCore.App and Microsoft.AspNetCore.App runtimes are installed.
+.PARAMETER RequiredMajorVersion
+    The exact major version of .NET runtime to look for (typically read from the BC artifact's
+    manifest.json dotNetVersion field).
 .OUTPUTS
-    System.Version of the highest compatible .NET runtime installed, or $null if none found.
+    System.Version of the highest matching .NET runtime installed, or $null if none found.
 #>
 function Get-DotnetRuntimeVersionInstalled {
     param(
-        [Parameter(Mandatory = $false)]
-        [int] $MinimumSupportedMajorVersion = 6, # TODO: Find a better way to determine minimum supported version and maximum supported version
-        [Parameter(Mandatory = $false)]
-        [int] $MaximumSupportedMajorVersion = 8
+        [Parameter(Mandatory = $true)]
+        [int] $RequiredMajorVersion
     )
 
     try {
@@ -623,10 +620,9 @@ function Get-DotnetRuntimeVersionInstalled {
             return $null
         }
 
-        # Find the highest version present in both, within the supported major version range
+        # Pick the highest installed version with the requested major where both runtimes are present.
         $compatibleVersions = $netCoreVersions | Where-Object {
-            $_.Major -ge $MinimumSupportedMajorVersion -and
-            $_.Major -le $MaximumSupportedMajorVersion -and
+            $_.Major -eq $RequiredMajorVersion -and
             $aspNetVersions -contains $_
         } | Sort-Object -Descending
 
@@ -640,6 +636,44 @@ function Get-DotnetRuntimeVersionInstalled {
         OutputDebug -message "Failed to detect .NET runtime version: $_"
         return $null
     }
+}
+
+<#
+.SYNOPSIS
+    Reads the required .NET major version from the BC artifact manifest.
+.DESCRIPTION
+    BcContainerHelper copies the artifact's manifest.json into the compiler folder. If the
+    manifest contains a dotNetVersion, this function returns its major version so the assembly
+    probing paths can target the exact .NET runtime the artifact was built against. Returns 0
+    when no manifest is present or the manifest does not declare a dotNetVersion.
+.PARAMETER CompilerFolder
+    The folder where the AL compiler tool is located (and where BcContainerHelper places
+    manifest.json).
+.OUTPUTS
+    The required .NET major version as an integer, or 0 when not declared.
+#>
+function Get-RequiredDotnetMajorVersionFromManifest {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $CompilerFolder
+    )
+
+    $manifestFile = Join-Path $CompilerFolder "manifest.json"
+    if (-not (Test-Path $manifestFile)) {
+        return 0
+    }
+
+    try {
+        $manifest = Get-Content -Path $manifestFile -Encoding UTF8 -Raw | ConvertFrom-Json
+        if ($manifest.dotNetVersion) {
+            return ([System.Version]$manifest.dotNetVersion).Major
+        }
+    }
+    catch {
+        OutputWarning -message "Could not read manifest.json from compiler folder: $($_.Exception.Message)"
+    }
+
+    return 0
 }
 
 <#
@@ -676,14 +710,27 @@ function Get-AssemblyProbingPaths {
     } elseif ($isLinux -or $isMacOS) {
         $probingPaths = @((Join-Path $compilerFolderDllsPath "OpenXML")) + $probingPaths
     } else {
-        $dotNetRuntimeVersion = (Get-DotnetRuntimeVersionInstalled)
-        if ($dotNetRuntimeVersion) {
-            $dotnetRoot = Split-Path (Get-Command dotnet).Source
-            $probingPaths = @((Join-Path $compilerFolderDllsPath "OpenXML"), (Join-Path $dotnetRoot "shared\Microsoft.NETCore.App\$dotNetRuntimeVersion"), (Join-Path $dotnetRoot "shared\Microsoft.AspNetCore.App\$dotNetRuntimeVersion")) + $probingPaths
+        # The BC artifact's manifest.json (copied into the compiler folder by BcContainerHelper)
+        # declares which .NET version the platform was built against. Pick the matching installed
+        # runtime so the compiler resolves the same assemblies BC will load at runtime.
+        $dotNetSharedPaths = @()
+        $requiredMajor = Get-RequiredDotnetMajorVersionFromManifest -CompilerFolder $CompilerFolder
+        if ($requiredMajor -gt 0) {
+            OutputDebug -message "Artifact manifest requires .NET major version $requiredMajor"
+            $dotNetRuntimeVersion = Get-DotnetRuntimeVersionInstalled -RequiredMajorVersion $requiredMajor
+            if ($dotNetRuntimeVersion) {
+                OutputDebug -message "Using .NET runtime version $dotNetRuntimeVersion for assembly probing paths"
+                $dotnetRoot = Split-Path (Get-Command dotnet).Source
+                $dotNetSharedPaths = @((Join-Path $dotnetRoot "shared\Microsoft.NETCore.App\$dotNetRuntimeVersion"), (Join-Path $dotnetRoot "shared\Microsoft.AspNetCore.App\$dotNetRuntimeVersion"))
+            }
+            else {
+                OutputWarning -message "No installed .NET runtime matches the major version ($requiredMajor) required by the artifact manifest. .NET assembly probing paths will not be added."
+            }
         }
         else {
-            $probingPaths = @((Join-Path $compilerFolderDllsPath "OpenXML")) + $probingPaths
+            OutputDebug -message "Artifact manifest does not declare a dotNetVersion; skipping versioned .NET assembly probing paths."
         }
+        $probingPaths = @((Join-Path $compilerFolderDllsPath "OpenXML")) + $dotNetSharedPaths + $probingPaths
     }
 
     OutputArray -Message "Probing Paths:" -Array $probingPaths

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,6 @@
 ### Use artifact manifest to pick .NET runtime for assembly probing
 
-When compiling apps with the workspace compiler, AL-Go now reads the `dotNetVersion` from the BC artifact's `manifest.json` (copied into the compiler folder by BcContainerHelper) and selects an installed .NET runtime whose major version matches. This avoids version drift between the build agent's highest installed runtime and the platform the artifact was built against. If no installed runtime matches the required major, AL-Go falls back to the previous behavior.
+When compiling apps with the workspace compiler, AL-Go now reads the `dotNetVersion` from the BC artifact's `manifest.json` (copied into the compiler folder by BcContainerHelper) and selects an installed .NET runtime whose major version matches. This avoids version drift between the build agent's highest installed runtime and the platform the artifact was built against. If the manifest does not declare a `dotNetVersion`, or no installed runtime matches the required major, versioned .NET assembly probing paths are omitted (a warning is logged in the latter case).
 
 ### New AL-Go hooks (experimental)
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+### Use artifact manifest to pick .NET runtime for assembly probing
+
+When compiling apps with the workspace compiler, AL-Go now reads the `dotNetVersion` from the BC artifact's `manifest.json` (copied into the compiler folder by BcContainerHelper) and selects an installed .NET runtime whose major version matches. This avoids version drift between the build agent's highest installed runtime and the platform the artifact was built against. If no installed runtime matches the required major, AL-Go falls back to the previous behavior.
+
 ### New AL-Go hooks (experimental)
 
 AL-Go for GitHub now supports a new generic hook mechanism that is independent of BcContainerHelper. A new `RunHook` action invokes scripts placed in the project's `.AL-Go` folder at well-known extension points in the workflows. The first such extension point is `BuildInitialize`, which runs in the build workflow immediately after `Read settings` (so AL-Go settings are available as environment variables).

--- a/Tests/CompileFromWorkspace.Test.ps1
+++ b/Tests/CompileFromWorkspace.Test.ps1
@@ -818,7 +818,7 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
         }
 
         It 'Passes the major version from manifest.json to Get-DotnetRuntimeVersionInstalled' {
-            if ($script:isLinux -or $script:isMacOS) {
+            if ($PSVersionTable.PSVersion.Major -ge 6 -and ($IsLinux -or $IsMacOS)) {
                 Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
                 return
             }
@@ -842,7 +842,7 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
         }
 
         It 'Skips versioned .NET probing paths when no installed runtime matches the manifest major' {
-            if ($script:isLinux -or $script:isMacOS) {
+            if ($PSVersionTable.PSVersion.Major -ge 6 -and ($IsLinux -or $IsMacOS)) {
                 Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
                 return
             }
@@ -863,7 +863,7 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
         }
 
         It 'Skips versioned .NET probing paths when no manifest.json is present' {
-            if ($script:isLinux -or $script:isMacOS) {
+            if ($PSVersionTable.PSVersion.Major -ge 6 -and ($IsLinux -or $IsMacOS)) {
                 Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
                 return
             }
@@ -882,7 +882,7 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
         }
 
         It 'Ignores a malformed manifest.json and skips versioned .NET probing paths' {
-            if ($script:isLinux -or $script:isMacOS) {
+            if ($PSVersionTable.PSVersion.Major -ge 6 -and ($IsLinux -or $IsMacOS)) {
                 Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
                 return
             }

--- a/Tests/CompileFromWorkspace.Test.ps1
+++ b/Tests/CompileFromWorkspace.Test.ps1
@@ -818,7 +818,7 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
         }
 
         It 'Passes the major version from manifest.json to Get-DotnetRuntimeVersionInstalled' {
-            if ($isLinux -or $isMacOS) {
+            if ($script:isLinux -or $script:isMacOS) {
                 Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
                 return
             }
@@ -842,7 +842,7 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
         }
 
         It 'Skips versioned .NET probing paths when no installed runtime matches the manifest major' {
-            if ($isLinux -or $isMacOS) {
+            if ($script:isLinux -or $script:isMacOS) {
                 Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
                 return
             }
@@ -863,7 +863,7 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
         }
 
         It 'Skips versioned .NET probing paths when no manifest.json is present' {
-            if ($isLinux -or $isMacOS) {
+            if ($script:isLinux -or $script:isMacOS) {
                 Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
                 return
             }
@@ -882,7 +882,7 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
         }
 
         It 'Ignores a malformed manifest.json and skips versioned .NET probing paths' {
-            if ($isLinux -or $isMacOS) {
+            if ($script:isLinux -or $script:isMacOS) {
                 Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
                 return
             }
@@ -924,6 +924,28 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
             }
         }
 
+        It 'Returns the major version for a 2-segment dotNetVersion' {
+            $compilerFolder = Join-Path $TestDrive 'compiler-with-manifest-2segment'
+            New-Item -Path $compilerFolder -ItemType Directory -Force | Out-Null
+            @{ dotNetVersion = '8.0' } | ConvertTo-Json | Set-Content -Path (Join-Path $compilerFolder 'manifest.json') -Encoding UTF8
+
+            InModuleScope CompileFromWorkspace -Parameters @{ Folder = $compilerFolder } {
+                param($Folder)
+                Get-RequiredDotnetMajorVersionFromManifest -CompilerFolder $Folder | Should -Be 8
+            }
+        }
+
+        It 'Returns the major version for a single-segment dotNetVersion via the fallback parser' {
+            $compilerFolder = Join-Path $TestDrive 'compiler-with-manifest-1segment'
+            New-Item -Path $compilerFolder -ItemType Directory -Force | Out-Null
+            @{ dotNetVersion = '8' } | ConvertTo-Json | Set-Content -Path (Join-Path $compilerFolder 'manifest.json') -Encoding UTF8
+
+            InModuleScope CompileFromWorkspace -Parameters @{ Folder = $compilerFolder } {
+                param($Folder)
+                Get-RequiredDotnetMajorVersionFromManifest -CompilerFolder $Folder | Should -Be 8
+            }
+        }
+
         It 'Returns 0 when manifest.json has no dotNetVersion property' {
             $compilerFolder = Join-Path $TestDrive 'compiler-manifest-no-dotnet'
             New-Item -Path $compilerFolder -ItemType Directory -Force | Out-Null
@@ -943,6 +965,90 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
             InModuleScope CompileFromWorkspace -Parameters @{ Folder = $compilerFolder } {
                 param($Folder)
                 Get-RequiredDotnetMajorVersionFromManifest -CompilerFolder $Folder | Should -Be 0
+            }
+        }
+    }
+
+    Describe 'Get-DotnetRuntimeVersionInstalled' {
+        # Sample 'dotnet --list-runtimes' output: lines like
+        # "Microsoft.AspNetCore.App 6.0.36 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]"
+        # We mock the wrapper Get-DotnetListRuntimes to return canned strings.
+
+        It 'Returns the highest installed version matching the requested major' {
+            InModuleScope CompileFromWorkspace {
+                Mock Get-DotnetListRuntimes {
+                    @(
+                        'Microsoft.AspNetCore.App 6.0.36 [path]',
+                        'Microsoft.AspNetCore.App 8.0.5 [path]',
+                        'Microsoft.AspNetCore.App 8.0.10 [path]',
+                        'Microsoft.NETCore.App 6.0.36 [path]',
+                        'Microsoft.NETCore.App 8.0.5 [path]',
+                        'Microsoft.NETCore.App 8.0.10 [path]'
+                    )
+                }
+
+                $result = Get-DotnetRuntimeVersionInstalled -RequiredMajorVersion 8
+
+                $result | Should -Be ([System.Version]'8.0.10')
+            }
+        }
+
+        It 'Returns $null when no installed runtime matches the requested major' {
+            InModuleScope CompileFromWorkspace {
+                Mock Get-DotnetListRuntimes {
+                    @(
+                        'Microsoft.AspNetCore.App 6.0.36 [path]',
+                        'Microsoft.NETCore.App 6.0.36 [path]'
+                    )
+                }
+
+                Get-DotnetRuntimeVersionInstalled -RequiredMajorVersion 9 | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Returns $null when only Microsoft.NETCore.App is installed for the requested major' {
+            InModuleScope CompileFromWorkspace {
+                Mock Get-DotnetListRuntimes {
+                    @(
+                        'Microsoft.NETCore.App 8.0.10 [path]'
+                    )
+                }
+
+                Get-DotnetRuntimeVersionInstalled -RequiredMajorVersion 8 | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Returns $null when only Microsoft.AspNetCore.App is installed for the requested major' {
+            InModuleScope CompileFromWorkspace {
+                Mock Get-DotnetListRuntimes {
+                    @(
+                        'Microsoft.AspNetCore.App 8.0.10 [path]'
+                    )
+                }
+
+                Get-DotnetRuntimeVersionInstalled -RequiredMajorVersion 8 | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Returns $null when matching versions exist in NETCore.App but not in AspNetCore.App' {
+            InModuleScope CompileFromWorkspace {
+                Mock Get-DotnetListRuntimes {
+                    @(
+                        'Microsoft.AspNetCore.App 8.0.5 [path]',
+                        'Microsoft.NETCore.App 8.0.10 [path]'
+                    )
+                }
+
+                # 8.0.10 is only in NETCore.App; 8.0.5 is only in AspNetCore.App; no overlap
+                Get-DotnetRuntimeVersionInstalled -RequiredMajorVersion 8 | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Returns $null when dotnet --list-runtimes produces no output' {
+            InModuleScope CompileFromWorkspace {
+                Mock Get-DotnetListRuntimes { return $null }
+
+                Get-DotnetRuntimeVersionInstalled -RequiredMajorVersion 8 | Should -BeNullOrEmpty
             }
         }
     }

--- a/Tests/CompileFromWorkspace.Test.ps1
+++ b/Tests/CompileFromWorkspace.Test.ps1
@@ -816,6 +816,135 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
 
             ($result -like '*shared') | Should -Not -BeNullOrEmpty
         }
+
+        It 'Passes the major version from manifest.json to Get-DotnetRuntimeVersionInstalled' {
+            if ($isLinux -or $isMacOS) {
+                Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
+                return
+            }
+
+            $compilerFolder = Join-Path $TestDrive 'compiler-probing-manifest'
+            $dllsPath = Join-Path $compilerFolder 'dlls'
+            New-Item -Path (Join-Path $dllsPath 'OpenXML') -ItemType Directory -Force | Out-Null
+            @{ dotNetVersion = '8.0.10' } | ConvertTo-Json | Set-Content -Path (Join-Path $compilerFolder 'manifest.json') -Encoding UTF8
+
+            Mock Get-DotnetRuntimeVersionInstalled -ModuleName CompileFromWorkspace -MockWith {
+                param($RequiredMajorVersion)
+                if ($RequiredMajorVersion -eq 8) { return [System.Version]'8.0.10' }
+                return $null
+            }
+
+            $result = Get-AssemblyProbingPaths -CompilerFolder $compilerFolder
+
+            ($result -like '*Microsoft.NETCore.App*8.0.10*') | Should -Not -BeNullOrEmpty
+            ($result -like '*Microsoft.AspNetCore.App*8.0.10*') | Should -Not -BeNullOrEmpty
+            Should -Invoke Get-DotnetRuntimeVersionInstalled -ModuleName CompileFromWorkspace -ParameterFilter { $RequiredMajorVersion -eq 8 }
+        }
+
+        It 'Skips versioned .NET probing paths when no installed runtime matches the manifest major' {
+            if ($isLinux -or $isMacOS) {
+                Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
+                return
+            }
+
+            $compilerFolder = Join-Path $TestDrive 'compiler-probing-manifest-no-match'
+            $dllsPath = Join-Path $compilerFolder 'dlls'
+            New-Item -Path (Join-Path $dllsPath 'OpenXML') -ItemType Directory -Force | Out-Null
+            @{ dotNetVersion = '9.0.0' } | ConvertTo-Json | Set-Content -Path (Join-Path $compilerFolder 'manifest.json') -Encoding UTF8
+
+            Mock Get-DotnetRuntimeVersionInstalled -ModuleName CompileFromWorkspace -MockWith { return $null }
+
+            $result = Get-AssemblyProbingPaths -CompilerFolder $compilerFolder
+
+            ($result -like '*Microsoft.NETCore.App*') | Should -BeNullOrEmpty
+            ($result -like '*Microsoft.AspNetCore.App*') | Should -BeNullOrEmpty
+            ($result -like '*OpenXML') | Should -Not -BeNullOrEmpty
+            Should -Invoke Get-DotnetRuntimeVersionInstalled -ModuleName CompileFromWorkspace -Times 1
+        }
+
+        It 'Skips versioned .NET probing paths when no manifest.json is present' {
+            if ($isLinux -or $isMacOS) {
+                Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
+                return
+            }
+
+            $compilerFolder = Join-Path $TestDrive 'compiler-probing-no-manifest'
+            $dllsPath = Join-Path $compilerFolder 'dlls'
+            New-Item -Path (Join-Path $dllsPath 'OpenXML') -ItemType Directory -Force | Out-Null
+
+            Mock Get-DotnetRuntimeVersionInstalled -ModuleName CompileFromWorkspace -MockWith { return [System.Version]'8.0.10' }
+
+            $result = Get-AssemblyProbingPaths -CompilerFolder $compilerFolder
+
+            ($result -like '*Microsoft.NETCore.App*') | Should -BeNullOrEmpty
+            ($result -like '*OpenXML') | Should -Not -BeNullOrEmpty
+            Should -Invoke Get-DotnetRuntimeVersionInstalled -ModuleName CompileFromWorkspace -Times 0
+        }
+
+        It 'Ignores a malformed manifest.json and skips versioned .NET probing paths' {
+            if ($isLinux -or $isMacOS) {
+                Set-ItResult -Skipped -Because 'manifest-driven runtime resolution only applies on Windows'
+                return
+            }
+
+            $compilerFolder = Join-Path $TestDrive 'compiler-probing-manifest-malformed'
+            $dllsPath = Join-Path $compilerFolder 'dlls'
+            New-Item -Path (Join-Path $dllsPath 'OpenXML') -ItemType Directory -Force | Out-Null
+            Set-Content -Path (Join-Path $compilerFolder 'manifest.json') -Value 'not-json' -Encoding UTF8
+
+            Mock Get-DotnetRuntimeVersionInstalled -ModuleName CompileFromWorkspace -MockWith { return [System.Version]'8.0.10' }
+
+            $result = Get-AssemblyProbingPaths -CompilerFolder $compilerFolder
+
+            ($result -like '*Microsoft.NETCore.App*') | Should -BeNullOrEmpty
+            ($result -like '*OpenXML') | Should -Not -BeNullOrEmpty
+            Should -Invoke Get-DotnetRuntimeVersionInstalled -ModuleName CompileFromWorkspace -Times 0
+        }
+    }
+
+    Describe 'Get-RequiredDotnetMajorVersionFromManifest' {
+        It 'Returns 0 when no manifest.json exists' {
+            $compilerFolder = Join-Path $TestDrive 'compiler-no-manifest'
+            New-Item -Path $compilerFolder -ItemType Directory -Force | Out-Null
+
+            InModuleScope CompileFromWorkspace -Parameters @{ Folder = $compilerFolder } {
+                param($Folder)
+                Get-RequiredDotnetMajorVersionFromManifest -CompilerFolder $Folder | Should -Be 0
+            }
+        }
+
+        It 'Returns the major version from manifest.json' {
+            $compilerFolder = Join-Path $TestDrive 'compiler-with-manifest'
+            New-Item -Path $compilerFolder -ItemType Directory -Force | Out-Null
+            @{ dotNetVersion = '8.0.10' } | ConvertTo-Json | Set-Content -Path (Join-Path $compilerFolder 'manifest.json') -Encoding UTF8
+
+            InModuleScope CompileFromWorkspace -Parameters @{ Folder = $compilerFolder } {
+                param($Folder)
+                Get-RequiredDotnetMajorVersionFromManifest -CompilerFolder $Folder | Should -Be 8
+            }
+        }
+
+        It 'Returns 0 when manifest.json has no dotNetVersion property' {
+            $compilerFolder = Join-Path $TestDrive 'compiler-manifest-no-dotnet'
+            New-Item -Path $compilerFolder -ItemType Directory -Force | Out-Null
+            @{ version = '26.0.0.0' } | ConvertTo-Json | Set-Content -Path (Join-Path $compilerFolder 'manifest.json') -Encoding UTF8
+
+            InModuleScope CompileFromWorkspace -Parameters @{ Folder = $compilerFolder } {
+                param($Folder)
+                Get-RequiredDotnetMajorVersionFromManifest -CompilerFolder $Folder | Should -Be 0
+            }
+        }
+
+        It 'Returns 0 when manifest.json is malformed' {
+            $compilerFolder = Join-Path $TestDrive 'compiler-manifest-malformed'
+            New-Item -Path $compilerFolder -ItemType Directory -Force | Out-Null
+            Set-Content -Path (Join-Path $compilerFolder 'manifest.json') -Value '{ not valid json' -Encoding UTF8
+
+            InModuleScope CompileFromWorkspace -Parameters @{ Folder = $compilerFolder } {
+                param($Folder)
+                Get-RequiredDotnetMajorVersionFromManifest -CompilerFolder $Folder | Should -Be 0
+            }
+        }
     }
 
     Describe 'CompileAppsInWorkspace argument construction' {


### PR DESCRIPTION
Mirrors microsoft/navcontainerhelper#4130 on the AL-Go side. BcContainerHelper now copies the BC artifact's `manifest.json` into the compiler folder, which declares the `dotNetVersion` the platform was built against. Previously, AL-Go's workspace compiler picked the highest installed .NET runtime within a hardcoded major-version range (6-8) for assembly probing. That heuristic drifts as new artifact platforms ship and is just a guess when the build agent has multiple runtimes installed.

This change makes the artifact manifest the source of truth.

### Approach

- New private helper `Get-RequiredDotnetMajorVersionFromManifest` reads `dotNetVersion` from the manifest in the compiler folder and returns the required major (or 0 if the manifest is missing/malformed).
- `Get-DotnetRuntimeVersionInstalled` now takes a single mandatory `-RequiredMajorVersion` parameter and returns the highest installed runtime matching that major where both `Microsoft.NETCore.App` and `Microsoft.AspNetCore.App` are present. The old `MinimumSupportedMajorVersion` / `MaximumSupportedMajorVersion` parameters and the "best guess" fallback are gone.
- `Get-AssemblyProbingPaths` reads the manifest, asks for the matching runtime, and adds versioned `Microsoft.NETCore.App\<version>` + `Microsoft.AspNetCore.App\<version>` paths. If either the manifest or the matching runtime is missing, the versioned paths are simply omitted (warning logged for the latter) rather than falling back to a potentially wrong "highest installed" runtime.

### Tests

Added Pester coverage for: manifest present with matching runtime, manifest present but no matching runtime, no manifest, malformed manifest, and direct unit tests for `Get-RequiredDotnetMajorVersionFromManifest` (via `InModuleScope` since it's not exported). All 63 tests in `CompileFromWorkspace.Test.ps1` pass.

### Worth a careful look

- The `MinimumSupportedMajorVersion`/`MaximumSupportedMajorVersion` parameters are removed entirely rather than kept as a fallback. Rationale: if the manifest doesn't tell us the version, picking "highest installed in some range" is no more correct than skipping the versioned paths. Worth a sanity check that we're comfortable with that posture.
- This depends on BcContainerHelper preview (which AL-Go already pins via `$defaultBcContainerHelperVersion = "preview"`) actually copying `manifest.json` into the compiler folder. PR #4130 is merged, so this should be in the preview stream.