### PR TITLE
Fix PR status fail for large builds

### DIFF
--- a/Actions/PullRequestStatusCheck/PullRequestStatusCheck.ps1
+++ b/Actions/PullRequestStatusCheck/PullRequestStatusCheck.ps1
@@ -32,7 +32,7 @@ function PullRequestStatusCheck()
     Write-Host "Checking PR Build status for run $RunId in repository $Repository"
 
     $workflowJobs = Invoke-CommandWithRetry -RetryCount 5 -FirstDelay 5 -MaxWaitBetweenRetries 60 -ScriptBlock {
-        $jobsJson = gh api /repos/$Repository/actions/runs/$RunId/jobs?per_page=50 --paginate --slurp -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28"
+        $jobsJson = gh api "/repos/$Repository/actions/runs/$RunId/jobs?per_page=50" --paginate --slurp -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28"
         if ($LASTEXITCODE) {
             throw "Failed to get jobs for run $RunId in repository $Repository (gh exit code $LASTEXITCODE)."
         }

--- a/Actions/PullRequestStatusCheck/PullRequestStatusCheck.ps1
+++ b/Actions/PullRequestStatusCheck/PullRequestStatusCheck.ps1
@@ -1,4 +1,27 @@
-﻿function PullRequestStatusCheck()
+﻿$gitHubHelperPath = Join-Path $PSScriptRoot '..\Github-Helper.psm1' -Resolve
+Import-Module $gitHubHelperPath -DisableNameChecking
+
+<#
+.SYNOPSIS
+    Checks the status of all jobs in a Pull Request build run and fails if any job failed.
+.DESCRIPTION
+    Queries the GitHub Actions jobs API for the given run and throws if any job concluded with "failure".
+    The jobs endpoint is paginated and can return a large response for builds with many jobs (for example
+    a build that spans many countries). Three robustness measures are applied:
+    - The request is retried, because the (large) jobs endpoint intermittently returns HTTP 502.
+    - A smaller page size (per_page) is requested so each page is faster to generate server-side, which
+      reduces the chance of a gateway timeout (HTTP 502).
+    - "--slurp" is used so that multi-page responses are returned as a single JSON array. Without it,
+      "gh api --paginate" concatenates one JSON object per page, which ConvertFrom-Json cannot parse
+      (it fails with "Invalid JSON primitive").
+.PARAMETER Repository
+    The repository (owner/name) that owns the run.
+.PARAMETER RunId
+    The id of the workflow run to check.
+.EXAMPLE
+    PullRequestStatusCheck -Repository "owner/repo" -RunId "123456"
+#>
+function PullRequestStatusCheck()
 {
     param(
         [Parameter(HelpMessage = "Repository name", Mandatory = $true)]
@@ -8,8 +31,17 @@
     )
     Write-Host "Checking PR Build status for run $RunId in repository $Repository"
 
-    $workflowJobs = gh api /repos/$Repository/actions/runs/$RunId/jobs --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" | ConvertFrom-Json
-    $failedJobs = $workflowJobs.jobs | Where-Object { $_.conclusion -eq "failure" }
+    $workflowJobs = Invoke-CommandWithRetry -RetryCount 5 -FirstDelay 5 -MaxWaitBetweenRetries 60 -ScriptBlock {
+        $jobsJson = gh api /repos/$Repository/actions/runs/$RunId/jobs?per_page=50 --paginate --slurp -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28"
+        if ($LASTEXITCODE) {
+            throw "Failed to get jobs for run $RunId in repository $Repository (gh exit code $LASTEXITCODE)."
+        }
+        $jobsJson | ConvertFrom-Json
+    }
+
+    # --slurp yields an array with one entry per page; member enumeration flattens jobs across all pages.
+    # When a single (non-slurped) object is returned, .jobs resolves to that object's jobs.
+    $failedJobs = @($workflowJobs.jobs | Where-Object { $_.conclusion -eq "failure" })
 
     if ($failedJobs) {
         throw "PR Build failed. Failing jobs: $($failedJobs.name -join ', ')"

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,7 @@
+### Resilient Pull Request Status Check for large builds
+
+The Pull Request Status Check action no longer fails on builds with more than one page of jobs (more than 100 jobs). The jobs API call now uses `--slurp` so multi-page responses are parsed as a single JSON array (previously `gh api --paginate | ConvertFrom-Json` failed with "Invalid JSON primitive" when more than one page was returned). The call is also retried, and requests a smaller page size, to tolerate the intermittent HTTP 502 responses that the GitHub jobs endpoint returns for large builds.
+
 ### Use artifact manifest to pick .NET runtime for assembly probing
 
 When compiling apps with the workspace compiler, AL-Go now reads the `dotNetVersion` from the BC artifact's `manifest.json` (copied into the compiler folder by BcContainerHelper) and selects an installed .NET runtime whose major version matches. This avoids version drift between the build agent's highest installed runtime and the platform the artifact was built against. If the manifest does not declare a `dotNetVersion`, or no installed runtime matches the required major, versioned .NET assembly probing paths are omitted (a warning is logged in the latter case).

--- a/Tests/PullRequestStatusCheck.Test.ps1
+++ b/Tests/PullRequestStatusCheck.Test.ps1
@@ -12,7 +12,7 @@ Describe "PullRequestStatusCheck Action Tests" {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'actionScript', Justification = 'False positive.')]
         $actionScript = GetActionScript -scriptRoot $scriptRoot -scriptName $scriptName
         # Import Github-Helper so Invoke-CommandWithRetry is available and its Start-Sleep can be mocked.
-        Import-Module (Join-Path $scriptRoot '..\Github-Helper.psm1' -Resolve) -DisableNameChecking -Force
+        Import-Module (Join-Path $scriptRoot '..\Github-Helper.psm1' -Resolve) -DisableNameChecking
         $ENV:GITHUB_REPOSITORY = "organization/repository"
         $ENV:GITHUB_RUN_ID = "123456"
     }

--- a/Tests/PullRequestStatusCheck.Test.ps1
+++ b/Tests/PullRequestStatusCheck.Test.ps1
@@ -11,6 +11,8 @@ Describe "PullRequestStatusCheck Action Tests" {
         $scriptPath = Join-Path $scriptRoot $scriptName
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'actionScript', Justification = 'False positive.')]
         $actionScript = GetActionScript -scriptRoot $scriptRoot -scriptName $scriptName
