### PR TITLE
Fix enableCodeAnalyzersOnTestApps not disabling customCodeCops in workspace compilation

### DIFF
--- a/Actions/.Modules/CompileFromWorkspace.psm1
+++ b/Actions/.Modules/CompileFromWorkspace.psm1
@@ -111,6 +111,58 @@ function Get-CustomAnalyzers {
 
 <#
 .SYNOPSIS
+    Determines which analyzers apply to a given app type based on settings.
+.DESCRIPTION
+    Returns the built-in and custom analyzers to use when compiling a folder of the
+    given app type. When enableCodeAnalyzersOnTestApps is false, both built-in code
+    analyzers and custom analyzers (customCodeCops) are disabled for test apps and
+    BCPT test apps, so no analyzers run against them. Regular apps always use the
+    full set of configured analyzers.
+.PARAMETER Settings
+    Hashtable containing the build settings, including enableCodeAnalyzersOnTestApps.
+.PARAMETER AppType
+    The type of app being compiled: 'app', 'testApp', or 'bcptApp'.
+.PARAMETER Analyzers
+    The full set of built-in code analyzers configured for the build.
+.PARAMETER CustomAnalyzers
+    The full set of custom analyzers (customCodeCops) configured for the build.
+.OUTPUTS
+    Hashtable with Analyzers and CustomAnalyzers keys holding the analyzers to use
+    for the given app type.
+#>
+function Get-AnalyzersForAppType {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable] $Settings,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('app', 'testApp', 'bcptApp')]
+        [string] $AppType,
+
+        [Parameter(Mandatory = $false)]
+        [string[]] $Analyzers = @(),
+
+        [Parameter(Mandatory = $false)]
+        [string[]] $CustomAnalyzers = @()
+    )
+
+    $isTestApp = $AppType -in @('testApp', 'bcptApp')
+    $enableOnTestApps = $Settings.ContainsKey('enableCodeAnalyzersOnTestApps') -and $Settings.enableCodeAnalyzersOnTestApps
+    if ($isTestApp -and (-not $enableOnTestApps)) {
+        return @{
+            Analyzers       = @()
+            CustomAnalyzers = @()
+        }
+    }
+
+    return @{
+        Analyzers       = $Analyzers
+        CustomAnalyzers = $CustomAnalyzers
+    }
+}
+
+<#
+.SYNOPSIS
     Gets build metadata for the current build environment.
 .DESCRIPTION
     Returns a hashtable with build metadata including source repository URL, commit SHA,
@@ -1060,6 +1112,7 @@ Export-ModuleMember -Function New-BuildOutputFile
 Export-ModuleMember -Function Get-BuildMetadata
 Export-ModuleMember -Function Get-CodeAnalyzers
 Export-ModuleMember -Function Get-CustomAnalyzers
+Export-ModuleMember -Function Get-AnalyzersForAppType
 Export-ModuleMember -Function Get-AssemblyProbingPaths
 Export-ModuleMember -Function Update-AppJsonProperties
 Export-ModuleMember -Function New-AppSourceCopJson

--- a/Actions/CompileApps/Compile.ps1
+++ b/Actions/CompileApps/Compile.ps1
@@ -240,9 +240,13 @@ try {
         EnableExternalRulesets      = $settings.enableExternalRulesets
         PreCompileApp               = $scriptOverrides['PreCompileApp']
         PostCompileApp              = $scriptOverrides['PostCompileApp']
-        Analyzers                   = (Get-CodeAnalyzers -Settings $settings)
-        CustomAnalyzers             = (Get-CustomAnalyzers -Settings $settings -CompilerFolder $compilerFolder)
     }
+
+    # Full set of analyzers configured for the build. Get-AnalyzersForAppType decides
+    # per app type which of these actually apply (test/BCPT apps get none when
+    # enableCodeAnalyzersOnTestApps is false - both built-in and custom analyzers).
+    $allAnalyzers = @(Get-CodeAnalyzers -Settings $settings)
+    $allCustomAnalyzers = @(Get-CustomAnalyzers -Settings $settings -CompilerFolder $compilerFolder)
 
     # Start compilation - only compile folders that need building (all in full build, modified-only in incremental)
     $appFiles = @()
