### PR TITLE
Add PreNewBcCompilerFolder and PostNewBcCompilerFolder hooks

### DIFF
--- a/Actions/CompileApps/Compile.ps1
+++ b/Actions/CompileApps/Compile.ps1
@@ -56,7 +56,7 @@ try {
     }
 
     # Check for precompile and postcompile overrides
-    $scriptOverrides = Get-ScriptOverrides -ALGoFolderName (Join-Path $projectFolder ".AL-Go") -OverrideScriptNames @("PreCompileApp", "PostCompileApp", "NewBcCompilerFolder")
+    $scriptOverrides = Get-ScriptOverrides -ALGoFolderName (Join-Path $projectFolder ".AL-Go") -OverrideScriptNames @("PreCompileApp", "PostCompileApp", "PreNewBcCompilerFolder", "PostNewBcCompilerFolder")
     $scriptOverrides.Keys | ForEach-Object { Trace-Information -Message "Using override for $_" }
 
     # Prepare build metadata
@@ -103,7 +103,27 @@ try {
         # On GitHub-hosted runners, use a folder in the runner temp directory for caching to speed up subsequent builds
         $cacheFolder = Join-Path $ENV:RUNNER_TEMP ".artifactcache"
     }
-    $compilerFolder = New-BcCompilerFolder -artifactUrl $artifact -vsixFile $settings.vsixFile -containerName "$($containerName)compiler" -cacheFolder $cacheFolder
+
+    $newCompilerFolderParameters = @{
+        artifactUrl          = $artifact
+        vsixFile             = $settings.vsixFile
+        containerName        = "$($containerName)compiler"
+        cacheFolder          = $cacheFolder
+    }
+
+    # Run PreNewBcCompilerFolder override if available (can modify parameters)
+    if ($scriptOverrides['PreNewBcCompilerFolder']) {
+        & $scriptOverrides['PreNewBcCompilerFolder'] -parameters $newCompilerFolderParameters
+    }
+
+    # Create the compiler folder
+    $compilerFolder = New-BcCompilerFolder @newCompilerFolderParameters
+
+    # Run PostNewBcCompilerFolder override if available
+    if ($scriptOverrides['PostNewBcCompilerFolder']) {
+        & $scriptOverrides['PostNewBcCompilerFolder'] -parameters $newCompilerFolderParameters -compilerFolder $compilerFolder
+    }
+
     $packageCachePath = Join-Path $compilerFolder "symbols"
 
     # Copy dependency apps and test apps to the package cache so the compiler can resolve them

--- a/Actions/CompileApps/Compile.ps1
+++ b/Actions/CompileApps/Compile.ps1
@@ -111,7 +111,7 @@ try {
         cacheFolder          = $cacheFolder
     }
 
-    # Run PreNewBcCompilerFolder override if available (can modify parameters)
+    # Run PreNewBcCompilerFolder hook if available (can modify parameters)
     if ($scriptOverrides['PreNewBcCompilerFolder']) {
         & $scriptOverrides['PreNewBcCompilerFolder'] -parameters $newCompilerFolderParameters
     }
