### PR TITLE
Genericize freddyk references in docs examples

### DIFF
--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -29,7 +29,7 @@ on:
         required: false
         default: false
       defaultBcContainerHelperVersion:
-        description: 'Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/myuser/navcontainerhelper/archive/master.zip). Leave empty to use latest (or preview for preview branches)'
+        description: 'Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/contoso/navcontainerhelper/archive/master.zip). Leave empty to use latest (or preview for preview branches)'
         required: false
         default: 'latest'
 

--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -29,7 +29,7 @@ on:
         required: false
         default: false
       defaultBcContainerHelperVersion:
-        description: 'Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/contoso/navcontainerhelper/archive/master.zip). Leave empty to use latest (or preview for preview branches)'
+        description: 'Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/microsoft/navcontainerhelper/archive/main.zip). Leave empty to use latest (or preview for preview branches)'
         required: false
         default: 'latest'
 

--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -29,7 +29,7 @@ on:
         required: false
         default: false
       defaultBcContainerHelperVersion:
-        description: 'Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/freddydk/navcontainerhelper/archive/master.zip). Leave empty to use latest (or preview for preview branches)'
+        description: 'Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/myuser/navcontainerhelper/archive/master.zip). Leave empty to use latest (or preview for preview branches)'
         required: false
         default: 'latest'
 

--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -35,7 +35,7 @@ on:
         type: boolean
         default: true
       bcContainerHelperVersion:
-        description: Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/contoso/navcontainerhelper/archive/master.zip - leave empty to use latest)
+        description: Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/microsoft/navcontainerhelper/archive/main.zip - leave empty to use latest)
         required: false
         default: 'preview'
 

--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -35,7 +35,7 @@ on:
         type: boolean
         default: true
       bcContainerHelperVersion:
-        description: Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/freddydk/navcontainerhelper/archive/master.zip - leave empty to use latest)
+        description: Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/myuser/navcontainerhelper/archive/master.zip - leave empty to use latest)
         required: false
         default: 'preview'
 

--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -35,7 +35,7 @@ on:
         type: boolean
         default: true
       bcContainerHelperVersion:
