### PR TITLE
Add configurable projectScanDepth for project discovery

### DIFF
--- a/Actions/.Modules/ReadSettings.psm1
+++ b/Actions/.Modules/ReadSettings.psm1
@@ -115,6 +115,7 @@ function GetDefaultSettings
         "type"                                          = "PTE"
         "unusedALGoSystemFiles"                         = @()
         "projects"                                      = @()
+        "projectScanDepth"                              = 2
         "powerPlatformSolutionFolder"                   = ""
         "country"                                       = "us"
         "artifact"                                      = ""

--- a/Actions/.Modules/settings.schema.json
+++ b/Actions/.Modules/settings.schema.json
@@ -23,6 +23,12 @@
             },
             "description": "An array of AL-Go projects. See https://aka.ms/ALGoSettings#projects"
         },
+        "projectScanDepth": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 2,
+            "description": "Maximum directory depth for automatic project discovery when 'projects' is not set. Increase if your projects are nested deeper than 2 levels from the repository root."
+        },
         "powerPlatformSolutionFolder": {
             "type": "string",
             "description": "Folder containing the Power Platform solution. See https://aka.ms/ALGoSettings#powerplatformsolutionfolder"

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -2405,7 +2405,7 @@ function GetFoldersFromAllProjects {
     Push-Location $baseFolder
     try {
         $settings = ReadSettings -baseFolder $baseFolder
-        $projects = GetProjectsFromRepository -baseFolder $baseFolder -projectsFromSettings $settings.projects
+        $projects = GetProjectsFromRepository -baseFolder $baseFolder -projectsFromSettings $settings.projects -scanDepth $settings.projectScanDepth
         $folders = @()
         foreach($project in $projects) {
             $projectSettings = ReadSettings -project $project -baseFolder $baseFolder

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -1,4 +1,4 @@
-﻿Param(
+Param(
     [Parameter(HelpMessage = "The GitHub actor running the action", Mandatory = $false)]
     [string] $actor,
     [Parameter(HelpMessage = "Base64 encoded GhTokenWorkflow secret", Mandatory = $false)]
@@ -113,7 +113,7 @@ if (-not $isDirectALGo) {
 
 # Get the list of projects in the current repository
 $baseFolder = $ENV:GITHUB_WORKSPACE
-$projects = @(GetProjectsFromRepository -baseFolder $baseFolder -projectsFromSettings $repoSettings.projects)
+$projects = @(GetProjectsFromRepository -baseFolder $baseFolder -projectsFromSettings $repoSettings.projects -scanDepth $repoSettings.projectScanDepth)
 
 $filesToInclude, $filesToExclude = GetFilesToUpdate -settings $repoSettings -projects $projects -baseFolder $baseFolder -templateFolder $templateFolder -originalTemplateFolder $originalTemplateFolder
 

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -167,12 +167,13 @@ function Get-ProjectsToBuild {
     Push-Location $baseFolder
     try {
         $settings = $env:Settings | ConvertFrom-Json
-        $projects = @(GetProjectsFromRepository -baseFolder $baseFolder -projectsFromSettings $settings.projects)
+        $projects = @(GetProjectsFromRepository -baseFolder $baseFolder -projectsFromSettings $settings.projects -scanDepth $settings.projectScanDepth)
         Write-Host "Found AL-Go Projects: $($projects -join ', ')"
 
         $modifiedProjects = @()
         $projectsToBuild = @()
         $projectsOrderToBuild = @()
+        $projectBuildInfo = @{ projectDependencies = @{}; FullProjectsOrder = @(); AdditionalProjectsToBuild = @{} }
 
         if ($projects) {
             # Calculate the full projects order

--- a/Actions/IncrementVersionNumber/IncrementVersionNumber.ps1
+++ b/Actions/IncrementVersionNumber/IncrementVersionNumber.ps1
@@ -1,4 +1,4 @@
-﻿Param(
+Param(
     [Parameter(HelpMessage = "The GitHub actor running the action", Mandatory = $false)]
     [string] $actor,
     [Parameter(HelpMessage = "The GitHub token running the action", Mandatory = $false)]
@@ -48,7 +48,7 @@ else {
 }
 
 # Collect all projects (AL and PowerPlatform Solution)
-$projectList = @(GetProjectsFromRepository -baseFolder $baseFolder -projectsFromSettings $settings.projects -selectProjects $projects)
+$projectList = @(GetProjectsFromRepository -baseFolder $baseFolder -projectsFromSettings $settings.projects -selectProjects $projects -scanDepth $settings.projectScanDepth)
 $PPprojects = @(GetMatchingProjects -projects @($settings.powerPlatformSolutionFolder) -selectProjects $projects)
 if ($projectList.Count -eq 0 -and $PPprojects.Count -eq 0) {
     throw "No projects matches '$projects'"


### PR DESCRIPTION
## Problem

The \GetProjectsFromRepository\ function in \AL-Go-Helper.ps1\ uses a hardcoded \-Depth 2\ when auto-discovering AL-Go projects (scanning for \.AL-Go/settings.json\ directories). This means repositories that nest their projects deeper than 2 levels from the root cannot use automatic project discovery.

For example, a repository with projects at \ng/AL-Go/projects/MyProject/.AL-Go/settings.json\ (depth 3) will not find any projects, leading to a strict mode error:
\\\
The variable '\' cannot be retrieved because it has not been set.
\\\

This happens because when no projects are found, the \if (\)\ block is skipped, leaving \\\ uninitialized, but line 231 still tries to access \\.projectDependencies\.

## Fix

1. **New setting: \projectScanDepth\** (default: 2) — Controls the \-Depth\ parameter for automatic project discovery. Repositories can increase this in \.github/AL-Go-Settings.json\:
   \\\json
   { "projectScanDepth": 4 }
   \\\

2. **Defensive initialization** — \\\ is now initialized with safe defaults before the \if (\)\ guard, preventing strict mode errors when no projects are discovered.

3. **Schema update** — Added \projectScanDepth\ to \settings.schema.json\ for IntelliSense support.

## Files Changed

- \Actions/.Modules/ReadSettings.psm1\ — Added default setting
- \Actions/.Modules/settings.schema.json\ — Added schema definition
- \Actions/AL-Go-Helper.ps1\ — Added \-scanDepth\ parameter to \GetProjectsFromRepository\; updated internal caller
- \Actions/CheckForUpdates/CheckForUpdates.ps1\ — Pass \scanDepth\
- \Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1\ — Pass \scanDepth\; initialize \\\
- \Actions/IncrementVersionNumber/IncrementVersionNumber.ps1\ — Pass \scanDepth\

## Backward Compatibility

The default value of 2 preserves existing behavior. Only repositories that explicitly set \projectScanDepth\ to a higher value will see different discovery behavior.