### PR TITLE
Fix GitHub App authentication on runners with minor clock drift

### DIFF
--- a/Actions/Github-Helper.psm1
+++ b/Actions/Github-Helper.psm1
@@ -1402,7 +1402,7 @@ function GenerateJwtForTokenRequest {
     }))).TrimEnd('=').Replace('+', '-').Replace('/', '_');
 
     $payload = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((ConvertTo-Json -InputObject @{
-        iat = [System.DateTimeOffset]::UtcNow.AddSeconds(-10).ToUnixTimeSeconds()
+        iat = [System.DateTimeOffset]::UtcNow.AddSeconds(-60).ToUnixTimeSeconds()
         exp = [System.DateTimeOffset]::UtcNow.AddMinutes(10).ToUnixTimeSeconds()
         iss = $gitHubAppClientId
     }))).TrimEnd('=').Replace('+', '-').Replace('/', '_');

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,7 +1,3 @@
-### Fix GitHub App authentication on runners with minor clock drift
-
-The JSON Web Token (JWT) used for GitHub App authentication now backdates its `iat` ("issued at") claim by 60 seconds instead of 10, as [recommended by GitHub](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#about-json-web-tokens-jwts) to protect against clock drift. Previously, a runner whose clock ran more than ~10 seconds ahead of GitHub would have its JWT rejected with a `401 (Unauthorized)` error (typically seen on self-hosted runners that aren't tightly time-synced). The wider tolerance allows authentication to succeed with up to ~60 seconds of clock drift. Note that keeping the runner's clock synchronized (for example, via the Network Time Protocol) is still recommended.
-
 ### Use artifact manifest to pick .NET runtime for assembly probing
 
 When compiling apps with the workspace compiler, AL-Go now reads the `dotNetVersion` from the BC artifact's `manifest.json` (copied into the compiler folder by BcContainerHelper) and selects an installed .NET runtime whose major version matches. This avoids version drift between the build agent's highest installed runtime and the platform the artifact was built against. If the manifest does not declare a `dotNetVersion`, or no installed runtime matches the required major, versioned .NET assembly probing paths are omitted (a warning is logged in the latter case).
@@ -63,6 +59,7 @@ The `DownloadProjectDependencies` action now downloads only artifacts from depen
 - Issue 2214 - Workspace compilation not working with external dependencies
 - Issue 2235 - Workspace compilation: only the first `customCodeCops` entry resolved when multiple relative paths were configured. Relative `customCodeCops` paths are now resolved against the project folder before being passed to the compiler.
 - Issue 2265 - Creating a Performance Test App fails on Linux due to case-sensitive path lookup for the Performance Toolkit sample app
+- Issue 2284 - GitHub App authentication fails with `401 (Unauthorized)` on runners with minor clock drift. The JWT `iat` claim is now backdated by 60 seconds instead of 10, as recommended by GitHub, to tolerate runners whose clock runs slightly ahead of GitHub.
 
 ## v9.0
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+### Fix GitHub App authentication on runners with minor clock drift
+
+The JSON Web Token (JWT) used for GitHub App authentication now backdates its `iat` ("issued at") claim by 60 seconds instead of 10, as [recommended by GitHub](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#about-json-web-tokens-jwts) to protect against clock drift. Previously, a runner whose clock ran more than ~10 seconds ahead of GitHub would have its JWT rejected with a `401 (Unauthorized)` error (typically seen on self-hosted runners that aren't tightly time-synced). The wider tolerance allows authentication to succeed with up to ~60 seconds of clock drift. Note that keeping the runner's clock synchronized (for example, via the Network Time Protocol) is still recommended.
+
 ### Use artifact manifest to pick .NET runtime for assembly probing
 
 When compiling apps with the workspace compiler, AL-Go now reads the `dotNetVersion` from the BC artifact's `manifest.json` (copied into the compiler folder by BcContainerHelper) and selects an installed .NET runtime whose major version matches. This avoids version drift between the build agent's highest installed runtime and the platform the artifact was built against. If the manifest does not declare a `dotNetVersion`, or no installed runtime matches the required major, versioned .NET assembly probing paths are omitted (a warning is logged in the latter case).


### PR DESCRIPTION
## Why

GitHub App authentication intermittently failed with `401 (Unauthorized)` during steps like "Download Project Dependencies", but only on self-hosted runners. The same repo, project, App, and dependency worked fine on GitHub-hosted runners. The differentiator was the runner's clock.

## Root cause

`GenerateJwtForTokenRequest` backdated the JWT `iat` ("issued at") claim by only 10 seconds. GitHub rejects a JWT whose `iat` is in its future. A self-hosted runner whose clock runs more than ~10 seconds ahead of GitHub therefore produces a future-dated `iat`, and the JWT-only call (`GET /repos/.../installation`, made before any installation token exists) gets a 401. GitHub-hosted runners are tightly time-synced, so they never hit this.

## Fix

Backdate `iat` by 60 seconds instead of 10, [as recommended by GitHub](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#about-json-web-tokens-jwts), to tolerate runners whose clock runs slightly ahead. The `exp` claim is left at 10 minutes (already within GitHub's "no more than 10 minutes into the future" limit).

This is intentionally minimal: a one-line change to the backdate plus a release note. Keeping the runner clock synchronized (e.g. via NTP) is still recommended, but AL-Go now tolerates the small drift commonly seen on self-hosted runners.

Fixes: #2284