-        description: Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/myuser/navcontainerhelper/archive/master.zip - leave empty to use latest)
+        description: Which version of BcContainerHelper to use? (latest, preview, private, a specific version number or a direct download URL like https://github.com/contoso/navcontainerhelper/archive/master.zip - leave empty to use latest)
         required: false
         default: 'preview'
 

--- a/Scenarios/Contribute.md
+++ b/Scenarios/Contribute.md
@@ -161,12 +161,12 @@ You can also run the end to end tests directly from VS Code, by providing the fo
 
 |Variable|Type|Description|
 |---|---|---|
-|$global:E2EgitHubOwner| String | The GitHub owner of the test repositories (like `contoso` or `microsoft`) |
+|$global:E2EgitHubOwner| String | The GitHub owner of the test repositories (like `myuser` or `microsoft`) |
 |$global:SecureALGOAUTHAPP | SecureString | A json secret containing GitHubAppClientId and PrivateKey for a GitHub App with these repo read & write permissions: _Actions, Administration, Content, Packages, Pages, Pull Requests and Workflows_ |
 |$global:SecureadminCenterApiCredentials| SecureString | Admin Center API Credentials |
 |$global:SecureLicenseFileUrl| SecureString | Direct download URL to a license file |
-|$global:pteTemplate| String | URL for your PTE template (like `contoso/AL-Go-PTE@main` or `contoso/AL-Go@main\|Templates/Per Tenant Extension` for using your AL-Go fork directly) |
-|$global:appSourceTemplate| String | URL for your AppSource template (like `contoso/AL-Go-AppSource@main` or `contoso/AL-Go@main\|Templates/AppSource App` for using your AL-Go fork directly) |
+|$global:pteTemplate| String | URL for your PTE template (like `myuser/AL-Go-PTE@main` or `myuser/AL-Go@main\|Templates/Per Tenant Extension` for using your AL-Go fork directly) |
+|$global:appSourceTemplate| String | URL for your AppSource template (like `myuser/AL-Go-AppSource@main` or `myuser/AL-Go@main\|Templates/AppSource App` for using your AL-Go fork directly) |
 |$global:SecureAzureCredentials| SecureString | A JSON string containing the Azure_Credentials set up with [federated credentials](https://github.com/microsoft/AL-Go/blob/main/Scenarios/secrets.md#federated-credential) |
 |$global:SecureGitHubPackagesToken| SecureString | A classic PAT with read/write access to GitHub packages in the organization the E2E tests are running in. |
 

--- a/Scenarios/Contribute.md
+++ b/Scenarios/Contribute.md
@@ -161,12 +161,12 @@ You can also run the end to end tests directly from VS Code, by providing the fo
 
 |Variable|Type|Description|
 |---|---|---|
-|$global:E2EgitHubOwner| String | The GitHub owner of the test repositories (like `myuser` or `microsoft`) |
+|$global:E2EgitHubOwner| String | The GitHub owner of the test repositories (like `contoso` or `microsoft`) |
 |$global:SecureALGOAUTHAPP | SecureString | A json secret containing GitHubAppClientId and PrivateKey for a GitHub App with these repo read & write permissions: _Actions, Administration, Content, Packages, Pages, Pull Requests and Workflows_ |
 |$global:SecureadminCenterApiCredentials| SecureString | Admin Center API Credentials |
 |$global:SecureLicenseFileUrl| SecureString | Direct download URL to a license file |
-|$global:pteTemplate| String | URL for your PTE template (like `myuser/AL-Go-PTE@main` or `myuser/AL-Go@main\|Templates/Per Tenant Extension` for using your AL-Go fork directly) |
-|$global:appSourceTemplate| String | URL for your AppSource template (like `myuser/AL-Go-AppSource@main` or `myuser/AL-Go@main\|Templates/AppSource App` for using your AL-Go fork directly) |
+|$global:pteTemplate| String | URL for your PTE template (like `contoso/AL-Go-PTE@main` or `contoso/AL-Go@main\|Templates/Per Tenant Extension` for using your AL-Go fork directly) |
+|$global:appSourceTemplate| String | URL for your AppSource template (like `contoso/AL-Go-AppSource@main` or `contoso/AL-Go@main\|Templates/AppSource App` for using your AL-Go fork directly) |
 |$global:SecureAzureCredentials| SecureString | A JSON string containing the Azure_Credentials set up with [federated credentials](https://github.com/microsoft/AL-Go/blob/main/Scenarios/secrets.md#federated-credential) |
 |$global:SecureGitHubPackagesToken| SecureString | A classic PAT with read/write access to GitHub packages in the organization the E2E tests are running in. |
 

--- a/Scenarios/Contribute.md
+++ b/Scenarios/Contribute.md
@@ -161,12 +161,12 @@ You can also run the end to end tests directly from VS Code, by providing the fo
 
 |Variable|Type|Description|
 |---|---|---|
-|$global:E2EgitHubOwner| String | The GitHub owner of the test repositories (like `freddydk` or `microsoft`) |
+|$global:E2EgitHubOwner| String | The GitHub owner of the test repositories (like `myuser` or `microsoft`) |
 |$global:SecureALGOAUTHAPP | SecureString | A json secret containing GitHubAppClientId and PrivateKey for a GitHub App with these repo read & write permissions: _Actions, Administration, Content, Packages, Pages, Pull Requests and Workflows_ |
 |$global:SecureadminCenterApiCredentials| SecureString | Admin Center API Credentials |
 |$global:SecureLicenseFileUrl| SecureString | Direct download URL to a license file |
-|$global:pteTemplate| String | URL for your PTE template (like `freddyk/AL-Go-PTE@main` or `freddydk/AL-Go@main\|Templates/Per Tenant Extension` for using your AL-Go fork directly) |
-|$global:appSourceTemplate| String | URL for your PTE template (like `freddyk/AL-Go-AppSource@main` or `freddydk/AL-Go@main\|Templates/AppSource App` for using your AL-Go fork directly) |
+|$global:pteTemplate| String | URL for your PTE template (like `myuser/AL-Go-PTE@main` or `myuser/AL-Go@main\|Templates/Per Tenant Extension` for using your AL-Go fork directly) |
+|$global:appSourceTemplate| String | URL for your PTE template (like `myuser/AL-Go-AppSource@main` or `myuser/AL-Go@main\|Templates/AppSource App` for using your AL-Go fork directly) |
 |$global:SecureAzureCredentials| SecureString | A JSON string containing the Azure_Credentials set up with [federated credentials](https://github.com/microsoft/AL-Go/blob/main/Scenarios/secrets.md#federated-credential) |
 |$global:SecureGitHubPackagesToken| SecureString | A classic PAT with read/write access to GitHub packages in the organization the E2E tests are running in. |
 

--- a/Scenarios/Contribute.md
+++ b/Scenarios/Contribute.md
@@ -166,7 +166,7 @@ You can also run the end to end tests directly from VS Code, by providing the fo
 |$global:SecureadminCenterApiCredentials| SecureString | Admin Center API Credentials |
 |$global:SecureLicenseFileUrl| SecureString | Direct download URL to a license file |
 |$global:pteTemplate| String | URL for your PTE template (like `myuser/AL-Go-PTE@main` or `myuser/AL-Go@main\|Templates/Per Tenant Extension` for using your AL-Go fork directly) |
-|$global:appSourceTemplate| String | URL for your PTE template (like `myuser/AL-Go-AppSource@main` or `myuser/AL-Go@main\|Templates/AppSource App` for using your AL-Go fork directly) |
+|$global:appSourceTemplate| String | URL for your AppSource template (like `myuser/AL-Go-AppSource@main` or `myuser/AL-Go@main\|Templates/AppSource App` for using your AL-Go fork directly) |
 |$global:SecureAzureCredentials| SecureString | A JSON string containing the Azure_Credentials set up with [federated credentials](https://github.com/microsoft/AL-Go/blob/main/Scenarios/secrets.md#federated-credential) |
 |$global:SecureGitHubPackagesToken| SecureString | A classic PAT with read/write access to GitHub packages in the organization the E2E tests are running in. |
 

--- a/Scenarios/GetStarted.md
+++ b/Scenarios/GetStarted.md
@@ -24,7 +24,7 @@
 
    ![app1](https://github.com/user-attachments/assets/b119b33a-7ab2-4605-91d6-669ce4b71fc7)
 
-1. Choose the **Code** button and copy the **https Clone Url** (for example: *https://github.com/myuser/app1.git*)
+1. Choose the **Code** button and copy the **https Clone Url**
 
    ![Copy Url](https://github.com/user-attachments/assets/469c4f1b-9991-40e9-88a3-f306819845d6)
 

--- a/Scenarios/GetStarted.md
+++ b/Scenarios/GetStarted.md
@@ -24,7 +24,7 @@
 
    ![app1](https://github.com/user-attachments/assets/b119b33a-7ab2-4605-91d6-669ce4b71fc7)
 
-1. Choose the **Code** button and copy the **https Clone Url**
+1. Choose the **Code** button and copy the **https Clone Url** (for example: *https://github.com/myuser/app1.git*)
 
    ![Copy Url](https://github.com/user-attachments/assets/469c4f1b-9991-40e9-88a3-f306819845d6)
 

--- a/Scenarios/GetStarted.md
+++ b/Scenarios/GetStarted.md
@@ -24,7 +24,7 @@
 
    ![app1](https://github.com/user-attachments/assets/b119b33a-7ab2-4605-91d6-669ce4b71fc7)
 
-1. Choose the **Code** button and copy the **https Clone Url** (in this picture: *https://github.com/myuser/app1.git*)
+1. Choose the **Code** button and copy the **https Clone Url**
 
    ![Copy Url](https://github.com/user-attachments/assets/469c4f1b-9991-40e9-88a3-f306819845d6)
 

--- a/Scenarios/GetStarted.md
+++ b/Scenarios/GetStarted.md
@@ -24,7 +24,7 @@
 
    ![app1](https://github.com/user-attachments/assets/b119b33a-7ab2-4605-91d6-669ce4b71fc7)
 
-1. Choose the **Code** button and copy the **https Clone Url** (in this picture: *https://github.com/freddyk-temp/app1.git*)
+1. Choose the **Code** button and copy the **https Clone Url** (in this picture: *https://github.com/myuser/app1.git*)
 
    ![Copy Url](https://github.com/user-attachments/assets/469c4f1b-9991-40e9-88a3-f306819845d6)
 

--- a/Workshop/Dependencies2.md
+++ b/Workshop/Dependencies2.md
@@ -76,13 +76,13 @@ In the MySolution repository, navigate to Settings -> Secrets and Variables -> A
 ```json
   "appDependencyProbingPaths": [
     {
-      "repo": "freddydkorg/Common",
+      "repo": "myorg/Common",
       "release_status": "latestBuild"
     }
   ]
 ```
 
-replacing **freddydkorg** with your organization name obviously.
+replacing **myorg** with your organization name obviously.
 
 | ![image](https://github.com/microsoft/AL-Go/assets/10775043/0ae5d283-0494-4a3d-b6a0-661092b46e09) |
 |-|
@@ -90,7 +90,7 @@ replacing **freddydkorg** with your organization name obviously.
 > [!NOTE]
 > Make sure you create a repository variable and not a repository secret
 
-This setting means that all projects in this repository will download the **latest build** from **freddydkorg/Common** and a subsequent build will succeed. Go to **Actions**, select the **CI/CD** workflow, click **Run workflow** and wait for the workflow to complete.
+This setting means that all projects in this repository will download the **latest build** from **myorg/Common** and a subsequent build will succeed. Go to **Actions**, select the **CI/CD** workflow, click **Run workflow** and wait for the workflow to complete.
 
 | ![image](https://github.com/microsoft/AL-Go/assets/10775043/b10c3050-dd45-47a0-8c2b-fbeb517c94c2) |
 |-|
@@ -107,10 +107,10 @@ This setting means that all projects in this repository will download the **late
 In order to use GitHub Packages for dependency resolution, we need to create an organizational secret called **GitHubPackagesContext**. The format of this secret needs to be **compressed JSON** containing two values: **serverUrl** and **token**. Example:
 
 ```json
-{"token":"ghp_XXX","serverUrl":"https://nuget.pkg.github.com/freddydkorg/index.json"}
+{"token":"ghp_XXX","serverUrl":"https://nuget.pkg.github.com/myorg/index.json"}
 ```
 
-Where **ghp_XXX** should be replaced by a **personal access token** with permissions to **write:packages** and **freddydkorg** should be replaced by your **organization name**.
+Where **ghp_XXX** should be replaced by a **personal access token** with permissions to **write:packages** and **myorg** should be replaced by your **organization name**.
 
 > [!NOTE]
 > Fine-grained personal access tokens doesn't support packages at this time, you need to use classic personal access tokens.

--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -408,7 +408,7 @@ function CreateAlGoRepository {
     $templateFolder = ''
     if ($template.Contains('|')) {
         # In order to run tests on the direct AL-Go Development branch, specify the folder in which the template is located after a | character in template
-        # example: "https://github.com/contoso/AL-Go@branch|Templates/Per Tenant Extension"
+        # example: "https://github.com/myuser/AL-Go@branch|Templates/Per Tenant Extension"
         $templateFolder = $template.Split('|')[1]
         $templateOwner = $template.Split('/')[3]
         $template = $template.Split('|')[0]

--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -408,7 +408,7 @@ function CreateAlGoRepository {
     $templateFolder = ''
     if ($template.Contains('|')) {
         # In order to run tests on the direct AL-Go Development branch, specify the folder in which the template is located after a | character in template
-        # example: "https://github.com/freddydk/AL-Go@branch|Templates/Per Tenant Extension"
+        # example: "https://github.com/myuser/AL-Go@branch|Templates/Per Tenant Extension"
         $templateFolder = $template.Split('|')[1]
         $templateOwner = $template.Split('/')[3]
         $template = $template.Split('|')[0]

--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -408,7 +408,7 @@ function CreateAlGoRepository {
     $templateFolder = ''
     if ($template.Contains('|')) {
         # In order to run tests on the direct AL-Go Development branch, specify the folder in which the template is located after a | character in template
-        # example: "https://github.com/myuser/AL-Go@branch|Templates/Per Tenant Extension"
+        # example: "https://github.com/contoso/AL-Go@branch|Templates/Per Tenant Extension"
         $templateFolder = $template.Split('|')[1]
         $templateOwner = $template.Split('/')[3]
         $template = $template.Split('|')[0]


### PR DESCRIPTION
Replaces personal `freddyk`/`freddydk` account names in AL-Go documentation and example text with generic placeholders (`myuser` for a user/owner, `myorg` for an organization).

## Changes
- **Scenarios/GetStarted.md** — removed the inaccurate example clone URL note (per reviewer feedback).
- **Scenarios/Contribute.md** — `$global:E2EgitHubOwner`, `$global:pteTemplate`, and `$global:appSourceTemplate` examples now use `myuser`; also corrected the `appSourceTemplate` description (was mislabeled "PTE template").
- **.github/workflows/Deploy.yaml** & **.github/workflows/E2E.yaml** — BcContainerHelper direct-download example now points at the real `microsoft/navcontainerhelper/archive/main.zip`.
- **e2eTests/e2eTestHelper.psm1** — example template URL in a comment now uses `myuser`.
- **Workshop/Dependencies2.md** — tutorial org placeholder `freddydkorg` → `myorg` (repo, NuGet serverUrl, and accompanying prose).

## Intentionally left unchanged
- **e2eTests/orgmap.json** — `"freddydk": "businesscentralapps"` is functional E2E config (read by `GetOwnerForE2ETests.ps1` / `E2E.yaml`); changing it would break E2E runs.
- **Scenarios/PublishToAppSource.md** — `FreddyDK.Licensing` / "Freddy Kristiansen as the publisher" accurately describe the real `microsoft/bcsamples-bingmaps.appsource` sample repo, so genericizing would make the doc inaccurate.