### PR TITLE
Handle empty test failure stack traces

### DIFF
--- a/Actions/AnalyzeTests/TestResultAnalyzer.ps1
+++ b/Actions/AnalyzeTests/TestResultAnalyzer.ps1
@@ -192,10 +192,11 @@ function GetTestResultSummaryMD {
                                     foreach($failure in $testcase.ChildNodes) {
                                         Write-Host "      - Error: $($failure.message)"
                                         Write-Host "        Stacktrace:"
-                                        Write-Host "        $($failure."#text".Trim().Replace("`n","`n        "))"
+                                        $stackTrace = $failure.InnerText.Trim()
+                                        Write-Host "        $($stackTrace.Replace("`n","`n        "))"
                                         $testFailureNode = [FailureNode]::new($true)
                                         $testFailureNode.errorMessage = $failure.message
-                                        $testFailureNode.errorStackTrace = $($failure."#text".Trim().Replace("`n","<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"))
+                                        $testFailureNode.errorStackTrace = $($stackTrace.Replace("`n","<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"))
                                         $testCaseFailureNode.childSummaries.Add($testFailureNode) | Out-Null
                                     }
                                     $suiteFailureNode.childSummaries.Add($testCaseFailureNode) | Out-Null

--- a/Tests/AnalyzeTests.Test.ps1
+++ b/Tests/AnalyzeTests.Test.ps1
@@ -141,6 +141,33 @@ Describe "AnalyzeTests Action Tests" {
         $output | Should -BeOfType 'hashtable'
     }
 
+    It 'Test GetTestResultSummaryMD handles empty failure stack traces' {
+        . (Join-Path $scriptRoot '../AL-Go-Helper.ps1')
+        . (Join-Path $scriptRoot 'TestResultAnalyzer.ps1')
+
+        $testResultsFile = Join-Path ([System.IO.Path]::GetTempPath()) "$([GUID]::NewGuid().ToString()).xml"
+        try {
+            @'
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="Suite" tests="1" failures="1" skipped="0" time="1.0">
+    <properties>
+      <property name="appName" value="App" />
+    </properties>
+    <testcase name="Case" time="1.0">
+      <failure message="boom"></failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+'@ | Set-Content -Path $testResultsFile -Encoding UTF8
+
+            { GetTestResultSummaryMD -testResultsFile $testResultsFile } | Should -Not -Throw
+        }
+        finally {
+            Remove-Item -Path $testResultsFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
     AfterAll {
         Remove-Item -Path $bcptFilename -Force -ErrorAction SilentlyContinue
         Remove-Item -Path $bcptBaseLine1 -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- use `InnerText` when reading failure stack traces so empty XML failure nodes produce an empty string instead of `$null`
- keep the existing stack trace formatting for non-empty failures
- add a regression test with an empty `<failure>` node

Closes #2256.

## Testing
- `git diff --check`
- `Invoke-Pester -Path .\Tests\AnalyzeTests.Test.ps1` could not run locally because the installed Windows PowerShell Pester module is 3.4.0 and does not provide the repo helper's `Add-AssertionOperator` command.