+        # Import Github-Helper so Invoke-CommandWithRetry is available and its Start-Sleep can be mocked.
+        Import-Module (Join-Path $scriptRoot '..\Github-Helper.psm1' -Resolve) -DisableNameChecking -Force
         $ENV:GITHUB_REPOSITORY = "organization/repository"
         $ENV:GITHUB_RUN_ID = "123456"
     }
@@ -26,16 +28,32 @@ Describe "PullRequestStatusCheck Action Tests" {
     }
 
     It 'should fail if there is a job that fails' {
-        Mock -CommandName gh -MockWith {'{"total_count":3,"jobs":[{ "name": "job1", "conclusion":  "success" },{ "name": "job2", "conclusion":  "skipped" },{ "name": "job3", "conclusion":  "failure" }]}'}
+        Mock -CommandName gh -MockWith { $global:LASTEXITCODE = 0; '{"total_count":3,"jobs":[{ "name": "job1", "conclusion":  "success" },{ "name": "job2", "conclusion":  "skipped" },{ "name": "job3", "conclusion":  "failure" }]}' }
         {
             & $scriptPath
         } | Should -Throw -ExpectedMessage 'PR Build failed. Failing jobs: job3'
     }
 
+    It 'should detect failing jobs across multiple pages (gh --slurp returns an array)' {
+        Mock -CommandName gh -MockWith { $global:LASTEXITCODE = 0; '[{"total_count":4,"jobs":[{ "name": "job1", "conclusion": "success" },{ "name": "job2", "conclusion": "success" }]},{"total_count":4,"jobs":[{ "name": "job3", "conclusion": "success" },{ "name": "job4", "conclusion": "failure" }]}]' }
+        {
+            & $scriptPath
+        } | Should -Throw -ExpectedMessage 'PR Build failed. Failing jobs: job4'
+    }
+
     It 'should complete if there are no failing jobs' {
-        Mock -CommandName gh -MockWith {'{"total_count":3,"jobs":[{ "name": "job1", "conclusion":  "success" },{ "name": "job2", "conclusion":  "skipped" },{ "name": "job3", "conclusion":  "success" }]}'}
+        Mock -CommandName gh -MockWith { $global:LASTEXITCODE = 0; '{"total_count":3,"jobs":[{ "name": "job1", "conclusion":  "success" },{ "name": "job2", "conclusion":  "skipped" },{ "name": "job3", "conclusion":  "success" }]}' }
         Mock Write-Host {}
         & $scriptPath
         Assert-MockCalled Write-Host -Exactly 1 -Scope It -ParameterFilter { $Object -eq "PR Build succeeded" }
+    }
+
+    It 'should retry when the jobs API call fails and then give up' {
+        Mock -CommandName gh -MockWith { $global:LASTEXITCODE = 1 }
+        Mock -CommandName Start-Sleep -ModuleName Github-Helper -MockWith {}
+        {
+            & $scriptPath
+        } | Should -Throw -ExpectedMessage '*Failed to get jobs for run*'
+        Assert-MockCalled gh -Exactly 5 -Scope It
     }
 }


### PR DESCRIPTION
### ❔What, Why & How

Correctly return data when getting the PR status for builds with over a hundred jobs.

`--slurp` ensures a single object, instead of one object per 100 jobs.

Also limited the call to 50 per page, to lower request time per call which minimized chance of 502 error. Added retry logic as well.

Related to issue: #

### ✅ Checklist

- [x] Add tests (E2E, unit tests)
- [x] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