@@ -119,7 +119,7 @@ try {
     # Create the compiler folder
     $compilerFolder = New-BcCompilerFolder @newCompilerFolderParameters
 
-    # Run PostNewBcCompilerFolder override if available
+    # Run PostNewBcCompilerFolder hook if available
     if ($scriptOverrides['PostNewBcCompilerFolder']) {
         & $scriptOverrides['PostNewBcCompilerFolder'] -parameters $newCompilerFolderParameters -compilerFolder $compilerFolder
     }

--- a/Actions/CompileApps/Compile.ps1
+++ b/Actions/CompileApps/Compile.ps1
@@ -56,7 +56,7 @@ try {
     }
 
     # Check for precompile and postcompile overrides
-    $scriptOverrides = Get-ScriptOverrides -ALGoFolderName (Join-Path $projectFolder ".AL-Go") -OverrideScriptNames @("PreCompileApp", "PostCompileApp")
+    $scriptOverrides = Get-ScriptOverrides -ALGoFolderName (Join-Path $projectFolder ".AL-Go") -OverrideScriptNames @("PreCompileApp", "PostCompileApp", "NewBcCompilerFolder")
     $scriptOverrides.Keys | ForEach-Object { Trace-Information -Message "Using override for $_" }
 
     # Prepare build metadata

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,3 @@
-
 ### Use artifact manifest to pick .NET runtime for assembly probing
 
 When compiling apps with the workspace compiler, AL-Go now reads the `dotNetVersion` from the BC artifact's `manifest.json` (copied into the compiler folder by BcContainerHelper) and selects an installed .NET runtime whose major version matches. This avoids version drift between the build agent's highest installed runtime and the platform the artifact was built against. If the manifest does not declare a `dotNetVersion`, or no installed runtime matches the required major, versioned .NET assembly probing paths are omitted (a warning is logged in the latter case).

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,15 @@ AL-Go now allows repositories to override the `NewBcCompilerFolder` script durin
 
 When compiling apps with the workspace compiler, AL-Go now reads the `dotNetVersion` from the BC artifact's `manifest.json` (copied into the compiler folder by BcContainerHelper) and selects an installed .NET runtime whose major version matches. This avoids version drift between the build agent's highest installed runtime and the platform the artifact was built against. If the manifest does not declare a `dotNetVersion`, or no installed runtime matches the required major, versioned .NET assembly probing paths are omitted (a warning is logged in the latter case).
 
+### New compiler folder hooks
+
+Two new hooks are available for customizing the compiler folder creation process when workspace compilation is enabled:
+
+- **PreNewBcCompilerFolder.ps1** - Runs before `New-BcCompilerFolder` is called. Receives a `[hashtable] $parameters` argument containing the parameters that will be passed to `New-BcCompilerFolder`. The script can modify the hashtable in-place to customize the compiler folder creation (e.g., add a `platformArtifactUrl` to use a specific platform version).
+- **PostNewBcCompilerFolder.ps1** - Runs after the compiler folder is created. Receives `[hashtable] $parameters` and `[string] $compilerFolder` arguments.
+
+Place these scripts in your project's `.AL-Go` folder to use them.
+
 ### New AL-Go hooks (experimental)
 
 AL-Go for GitHub now supports a new generic hook mechanism that is independent of BcContainerHelper. A new `RunHook` action invokes scripts placed in the project's `.AL-Go` folder at well-known extension points in the workflows. The first such extension point is `BuildInitialize`, which runs in the build workflow immediately after `Read settings` (so AL-Go settings are available as environment variables).

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+### Support for overriding `NewBcCompilerFolder` during compilation
+
+AL-Go now allows repositories to override the `NewBcCompilerFolder` script during compilation. Place a `NewBcCompilerFolder.ps1` script in the project's `.AL-Go` folder to customize how the BC compiler folder is created. The script must accept a `[Hashtable] $parameters` argument and return the compiler folder path. If the script does not exist, the default `New-BcCompilerFolder` behavior is used.
+
 ### Use artifact manifest to pick .NET runtime for assembly probing
 
 When compiling apps with the workspace compiler, AL-Go now reads the `dotNetVersion` from the BC artifact's `manifest.json` (copied into the compiler folder by BcContainerHelper) and selects an installed .NET runtime whose major version matches. This avoids version drift between the build agent's highest installed runtime and the platform the artifact was built against. If the manifest does not declare a `dotNetVersion`, or no installed runtime matches the required major, versioned .NET assembly probing paths are omitted (a warning is logged in the latter case).

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,3 @@
-### Support for overriding `NewBcCompilerFolder` during compilation
-
-AL-Go now allows repositories to override the `NewBcCompilerFolder` script during compilation. Place a `NewBcCompilerFolder.ps1` script in the project's `.AL-Go` folder to customize how the BC compiler folder is created. The script must accept a `[Hashtable] $parameters` argument and return the compiler folder path. If the script does not exist, the default `New-BcCompilerFolder` behavior is used.
 
 ### Use artifact manifest to pick .NET runtime for assembly probing
 

--- a/Scenarios/settings.md
+++ b/Scenarios/settings.md
@@ -444,6 +444,8 @@ Note that changes to AL-Go for GitHub or Run-AlPipeline functionality in the fut
 | InstallMissingDependencies | Install missing dependencies |
 | BackupBcContainerDatabases | Backup Databases in container for subsequent restore(s) |
 | RestoreDatabasesInBcContainer | Restore Databases in container |
+| PreNewBcCompilerFolder | Hook script to run _before_ creating the compiler folder. The script should accept a hashtable of the parameters (`[hashtable] $parameters`) that will be passed to `New-BcCompilerFolder`. The script can modify the hashtable in-place to customize the compiler folder creation.<br/>**Note:** This hook is only called when workspace compilation is enabled.
+| PostNewBcCompilerFolder | Hook script to run _after_ creating the compiler folder. The script should accept the parameters hashtable (`[hashtable] $parameters`) and the path to the created compiler folder (`[string] $compilerFolder`).<br/>**Note:** This hook is only called when workspace compilation is enabled.
 | PreCompileApp | Custom script to run _before_ compiling an app. The script should accept the type of the app (`[string] $appType`) and a reference to the compilation parameters (`[ref] $compilationParams`).<br/>Possible values for `$appType` are: _app_, _testApp_, _bcptApp_.
 | PostCompileApp | Custom script to run _after_ compiling an app. The script should accept the file path of the produced .app file (`[string] $appFilePath`), the type of the app (`[string] $appType`), and a hashtable of the compilation parameters (`[hashtable] $compilationParams`).<br/>Possible values for `$appType` are: _app_, _testApp_, _bcptApp_.
 | InstallMissingDependencies | Install missing dependencies |


### PR DESCRIPTION
### Description

Adds two new hooks for customizing the compiler folder creation process when workspace compilation is enabled:

- **PreNewBcCompilerFolder.ps1** - Runs before `New-BcCompilerFolder` is called. Receives a `[hashtable] $parameters` argument containing the parameters that will be passed to `New-BcCompilerFolder`. The script can modify the hashtable in-place to customize the compiler folder creation (e.g., add a `platformArtifactUrl` to use a specific platform version).

- **PostNewBcCompilerFolder.ps1** - Runs after the compiler folder is created. Receives `[hashtable] $parameters` and `[string] $compilerFolder` arguments.

Place these scripts in your project's `.AL-Go` folder to use them.

### Changes

- Updated `Compile.ps1` to load and invoke PreNewBcCompilerFolder/PostNewBcCompilerFolder scripts via `Get-ScriptOverrides`
- Added documentation in `Scenarios/settings.md` for both hooks
- Added release notes in `RELEASENOTES.md`

### Note

These hooks are only called when workspace compilation is enabled.