### PR TITLE
Retry current-build dependency artifact download up to 3 times

### DIFF
--- a/Actions/DownloadProjectDependencies/action.yaml
+++ b/Actions/DownloadProjectDependencies/action.yaml
@@ -40,8 +40,44 @@ runs:
           ${{ github.action_path }}/ComputeDependencyArtifactPattern.ps1
         }
 
-    - name: Download dependency artifacts from current build
+    - name: Download dependency artifacts from current build (attempt 1 of 3)
+      id: downloadDependenciesAttempt1
       if: steps.computePattern.outputs.hasPattern == 'true'
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      env:
+        ACTIONS_RUNNER_DISABLE_NODE_MAGLEV: 1
+      with:
+        pattern: ${{ steps.computePattern.outputs.pattern }}
+        path: ${{ github.workspace }}/.dependencies
+
+    - name: Wait before retrying dependency artifact download (attempt 2 of 3)
+      if: steps.computePattern.outputs.hasPattern == 'true' && steps.downloadDependenciesAttempt1.outcome == 'failure'
+      shell: ${{ inputs.shell }}
+      run: |
+        Write-Host "Downloading dependency artifacts failed. Waiting 30 seconds before retrying..."
+        Start-Sleep -Seconds 30
+
+    - name: Download dependency artifacts from current build (attempt 2 of 3)
+      id: downloadDependenciesAttempt2
+      if: steps.computePattern.outputs.hasPattern == 'true' && steps.downloadDependenciesAttempt1.outcome == 'failure'
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      env:
+        ACTIONS_RUNNER_DISABLE_NODE_MAGLEV: 1
+      with:
+        pattern: ${{ steps.computePattern.outputs.pattern }}
+        path: ${{ github.workspace }}/.dependencies
+
+    - name: Wait before retrying dependency artifact download (attempt 3 of 3)
+      if: steps.computePattern.outputs.hasPattern == 'true' && steps.downloadDependenciesAttempt1.outcome == 'failure' && steps.downloadDependenciesAttempt2.outcome == 'failure'
+      shell: ${{ inputs.shell }}
+      run: |
+        Write-Host "Downloading dependency artifacts failed again. Waiting 30 seconds before the final retry..."
+        Start-Sleep -Seconds 30
+
+    - name: Download dependency artifacts from current build (attempt 3 of 3)
+      if: steps.computePattern.outputs.hasPattern == 'true' && steps.downloadDependenciesAttempt1.outcome == 'failure' && steps.downloadDependenciesAttempt2.outcome == 'failure'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       env:
         ACTIONS_RUNNER_DISABLE_NODE_MAGLEV: 1

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 ### Issues
 
 - Fix "filename or extension is too long" error when validating settings on PS5.1 with large settings JSON
+- Retry downloading dependency artifacts from the current build up to 3 times (30 seconds between attempts) to tolerate transient network errors such as "Failed to GetSignedArtifactURL: Unable to make request: ETIMEDOUT"
 
 ## v9.1
 


### PR DESCRIPTION
## Why

Builds across AL-Go consumers (e.g. BCApps) have started failing intermittently in the `Download Project Dependencies` step with transient network errors such as:

```
##[error]Unable to download artifact(s): Failed to GetSignedArtifactURL: Unable to make request: ETIMEDOUT
```

This happens inside `actions/download-artifact`, which calls GitHub's Actions Results service to mint a signed blob URL before each download. A single flaky call to that service fails the whole step and cascades to every dependent build job. The action retries the blob download but not the signed-URL request, and it exposes no retry option.

## What

Since a JS `uses:` step can't be looped inside a composite action, the single download step in `DownloadProjectDependencies/action.yaml` is now a 3-attempt chain:

- Attempt 1 runs with `continue-on-error: true`.
- If it fails, wait 30 seconds, then Attempt 2 (also `continue-on-error: true`).
- If that fails too, wait another 30 seconds, then Attempt 3, which has no `continue-on-error` so it fails the job normally.

The retry conditions gate on `steps.<id>.outcome == 'failure'` (the result before `continue-on-error` is applied), so a real failure correctly triggers the next attempt. The job fails only if all 3 attempts fail; when an attempt succeeds, the remaining attempts are skipped, so the happy path adds no time.

## Notes

- This is a mitigation for flaky infrastructure, not a code bug. A more durable follow-up would replace this JS action with AL-Go's own resilient PowerShell downloader (`DownloadArtifact` / `InvokeWebRequest`, which hits the REST `archive_download_url` directly and already retries), used everywhere else for dependency downloads.
- On a retry, the full matched artifact set is re-downloaded, including any that already succeeded. It's idempotent, just slightly redundant bandwidth on the uncommon retry path.