### PR TITLE
Handle app names with underscores correctly for reference documentation

### DIFF
--- a/Actions/BuildReferenceDocumentation/BuildReferenceDocumentation.HelperFunctions.ps1
+++ b/Actions/BuildReferenceDocumentation/BuildReferenceDocumentation.HelperFunctions.ps1
@@ -62,7 +62,7 @@
 }
 
 function SanitizeFileName([string] $fileName) {
-    $fileName.Replace('_','-').Replace('?','_').Replace('*','_').Replace(' ','-').Replace('\','-').Replace('/','-').Replace(':','-').Replace('<','-').Replace('>','-').Replace('|','-').Replace('%','pct')
+    ($fileName.ToLower().Split([System.IO.Path]::GetInvalidFileNameChars()) -join '').Replace(' ', '-')
 }
 
 function GetAppNameAndFolder {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -14,6 +14,7 @@ Workspace compilation now finds altool both in the platform-specific subfolder (
 - Retry downloading dependency artifacts from the current build up to 3 times (30 seconds between attempts) to tolerate transient network errors such as "Failed to GetSignedArtifactURL: Unable to make request: ETIMEDOUT"
 - Issue 2256 - Test Result Analyzer fails if no stack trace is available
 - Issue 2302 - AlDoc does not use --packagecache when building reference documentation
+- Reference documentation no longer fails with "InvalidTocInclude: Referenced TOC file ... does not exist" for apps whose name contains an underscore (e.g. `_Exclude_*` apps). The toc.yml folder names are now derived using the same rules as the aldoc tool, which keeps underscores instead of turning them into hyphens.
 - Issue 2319 - Under workspace compilation, `enableCodeAnalyzersOnTestApps: false` now also disables custom analyzers (`customCodeCops`) for test apps and BCPT test apps, not just the built-in code analyzers.
 - Issue 2267 - `AppSourceCop.json` is now created for test apps when `enableCodeAnalyzersOnTestApps` is true.
 

--- a/Tests/BuildReferenceDocumentation.Action.Test.ps1
+++ b/Tests/BuildReferenceDocumentation.Action.Test.ps1
@@ -64,6 +64,34 @@ Describe "BuildReferenceDocumentation Action Tests" {
         $allApps[0]."P4".Count | Should -be 4
     }
 
+    It 'SanitizeFileName matches aldoc GetValidDirectoryName' {
+        . (Join-Path $scriptRoot 'BuildReferenceDocumentation.HelperFunctions.ps1')
+
+        # The reference/<folder> directories are created by aldoc using Symbol.GetValidDirectoryName():
+        #   string.Join("", Name.ToLower().Split(Path.GetInvalidFileNameChars())).Replace(' ', '-')
+        # SanitizeFileName derives the toc.yml hrefs that point at those directories, so it must produce
+        # the exact same string. This guards against regressions like turning '_' into '-' (which broke
+        # BCApps '_Exclude_*' apps with "InvalidTocInclude: Referenced TOC file ... does not exist").
+        function AldocGetValidDirectoryName([string] $name) {
+            ($name.ToLower().Split([System.IO.Path]::GetInvalidFileNameChars()) -join '').Replace(' ', '-')
+        }
+
+        $names = @(
+            '_Exclude_APIV1_'
+            '_Exclude_Bank Deposits'
+            '_Exclude_Business_Events_'
+            '_Exclude_Microsoft Dynamics 365 - SmartList'
+            'Bank Deposits'
+            'Base Application'
+        )
+        foreach ($name in $names) {
+            SanitizeFileName -fileName $name | Should -Be (AldocGetValidDirectoryName $name)
+        }
+
+        # Underscores are preserved (not converted to hyphens)
+        SanitizeFileName -fileName '_Exclude_APIV1_' | Should -Be '_exclude_apiv1_'
+    }
+
     It 'Artifact URL generated if not provided' {
         . (Join-Path $scriptRoot 'BuildReferenceDocumentation.HelperFunctions.ps1')
         . (Join-Path -Path $scriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)


### PR DESCRIPTION
### ❔What, Why & How

There was a mismatch in how AL-Go and AlDoc handled underscores in appnames. AL-Go replaced underscores like `Replace('_', '-')` meaning app names like `_Exclude_APIV1_` becomes `-Exclude-APIV1-`. AlDoc doesn't do this and allows underscores. This then fails as AlDoc creates a path to a toc file which includes underscores, but AL-Go when referencing that file uses dashes.

### ✅ Checklist

- [x] Add tests (E2E, unit tests)
- [x] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
