### PR TITLE
Fix BCApps e2e: scope PR Build run lookup to e2etest branch

### DIFF
--- a/e2eTests/scenarios/BCApps/runtest.ps1
+++ b/e2eTests/scenarios/BCApps/runtest.ps1
@@ -161,7 +161,11 @@ elseif ($prs.Count -gt 1) {
 
 $headers = GetHeaders -token $ENV:GH_TOKEN -repository $repository
 $url = "https://api.github.com/repos/$repository/actions/runs"
-$run = ((InvokeWebRequest -Method Get -Headers $headers -Uri $url).Content | ConvertFrom-Json).workflow_runs | Where-Object { $_.event -eq 'pull_request' } | Where-Object { $_.name -eq 'Pull Request Build' }
+# Scope the lookup to the Pull Request Build run for the e2etest branch. Other pull_request runs
+# (for example a Dependabot PR) can also be named 'Pull Request Build', so filtering only by name
+# can return multiple runs, and passing an array of ids to WaitWorkflow builds an invalid URL.
+# The runs are returned newest-first, so take the most recent matching run.
+$run = @(((InvokeWebRequest -Method Get -Headers $headers -Uri $url).Content | ConvertFrom-Json).workflow_runs | Where-Object { $_.event -eq 'pull_request' -and $_.name -eq 'Pull Request Build' -and $_.head_branch -eq $branch }) | Select-Object -First 1
 if (-not $run) {
     throw "No Pull Request Build workflow run was found"
 }


### PR DESCRIPTION
### ❔What, Why & How

The `BCApps` e2e scenario intermittently fails during the Pull Request Build wait with a `404 (Not Found)` thrown from `WaitWorkflow`.

Root cause: the run lookup in `e2eTests/scenarios/BCApps/runtest.ps1` filtered `/actions/runs` only by `event -eq 'pull_request'` and `name -eq 'Pull Request Build'`. When a concurrent Dependabot PR is open in the temp repo, its build run is also named "Pull Request Build", so the filter returns more than one run and `$run` becomes an array. `WaitWorkflow`'s `[string] $runid` parameter then coerces that array to a space-joined string (`"<id1> <id2>"`), producing an invalid `/actions/runs/<id1> <id2>` URL that 404s.

The longer runtime introduced by #2306 (pushing the `projects` change to `main` and waiting for a full CI/CD build) widened the window for Dependabot to open its PR before the `e2etest` PR is created, which is why this surfaced now. The underlying filter bug predates that change.

Fix: scope the lookup to `head_branch -eq $branch` (the `e2etest` branch) and take the most recent match with `Select-Object -First 1`, so `$run.id` is always a single value.

### ✅ Checklist

- [x] Add tests (E2E, unit tests)
- [ ] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry

N/A for RELEASENOTES / documentation / telemetry: this only touches internal e2e test infrastructure and is not user facing.