### PR TITLE
Fix incremental builds poisoning buildMode-specific artifacts (#2337)

### DIFF
--- a/Actions/DetermineBuildProject/DetermineBuildProject.ps1
+++ b/Actions/DetermineBuildProject/DetermineBuildProject.ps1
@@ -6,7 +6,9 @@
     [Parameter(HelpMessage = "Name of the project to build", Mandatory = $true)]
     [string] $project,
     [Parameter(HelpMessage = "Id of the baseline workflow run, from which to download artifacts if build is skipped", Mandatory = $false)]
-    [string] $baselineWorkflowRunId
+    [string] $baselineWorkflowRunId,
+    [Parameter(HelpMessage = "Build mode used when building the artifacts", Mandatory = $false)]
+    [string] $buildMode = 'Default'
 )
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
@@ -22,16 +24,31 @@ if (!$buildIt) {
     # Set buildIt to true if the download isn't successful
     New-Item $buildArtifactFolder -ItemType Directory | Out-Null
     $buildIt = $true
+    # Artifacts are named with a build mode prefix (empty for the 'Default' build mode), matching CalculateArtifactNames.ps1.
+    # Download the artifacts for the same build mode as the current dimension, so that a skipped (project, buildMode)
+    # re-publishes the correct build mode-specific apps instead of always re-publishing the 'Default' build mode apps.
+    $buildModePrefix = ''
+    if ($buildMode -and $buildMode -ne 'Default') {
+        $buildModePrefix = $buildMode
+    }
     foreach($mask in @('Apps','TestApps','Dependencies','PowerPlatformSolution')) {
-        $artifact = GetArtifactsFromWorkflowRun -workflowRun $baselineWorkflowRunId -token $token -api_url $env:GITHUB_API_URL -repository $env:GITHUB_REPOSITORY -mask $mask -projects $project
+        # PowerPlatformSolution is always built with the 'Default' build mode, so its artifact is never build mode-prefixed.
+        if ($mask -eq 'PowerPlatformSolution') {
+            $artifactMask = $mask
+        }
+        else {
+            $artifactMask = "$buildModePrefix$mask"
+        }
+        $artifact = GetArtifactsFromWorkflowRun -workflowRun $baselineWorkflowRunId -token $token -api_url $env:GITHUB_API_URL -repository $env:GITHUB_REPOSITORY -mask $artifactMask -projects $project
         if ($artifact) {
-            Write-Host "Artifact found for mask $mask"
+            Write-Host "Artifact found for mask $artifactMask"
             if ($artifact -is [Array]) {
-                throw "Multiple artifacts found with mask $mask for project $project"
+                throw "Multiple artifacts found with mask $artifactMask for project $project"
             }
             $file = DownloadArtifact -path $buildArtifactFolder -token $token -artifact $artifact
             if ($file) {
-                Write-Host "Artifact downloaded for mask $mask"
+                Write-Host "Artifact downloaded for mask $artifactMask"
+                # Extract into the build mode-agnostic folder name (e.g. 'Apps'), as expected by the subsequent build steps.
                 $thisArtifactFolder = Join-Path $buildArtifactFolder $mask
                 Expand-Archive -Path $file -DestinationPath $thisArtifactFolder -Force
                 Remove-Item -Path $file -Force

--- a/Actions/DetermineBuildProject/README.md
+++ b/Actions/DetermineBuildProject/README.md
@@ -19,6 +19,7 @@ Determine whether to build project
 | skippedProjectsJson | Yes | Compressed JSON string containing the list of projects that should be skipped | |
 | project | Yes | Name of the project to build | |
 | baselineWorkflowRunId | Yes | Id of the baseline workflow run, from which to download artifacts if build is skipped | |
+| buildMode | | Build mode used when building the artifacts | Default |
 
 ## OUTPUT
 

--- a/Actions/DetermineBuildProject/action.yaml
+++ b/Actions/DetermineBuildProject/action.yaml
@@ -18,6 +18,10 @@ inputs:
   baselineWorkflowRunId:
     description: Id of the baseline workflow run, from which to download artifacts if build is skipped
     required: true
+  buildMode:
+    description: Build mode used when building the artifacts
+    required: false
+    default: Default
 outputs:
   BuildIt:
     description: Determines whether the project needs to be built
@@ -33,9 +37,10 @@ runs:
         _skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
         _project: ${{ inputs.project }}
         _baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
+        _buildMode: ${{ inputs.buildMode }}
       run: |
         ${{ github.action_path }}/../Invoke-AlGoAction.ps1 -ActionName "DetermineBuildProject" -Action {
-          ${{ github.action_path }}/DetermineBuildProject.ps1 -token $env:_token -skippedProjectsJson $env:_skippedProjectsJson -project $env:_project -baselineWorkflowRunId $env:_baselineWorkflowRunId
+          ${{ github.action_path }}/DetermineBuildProject.ps1 -token $env:_token -skippedProjectsJson $env:_skippedProjectsJson -project $env:_project -baselineWorkflowRunId $env:_baselineWorkflowRunId -buildMode $env:_buildMode
         }
 branding:
   icon: terminal

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -23,6 +23,7 @@ As part of this, the warning comparison now also parses the raw AL compiler outp
 - Reference documentation no longer fails with "InvalidTocInclude: Referenced TOC file ... does not exist" for apps whose name contains an underscore (e.g. `_Exclude_*` apps). The toc.yml folder names are now derived using the same rules as the aldoc tool, which keeps underscores instead of turning them into hyphens.
 - Issue 2319 - Under workspace compilation, `enableCodeAnalyzersOnTestApps: false` now also disables custom analyzers (`customCodeCops`) for test apps and BCPT test apps, not just the built-in code analyzers.
 - Issue 2267 - `AppSourceCop.json` is now created for test apps when `enableCodeAnalyzersOnTestApps` is true.
+- Issue 2337 - Incremental builds: skipped projects re-publish Default-mode apps into ALL buildMode-specific artifacts
 
 ### Valid SARIF URIs for file paths containing spaces
 

--- a/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/AppSource App/.github/workflows/_BuildALGoProject.yaml
@@ -127,6 +127,7 @@ jobs:
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
           project: ${{ inputs.project }}
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
+          buildMode: ${{ inputs.buildMode }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/_BuildALGoProject.yaml
@@ -127,6 +127,7 @@ jobs:
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
           project: ${{ inputs.project }}
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
+          buildMode: ${{ inputs.buildMode }}
 
       - name: Read secrets
         id: ReadSecrets

--- a/Tests/DetermineBuildProject.Action.Test.ps1
+++ b/Tests/DetermineBuildProject.Action.Test.ps1
@@ -1,0 +1,120 @@
+﻿Get-Module TestActionsHelper | Remove-Module -Force
+Import-Module (Join-Path $PSScriptRoot 'TestActionsHelper.psm1')
+$errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
+
+Describe "DetermineBuildProject Action Tests" {
+    BeforeAll {
+        $actionName = "DetermineBuildProject"
+        $scriptRoot = Join-Path $PSScriptRoot "..\Actions\$actionName" -Resolve
+        $scriptName = "$actionName.ps1"
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'scriptPath', Justification = 'False positive.')]
+        $scriptPath = Join-Path $scriptRoot $scriptName
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'actionScript', Justification = 'False positive.')]
+        $actionScript = GetActionScript -scriptRoot $scriptRoot -scriptName $scriptName
+    }
+
+    It 'Compile Action' {
+        Invoke-Expression $actionScript
+    }
+
+    Context 'Determine whether to build a skipped project' {
+        BeforeAll {
+            . (Join-Path $PSScriptRoot "..\Actions\AL-Go-Helper.ps1")
+        }
+
+        BeforeEach {
+            # Set up the function from the action script
+            Invoke-Expression $actionScript
+
+            # Set up GITHUB_OUTPUT
+            $script:githubOutputFile = Join-Path $TestDrive "github_output.txt"
+            $env:GITHUB_OUTPUT = $script:githubOutputFile
+            '' | Set-Content $script:githubOutputFile
+
+            # Set env vars used by the script
+            $env:Settings = '{}'
+            $script:workspace = Join-Path $TestDrive ([guid]::NewGuid().ToString())
+            New-Item -Path $script:workspace -ItemType Directory -Force | Out-Null
+            $env:GITHUB_WORKSPACE = $script:workspace
+            $env:GITHUB_API_URL = 'https://api.github.com'
+            $env:GITHUB_REPOSITORY = 'testorg/testrepo'
+
+            # By default no baseline artifacts are found, so the project needs to be built
+            Mock GetArtifactsFromWorkflowRun { return $null }
+            Mock DownloadArtifact {}
+        }
+
+        AfterEach {
+            Remove-Item -Path $env:GITHUB_OUTPUT -Force -ErrorAction SilentlyContinue
+            $env:GITHUB_OUTPUT = ''
+            $env:Settings = ''
+            $env:GITHUB_WORKSPACE = ''
+            $env:GITHUB_API_URL = ''
+            $env:GITHUB_REPOSITORY = ''
+        }
+
+        It 'Downloads the Default build mode artifacts (no build mode prefix) for a skipped Default build' {
+            DetermineBuildProject -token 'dummy' -skippedProjectsJson '["ProjectA"]' -project 'ProjectA' -baselineWorkflowRunId '123' -buildMode 'Default'
+
+            Should -Invoke GetArtifactsFromWorkflowRun -Times 1 -Exactly -ParameterFilter { $mask -eq 'Apps' }
+            Should -Invoke GetArtifactsFromWorkflowRun -Times 0 -Exactly -ParameterFilter { $mask -eq 'DefaultApps' }
+        }
+
+        It 'Downloads the build mode-prefixed artifacts for a skipped non-Default build' {
+            DetermineBuildProject -token 'dummy' -skippedProjectsJson '["ProjectA"]' -project 'ProjectA' -baselineWorkflowRunId '123' -buildMode 'BC27'
+
+            # The BC27 dimension must download the BC27-prefixed artifacts, not the Default (unprefixed) ones
+            Should -Invoke GetArtifactsFromWorkflowRun -Times 1 -Exactly -ParameterFilter { $mask -eq 'BC27Apps' }
+            Should -Invoke GetArtifactsFromWorkflowRun -Times 1 -Exactly -ParameterFilter { $mask -eq 'BC27TestApps' }
+            Should -Invoke GetArtifactsFromWorkflowRun -Times 1 -Exactly -ParameterFilter { $mask -eq 'BC27Dependencies' }
+            Should -Invoke GetArtifactsFromWorkflowRun -Times 0 -Exactly -ParameterFilter { $mask -eq 'Apps' }
+        }
+
+        It 'Never build mode-prefixes the PowerPlatformSolution mask (always built with Default build mode)' {
+            DetermineBuildProject -token 'dummy' -skippedProjectsJson '["ProjectA"]' -project 'ProjectA' -baselineWorkflowRunId '123' -buildMode 'BC27'
+
+            Should -Invoke GetArtifactsFromWorkflowRun -Times 1 -Exactly -ParameterFilter { $mask -eq 'PowerPlatformSolution' }
+            Should -Invoke GetArtifactsFromWorkflowRun -Times 0 -Exactly -ParameterFilter { $mask -eq 'BC27PowerPlatformSolution' }
+        }
+
+        It 'Defaults to the Default build mode when no build mode is provided' {
+            DetermineBuildProject -token 'dummy' -skippedProjectsJson '["ProjectA"]' -project 'ProjectA' -baselineWorkflowRunId '123'
+
+            Should -Invoke GetArtifactsFromWorkflowRun -Times 1 -Exactly -ParameterFilter { $mask -eq 'Apps' }
+        }
+
+        It 'Extracts downloaded artifacts into the build mode-agnostic folder name' {
+            Mock GetArtifactsFromWorkflowRun {
+                if ($mask -eq 'BC27Apps') { return @{ name = 'ProjectA-main-BC27Apps-1.0.0.0' } } else { return $null }
+            }
+            Mock DownloadArtifact {
+                # Simulate a downloaded zip file
+                $zipFile = Join-Path $path "artifact.zip"
+                New-Item -Path $zipFile -ItemType File -Force | Out-Null
+                return $zipFile
+            }
+            Mock Expand-Archive {}
+            Mock Remove-Item {}
+
+            DetermineBuildProject -token 'dummy' -skippedProjectsJson '["ProjectA"]' -project 'ProjectA' -baselineWorkflowRunId '123' -buildMode 'BC27'
+
+            # The extraction target must be the unprefixed 'Apps' folder that later build steps read from
+            Should -Invoke Expand-Archive -Times 1 -Exactly -ParameterFilter { $DestinationPath -like '*.buildartifacts*Apps' -and $DestinationPath -notlike '*BC27Apps' }
+        }
+
+        It 'Sets BuildIt=True when no baseline artifacts are available' {
+            DetermineBuildProject -token 'dummy' -skippedProjectsJson '["ProjectA"]' -project 'ProjectA' -baselineWorkflowRunId '123' -buildMode 'BC27'
+
+            $output = Get-Content $script:githubOutputFile -Raw
+            $output | Should -Match 'BuildIt=True'
+        }
+
+        It 'Sets BuildIt=True for a project that is not skipped without downloading artifacts' {
+            DetermineBuildProject -token 'dummy' -skippedProjectsJson '[]' -project 'ProjectA' -baselineWorkflowRunId '123' -buildMode 'BC27'
+
+            Should -Invoke GetArtifactsFromWorkflowRun -Times 0 -Exactly
+            $output = Get-Content $script:githubOutputFile -Raw
+            $output | Should -Match 'BuildIt=True'
+        }
+    }
+}


### PR DESCRIPTION
### ❔What, Why & How

When incremental builds skip a project, `DetermineBuildProject` downloads that project's baseline artifacts and re-publishes them for the current run. It downloaded them using build-mode-agnostic masks (`Apps`, `TestApps`, `Dependencies`), which only match the **Default** build mode artifact (`<project>-<branch>-Apps-*`). Every build mode dimension of a skipped project therefore re-published the Default-mode apps under its own build-mode-specific artifact name (e.g. `<project>-<branch>-CleanApps-*`), corrupting the content.

In multi-project repos where a project builds a non-Default mode against a different Business Central artifact (different runtime), dependent projects then downloaded the wrong app and failed, e.g.:

```
AL1153 The referenced module 'X' with runtime reference version '17.0'
cannot be loaded by the compiler with version '16.0'.
```

Because each incremental run becomes the baseline for the next, the corruption propagated until a full build happened.

**How:** `DetermineBuildProject` now receives the `buildMode` and downloads the artifacts for the same build mode as the current dimension, using build-mode-prefixed masks (empty prefix for `Default`), consistent with `CalculateArtifactNames` and the already-correct `modifiedApps` path in `DetermineProjectsToBuild`. `PowerPlatformSolution` stays unprefixed, since it is always built in `Default` mode (matching `GetArtifactsForDeployment`). Downloaded artifacts are still extracted into the build-mode-agnostic `.buildartifacts` folders that later build steps read.

Verified end to end on a two-project repro (`Default` = BC28 / runtime 17, custom `BC27` mode = BC27 / runtime 16): before the fix the skipped project's `BC27Apps` artifact contained the runtime-17 app and the dependent BC27 build failed with AL1153; after the fix it contains the runtime-16 app and the build passes.

Related to issue: #2337

### ✅ Checklist

- [x] Add tests (E2E, unit tests)
- [x] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios) - N/A (no user-facing settings or scenarios changed; `buildMode` is an internal action input)
- [ ] Add telemetry - N/A