### PR TITLE
Emit valid SARIF URIs for AL code analysis paths containing spaces

### DIFF
--- a/Actions/ProcessALCodeAnalysisLogs/ProcessALCodeAnalysisLogs.ps1
+++ b/Actions/ProcessALCodeAnalysisLogs/ProcessALCodeAnalysisLogs.ps1
@@ -54,12 +54,17 @@ function GenerateSARIFJson {
             continue
         }
 
+        # Encode the path into a valid SARIF artifact URI once, so the de-duplication comparison
+        # below and the stored result use the exact same value (raw and encoded paths differ when
+        # the path contains characters like spaces).
+        $artifactUri = ConvertTo-SarifArtifactUri -RelativePath $relativePath
+
         # Check if result already exists in the sarif object
         $existingResults = $sarif.runs[0].results | Where-Object {
             $_.ruleId -eq $issue.ruleId -and
             $_.message.text -eq $message -and
             $_.level -eq ($issueSeverity).ToLower() -and
-            ($_.locations[0].physicalLocation.artifactLocation.uri -eq $relativePath) -and
+            ($_.locations[0].physicalLocation.artifactLocation.uri -eq $artifactUri) -and
             ($_.locations[0].physicalLocation.region | ConvertTo-Json) -eq ($issue.locations[0].analysisTarget[0].region | ConvertTo-Json)
         }
 