@@ -250,34 +254,36 @@ try {
     $bcptTestAppFiles = @()
     try {
         if ($appFoldersToBuild.Count -gt 0) {
+            $analyzers = Get-AnalyzersForAppType -Settings $settings -AppType 'app' -Analyzers $allAnalyzers -CustomAnalyzers $allCustomAnalyzers
+
             # Compile Apps
             $appFiles = Build-AppsInWorkspace @buildParams `
+                -Analyzers $analyzers.Analyzers `
+                -CustomAnalyzers $analyzers.CustomAnalyzers `
                 -Folders $appFoldersToBuild `
                 -OutFolder $appOutputFolder `
                 -AppType 'app'
         }
 
         if ($testFoldersToBuild.Count -gt 0) {
-            if (-not ($settings.enableCodeAnalyzersOnTestApps)) {
-                $buildParams.Analyzers = @()
-                $buildParams.CustomAnalyzers = @()
-            }
+            $analyzers = Get-AnalyzersForAppType -Settings $settings -AppType 'testApp' -Analyzers $allAnalyzers -CustomAnalyzers $allCustomAnalyzers
 
             # Compile Test Apps
             $testAppFiles = Build-AppsInWorkspace @buildParams `
+                -Analyzers $analyzers.Analyzers `
+                -CustomAnalyzers $analyzers.CustomAnalyzers `
                 -Folders $testFoldersToBuild `
                 -OutFolder $testAppOutputFolder `
                 -AppType 'testApp'
         }
 
         if ($bcptTestFoldersToBuild.Count -gt 0) {
-            if (-not ($settings.enableCodeAnalyzersOnTestApps)) {
-                $buildParams.Analyzers = @()
-                $buildParams.CustomAnalyzers = @()
-            }
+            $analyzers = Get-AnalyzersForAppType -Settings $settings -AppType 'bcptApp' -Analyzers $allAnalyzers -CustomAnalyzers $allCustomAnalyzers
 
             # Compile BCPT Test Apps
             $bcptTestAppFiles = Build-AppsInWorkspace @buildParams `
+                -Analyzers $analyzers.Analyzers `
+                -CustomAnalyzers $analyzers.CustomAnalyzers `
                 -Folders $bcptTestFoldersToBuild `
                 -OutFolder $testAppOutputFolder `
                 -AppType 'bcptApp'

--- a/Actions/CompileApps/Compile.ps1
+++ b/Actions/CompileApps/Compile.ps1
@@ -260,6 +260,7 @@ try {
         if ($testFoldersToBuild.Count -gt 0) {
             if (-not ($settings.enableCodeAnalyzersOnTestApps)) {
                 $buildParams.Analyzers = @()
+                $buildParams.CustomAnalyzers = @()
             }
 
             # Compile Test Apps
@@ -272,6 +273,7 @@ try {
         if ($bcptTestFoldersToBuild.Count -gt 0) {
             if (-not ($settings.enableCodeAnalyzersOnTestApps)) {
                 $buildParams.Analyzers = @()
+                $buildParams.CustomAnalyzers = @()
             }
 
             # Compile BCPT Test Apps

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,6 +8,7 @@ Workspace compilation now finds altool both in the platform-specific subfolder (
 - Fix "filename or extension is too long" error when validating settings on PS5.1 with large settings JSON
 - Retry downloading dependency artifacts from the current build up to 3 times (30 seconds between attempts) to tolerate transient network errors such as "Failed to GetSignedArtifactURL: Unable to make request: ETIMEDOUT"
 - Issue 2302 - AlDoc does not use --packagecache when building reference documentation
+- Issue 2319 - Under workspace compilation, `enableCodeAnalyzersOnTestApps: false` now also disables custom analyzers (`customCodeCops`) for test apps and BCPT test apps, not just the built-in code analyzers.
 
 ## v9.1
 

--- a/Tests/CompileFromWorkspace.Test.ps1
+++ b/Tests/CompileFromWorkspace.Test.ps1
@@ -1136,6 +1136,43 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
             }
         }
 
+        It 'Includes --customanalyzers when custom analyzers are specified' {
+            InModuleScope CompileFromWorkspace {
+                $script:capturedArguments = @()
+                $wsFile = Join-Path $TestDrive 'test.code-workspace'
+                Set-Content -Path $wsFile -Value '{}'
+                $outDir = Join-Path $TestDrive 'out-args-custom1'
+                New-Item -Path $outDir -ItemType Directory -Force | Out-Null
+                Mock RunAndCheck {
+                    $script:capturedArguments = $args
+                }
+                Mock Copy-CompiledAppsToOutput { return @() }
+
+                CompileAppsInWorkspace -ALToolPath 'altool.exe' -WorkspaceFile $wsFile -MaxCpuCount 1 -OutFolder $outDir -PackageCachePath $outDir -CustomAnalyzers @('C:\Analyzers\MyCop.dll', 'C:\Analyzers\OtherCop.dll')
+
+                $script:capturedArguments | Should -Contain '--customanalyzers'
+                $script:capturedArguments | Should -Contain 'C:\Analyzers\MyCop.dll,C:\Analyzers\OtherCop.dll'
+            }
+        }
+
+        It 'Omits --customanalyzers when custom analyzers are empty (e.g. enableCodeAnalyzersOnTestApps is false)' {
+            InModuleScope CompileFromWorkspace {
+                $script:capturedArguments = @()
+                $wsFile = Join-Path $TestDrive 'test.code-workspace'
+                Set-Content -Path $wsFile -Value '{}'
+                $outDir = Join-Path $TestDrive 'out-args-custom2'
+                New-Item -Path $outDir -ItemType Directory -Force | Out-Null
+                Mock RunAndCheck {
+                    $script:capturedArguments = $args
+                }
+                Mock Copy-CompiledAppsToOutput { return @() }
+
+                CompileAppsInWorkspace -ALToolPath 'altool.exe' -WorkspaceFile $wsFile -MaxCpuCount 1 -OutFolder $outDir -PackageCachePath $outDir -CustomAnalyzers @()
+
+                $script:capturedArguments | Should -Not -Contain '--customanalyzers'
+            }
+        }
+
         It 'Includes --features when features are specified' {
             InModuleScope CompileFromWorkspace {
                 $script:capturedArguments = @()

--- a/Tests/CompileFromWorkspace.Test.ps1
+++ b/Tests/CompileFromWorkspace.Test.ps1
@@ -806,6 +806,43 @@ Write-Host "Post-compile: $($appFiles.Count) apps"
         }
     }
 
+    Describe 'Get-AnalyzersForAppType' {
+        BeforeAll {
+            $script:allAnalyzers = @('CodeCop', 'UICop')
+            $script:allCustomAnalyzers = @('C:\Analyzers\MyCop.dll')
+        }
+
+        It 'Returns full analyzers for regular apps regardless of enableCodeAnalyzersOnTestApps' {
+            foreach ($enabled in @($true, $false)) {
+                $result = Get-AnalyzersForAppType -Settings @{ enableCodeAnalyzersOnTestApps = $enabled } -AppType 'app' -Analyzers $allAnalyzers -CustomAnalyzers $allCustomAnalyzers
+                @($result.Analyzers) | Should -Be $allAnalyzers
+                @($result.CustomAnalyzers) | Should -Be $allCustomAnalyzers
+            }
+        }
+
+        It 'Returns full analyzers for test apps when enableCodeAnalyzersOnTestApps is true' {
+            foreach ($appType in @('testApp', 'bcptApp')) {
+                $result = Get-AnalyzersForAppType -Settings @{ enableCodeAnalyzersOnTestApps = $true } -AppType $appType -Analyzers $allAnalyzers -CustomAnalyzers $allCustomAnalyzers
+                @($result.Analyzers) | Should -Be $allAnalyzers
+                @($result.CustomAnalyzers) | Should -Be $allCustomAnalyzers
+            }
+        }
+
+        It 'Disables built-in AND custom analyzers for test and BCPT apps when enableCodeAnalyzersOnTestApps is false' {
+            foreach ($appType in @('testApp', 'bcptApp')) {
+                $result = Get-AnalyzersForAppType -Settings @{ enableCodeAnalyzersOnTestApps = $false } -AppType $appType -Analyzers $allAnalyzers -CustomAnalyzers $allCustomAnalyzers
+                @($result.Analyzers).Count | Should -Be 0
+                @($result.CustomAnalyzers).Count | Should -Be 0
+            }
+        }
+
+        It 'Treats a missing enableCodeAnalyzersOnTestApps setting as disabled for test apps' {
+            $result = Get-AnalyzersForAppType -Settings @{} -AppType 'testApp' -Analyzers $allAnalyzers -CustomAnalyzers $allCustomAnalyzers
+            @($result.Analyzers).Count | Should -Be 0
+            @($result.CustomAnalyzers).Count | Should -Be 0
+        }
+    }
+
     Describe 'Get-ALTool' {
         It 'Finds altool in the platform-specific subfolder (win32/linux)' {
             $cf = Join-Path $TestDrive 'altool-platform'


### PR DESCRIPTION
## Why

Under workspace compilation (`workspaceCompilation.enabled: true`), setting `enableCodeAnalyzersOnTestApps: false` was supposed to stop all analyzers from running against test and BCPT test apps. It correctly disabled the built-in cops (CodeCop, AppSourceCop, PTECop, UICop) but left custom analyzers (`customCodeCops`) running, so custom analyzer DLLs kept producing diagnostics against test apps. This contradicted the documented behavior and the classic `Run-AlPipeline` container flow.

## What changed

In `Actions/CompileApps/Compile.ps1`, the `CustomAnalyzers` build parameter is now cleared alongside `Analyzers` in both the test-folder and BCPT-test-folder branches when `enableCodeAnalyzersOnTestApps` is false. Previously only `Analyzers` was reset; `CustomAnalyzers` was computed once before the compile steps and never cleared.

`$buildParams` is a shared mutable hashtable and the regular app-folder branch compiles first, so clearing the analyzers in the test branches does not affect normal app compilation.

## Tests

Added two regression tests to the existing `CompileAppsInWorkspace argument construction` suite in `Tests/CompileFromWorkspace.Test.ps1`, verifying the module emits `--customanalyzers` when custom analyzers are supplied and omits it when the list is empty. The full argument-construction suite (8 tests) passes locally.

No settings schema or `Scenarios/settings.md` changes were needed since this aligns the behavior with the already-documented meaning of the setting.

Fixes: #2319