### PR TITLE
Add union merge driver for RELEASENOTES.md to reduce merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Use the "union" merge driver for RELEASENOTES.md so that concurrent PRs that
+# each append their own entries are merged by keeping both sides' added lines
+# instead of producing a merge conflict. This greatly reduces the merge-conflict
+# churn caused by many PRs editing the same top region of the changelog.
+RELEASENOTES.md merge=union


### PR DESCRIPTION
### ❔What, Why & How

Almost every PR edits the top region of `RELEASENOTES.md`, and the `Deploy.yaml` "Calculate Release Notes" step reads everything from the top of the file down to the first `## vX.Y` header. Because every PR touches that same region, having several PRs in flight reliably produces merge conflicts in the changelog.

This adds a repo-root `.gitattributes` that assigns the built-in **`union`** merge driver to `RELEASENOTES.md`:

```
RELEASENOTES.md merge=union
```

With `union`, git keeps the added lines from **both** sides during a merge/rebase instead of raising a conflict. `union` is a built-in git driver, so it takes effect automatically on clone/pull — no per-machine git config is required.

**Notes / caveats**
- `union` does not guarantee ordering and can occasionally duplicate a line on rebase — harmless for a bullet-list changelog; just glance at the unreleased section before cutting a release.
- It only takes effect during an actual merge/rebase, so existing open PRs benefit once they merge from `main`.
- The changelog is stored as LF in the index, so the union driver already merges on consistent line endings.

This is intended as a quick, low-risk mitigation. A more robust fragment-based approach (each PR drops a separate file, assembled at release time) can be considered as a follow-up.

Related to issue: #

### ✅ Checklist

- [ ] Add tests (E2E, unit tests)
- [ ] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry

<!-- No RELEASENOTES.md entry added: this is repository infrastructure, not a user-facing AL-Go feature. No new settings, code paths, or telemetry. -->