@@ -98,7 +103,7 @@ function GenerateSARIFJson {
             message = @{ text = $message }
             locations = @(@{
                 physicalLocation = @{
-                    artifactLocation = @{ uri = (ConvertTo-SarifArtifactUri -RelativePath $relativePath) }
+                    artifactLocation = @{ uri = $artifactUri }
                     region = $issue.locations[0].analysisTarget[0].region
                 }
             })

--- a/Actions/ProcessALCodeAnalysisLogs/ProcessALCodeAnalysisLogs.ps1
+++ b/Actions/ProcessALCodeAnalysisLogs/ProcessALCodeAnalysisLogs.ps1
@@ -98,7 +98,7 @@ function GenerateSARIFJson {
             message = @{ text = $message }
             locations = @(@{
                 physicalLocation = @{
-                    artifactLocation = @{ uri = $relativePath }
+                    artifactLocation = @{ uri = (ConvertTo-SarifArtifactUri -RelativePath $relativePath) }
                     region = $issue.locations[0].analysisTarget[0].region
                 }
             })

--- a/Actions/ProcessALCodeAnalysisLogs/ProcessALCodeAnalysisLogs.psm1
+++ b/Actions/ProcessALCodeAnalysisLogs/ProcessALCodeAnalysisLogs.psm1
@@ -22,6 +22,31 @@ function NormalizePath {
 
 <#
     .SYNOPSIS
+    Converts a workspace-relative path into a valid SARIF artifact URI.
+    .DESCRIPTION
+    SARIF artifactLocation URIs must be valid URI references. Relative paths from BC projects can contain
+    characters that are not valid in a URI (most commonly spaces, e.g. '1.Setup Data/Foo.al'), which makes
+    github/codeql-action/upload-sarif log "'...' is not a valid URI" warnings and can prevent alerts from
+    mapping to files. This URI-encodes each path segment individually with [Uri]::EscapeDataString while
+    preserving the '/' separators, producing a valid relative URI (e.g. '1.Setup%20Data/Foo.al').
+    .PARAMETER RelativePath
+    The forward-slash-separated workspace-relative path to encode.
+    .OUTPUTS
+    The URI-encoded relative path, or the original value when it is null or empty.
+#>
+function ConvertTo-SarifArtifactUri {
+    param(
+        [Parameter(Mandatory = $false)]
+        [string] $RelativePath
+    )
+    if ([string]::IsNullOrEmpty($RelativePath)) {
+        return $RelativePath
+    }
+    return (($RelativePath -split '/' | ForEach-Object { [Uri]::EscapeDataString($_) }) -join '/')
+}
+
+<#
+    .SYNOPSIS
     Gets the relative path from a base path to a target path using PowerShell 5/7 compatible approach.
     .DESCRIPTION
     This function calculates the relative path from a base path to a target path by temporarily
@@ -160,4 +185,4 @@ function Get-IssueSeverity {
     }
 }
 
-Export-ModuleMember -Function Get-FileFromAbsolutePath, Get-IssueMessage, Get-IssueSeverity
+Export-ModuleMember -Function Get-FileFromAbsolutePath, Get-IssueMessage, Get-IssueSeverity, ConvertTo-SarifArtifactUri

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -12,6 +12,10 @@ Workspace compilation now finds altool both in the platform-specific subfolder (
 - Issue 2319 - Under workspace compilation, `enableCodeAnalyzersOnTestApps: false` now also disables custom analyzers (`customCodeCops`) for test apps and BCPT test apps, not just the built-in code analyzers.
 - Issue 2267 - `AppSourceCop.json` is now created for test apps when `enableCodeAnalyzersOnTestApps` is true.
 
+### Valid SARIF URIs for file paths containing spaces
+
+`ProcessALCodeAnalysisLogs` now URI-encodes each segment of the artifact location path when writing SARIF (for example `1.Setup Data/Foo.al` becomes `1.Setup%20Data/Foo.al`). Paths that contain spaces or other characters that are not valid in a URI previously caused `github/codeql-action/upload-sarif` to log "is not a valid URI" warnings and could prevent AL code scanning alerts from mapping to the correct files. The `/` path separators are preserved so the path structure is unchanged.
+
 ## v9.1
 
 ### Resilient Pull Request Status Check for large builds

--- a/Tests/ProcessALCodeAnalysisLogs.Test.ps1
+++ b/Tests/ProcessALCodeAnalysisLogs.Test.ps1
@@ -267,6 +267,24 @@ Describe 'ProcessALCodeAnalysisLogs Action Tests' {
         $uri | Should -Not -Match '%2F'
     }
 
+    It 'Duplicate issues with a spaced path are only included once' {
+        # Regression: the emitted uri is encoded, so de-duplication must compare against the
+        # encoded uri. Two identical issues on a spaced path must collapse to a single result.
+        Mock Get-FileFromAbsolutePath { return "App/src/1.Setup Data/Foo.al" }
+        $errorLogFile = Join-Path $errorLogsFolder "spaced-dup.errorLog.json"
+        $baseIssueContent = $alErrorLogSchema
+        $baseIssueContent.issues += $sampleIssue1
+        $baseIssueContent.issues += $sampleIssue1
+        $baseIssueContent | ConvertTo-Json -Depth 10 | Set-Content -Path $errorLogFile
+
+        & $scriptPath
+
+        $sarifFile = Join-Path $errorLogsFolder "output.sarif.json"
+        $sarifContent = Get-Content -Path $sarifFile -Raw | ConvertFrom-Json
+        $sarifContent.runs[0].results.Count | Should -Be 1
+        $sarifContent.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri | Should -Be "App/src/1.Setup%20Data/Foo.al"
+    }
+
     It 'Test action.yaml matches script' {
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript
     }

--- a/Tests/ProcessALCodeAnalysisLogs.Test.ps1
+++ b/Tests/ProcessALCodeAnalysisLogs.Test.ps1
@@ -248,6 +248,25 @@ Describe 'ProcessALCodeAnalysisLogs Action Tests' {
         Invoke-Expression $actionScript
     }
 
+    It 'URI-encodes artifact locations that contain spaces (valid SARIF URI)' {
+        # BCApps paths often contain spaces (e.g. '1.Setup Data'). A raw space is not a valid URI
+        # character, so upload-sarif warns and alerts can fail to map. The emitted uri must be encoded.
+        Mock Get-FileFromAbsolutePath { return "App/src/1.Setup Data/Contoso Helpers/Foo.al" }
+        $errorLogFile = Join-Path $errorLogsFolder "spaced.errorLog.json"
+        $baseIssueContent = $alErrorLogSchema
+        $baseIssueContent.issues += $sampleIssue1
+        $baseIssueContent | ConvertTo-Json -Depth 10 | Set-Content -Path $errorLogFile
+
+        & $scriptPath
+
+        $sarifFile = Join-Path $errorLogsFolder "output.sarif.json"
+        $sarifContent = Get-Content -Path $sarifFile -Raw | ConvertFrom-Json
+        $uri = $sarifContent.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri
+        $uri | Should -Be "App/src/1.Setup%20Data/Contoso%20Helpers/Foo.al"
+        # '/' separators must remain unencoded so the path structure is preserved.
+        $uri | Should -Not -Match '%2F'
+    }
+
     It 'Test action.yaml matches script' {
         YamlTest -scriptRoot $scriptRoot -actionName $actionName -actionScript $actionScript
     }
@@ -309,6 +328,29 @@ Describe 'ProcessALCodeAnalysisLogs Action Tests' {
             $result = Get-FileFromAbsolutePath -AbsolutePath $pathWithDrive -WorkspacePath $testWorkspace
 
             $result | Should -Be "SubDir1/Nested/NestedFile.al"
+        }
+    }
+
+    Context 'ConvertTo-SarifArtifactUri Function Tests' {
+
+        BeforeAll {
+            Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "..\Actions\ProcessALCodeAnalysisLogs\ProcessALCodeAnalysisLogs.psm1" -Resolve) -Force
+        }
+
+        It 'Encodes spaces per segment but preserves / separators' {
+            $result = ConvertTo-SarifArtifactUri -RelativePath "App/src/1.Setup Data/Contoso Helpers/Foo.al"
+            $result | Should -Be "App/src/1.Setup%20Data/Contoso%20Helpers/Foo.al"
+        }
+
+        It 'Leaves already-valid paths unchanged' {
+            $result = ConvertTo-SarifArtifactUri -RelativePath "App/src/Foo.al"
+            $result | Should -Be "App/src/Foo.al"
+        }
+
+        It 'Returns an empty string for null or empty input' {
+            # A [string] parameter coerces $null to an empty string, so both cases return ''.
+            (ConvertTo-SarifArtifactUri -RelativePath $null) | Should -BeNullOrEmpty
+            (ConvertTo-SarifArtifactUri -RelativePath "") | Should -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
## Why

When `ProcessALCodeAnalysisLogs` writes the SARIF file it put the raw workspace-relative path straight into `results[].locations[0].physicalLocation.artifactLocation.uri`. SARIF `artifactLocation` URIs must be valid URI references, but BCApps paths routinely contain spaces (for example `1.Setup Data/Foo.al`, `Contoso Helpers/...`). A raw space is not a valid URI character, so `github/codeql-action/upload-sarif` logged thousands of `'...' is not a valid URI` warnings and alerts could fail to map back to their files.

## What

Added a small `ConvertTo-SarifArtifactUri` helper that URI-encodes each `/`-separated path segment individually with `[Uri]::EscapeDataString`, preserving the `/` separators. So `1.Setup Data/Foo.al` becomes `1.Setup%20Data/Foo.al` and the path structure is unchanged. `GenerateSARIFJson` now runs the relative path through this helper only when writing the `uri` field; de-duplication still keys on the raw relative path, so dedup semantics are untouched.

Verified live on a BCApps PR: after the fix, 0 `not a valid URI` warnings.

## Changes

- `Actions/ProcessALCodeAnalysisLogs/ProcessALCodeAnalysisLogs.psm1`: new `ConvertTo-SarifArtifactUri` function (with comment-based help), exported from the module.
- `Actions/ProcessALCodeAnalysisLogs/ProcessALCodeAnalysisLogs.ps1`: encode only the `uri` line in the result object.
- `Tests/ProcessALCodeAnalysisLogs.Test.ps1`: an end-to-end test asserting the emitted `uri` is encoded (and that `/` is preserved), plus a unit-test `Context` for the new function. Tests pass on both Windows PowerShell 5 and PowerShell 7.
- `RELEASENOTES.md`: release note describing the fix.

## Notes

This is split out of a larger changeset into its own PR: it contains only the SARIF URI fix, no performance/scaling change to `ProcessALCodeAnalysisLogs` and no `trackALAlertsInGitHub` workspace-compilation change.