### PR TITLE
Move CreateRelease update check to separate job

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,10 @@
 
 The starter Azure Data Explorer dashboard now includes dedicated views for workflow reliability, run exploration, test quality, workflow duration, runner efficiency, and AL-Go maintenance. It also provides repository, workflow, branch, and repository-type filtering, clearer empty states, and repository-level runtime supportability information.
 
+### Create Release checks AL-Go system file updates separately
+
+The `Create Release` workflow now checks for available AL-Go system file updates in a separate job that runs in parallel with and independently of release creation. This allows the release to be created without waiting for the update check and can reduce the overall workflow duration.
+
 ## v9.2
 
 ### New `doNotPerformUpgrade` setting

--- a/Scenarios/CreateRelease.md
+++ b/Scenarios/CreateRelease.md
@@ -6,6 +6,9 @@
 
    ![Create Release](https://github.com/user-attachments/assets/748537f5-781f-4e96-bb8f-79b7294dbca5)
 
+> [!NOTE]
+> The existing AL-Go system file update check in the **Create Release** workflow is executed in a separate `CheckForUpdates` job. It runs independently of release creation and reports available updates to AL-Go system files. It does not apply updates; use the **Update AL-Go System Files** workflow to apply them.
+
 1. When the **create release** workflow completes, choose the **Code** section to see the releases.
 
    ![Releases](https://github.com/user-attachments/assets/71de15de-1d29-49cf-a593-85b0c5041f4c)

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -126,7 +126,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          get: templateUrl,repoName,type,powerPlatformSolutionFolder
+          get: repoName,type,powerPlatformSolutionFolder
 
       - name: Validate Workflow Input
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -67,6 +67,36 @@ env:
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
+  CheckForUpdates:
+    runs-on: [ windows-latest ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
+        with:
+          shell: powershell
+          get: templateUrl
+
+      - name: Read secrets
+        id: ReadSecrets
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
+        with:
+          shell: powershell
+          gitHubSecrets: ${{ toJson(secrets) }}
+          getSecrets: 'ghTokenWorkflow'
+
+      - name: Check for updates to AL-Go system files
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          shell: powershell
+          templateUrl: ${{ env.templateUrl }}
+          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
+          downloadLatest: true
+
   CreateRelease:
     needs: [ ]
     runs-on: [ windows-latest ]
@@ -118,16 +148,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@main
         with:
           shell: powershell
-
-      - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@main
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          shell: powershell
-          templateUrl: ${{ env.templateUrl }}
-          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
-          downloadLatest: true
 
       - name: Determine artifacts for release
         uses: microsoft/AL-Go-Actions/DetermineArtifactsForRelease@main

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -126,7 +126,7 @@ jobs:
         uses: microsoft/AL-Go-Actions/ReadSettings@main
         with:
           shell: powershell
-          get: templateUrl,repoName,type,powerPlatformSolutionFolder
+          get: repoName,type,powerPlatformSolutionFolder
 
       - name: Validate Workflow Input
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -67,6 +67,36 @@ env:
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
+  CheckForUpdates:
+    runs-on: [ windows-latest ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@main
+        with:
+          shell: powershell
+          get: templateUrl
+
+      - name: Read secrets
+        id: ReadSecrets
+        uses: microsoft/AL-Go-Actions/ReadSecrets@main
+        with:
+          shell: powershell
+          gitHubSecrets: ${{ toJson(secrets) }}
+          getSecrets: 'ghTokenWorkflow'
+
+      - name: Check for updates to AL-Go system files
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          shell: powershell
+          templateUrl: ${{ env.templateUrl }}
+          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
+          downloadLatest: true
+
   CreateRelease:
     needs: [ ]
     runs-on: [ windows-latest ]
@@ -118,16 +148,6 @@ jobs:
         uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@main
         with:
           shell: powershell
-
-      - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@main
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          shell: powershell
-          templateUrl: ${{ env.templateUrl }}
-          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
-          downloadLatest: true
 
       - name: Determine artifacts for release
         uses: microsoft/AL-Go-Actions/DetermineArtifactsForRelease@main

--- a/Tests/CheckForUpdates.Action.Test.ps1
+++ b/Tests/CheckForUpdates.Action.Test.ps1
@@ -210,6 +210,7 @@ Describe "CheckForUpdates Action: CheckForUpdates.HelperFunctions.ps1" {
     BeforeAll {
         $actionName = "CheckForUpdates"
         $scriptRoot = Join-Path $PSScriptRoot "..\Actions\$actionName" -Resolve
+        . (Join-Path -Path $scriptRoot -ChildPath "yamlclass.ps1")
         Import-Module (Join-Path $scriptRoot "..\Github-Helper.psm1") -DisableNameChecking -Force
         . (Join-Path -Path $scriptRoot -ChildPath "CheckForUpdates.HelperFunctions.ps1")
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'tmpSrcFile', Justification = 'False positive.')]
@@ -226,6 +227,63 @@ Describe "CheckForUpdates Action: CheckForUpdates.HelperFunctions.ps1" {
         if (Test-Path $tmpDstFile) {
             Remove-Item -Path $tmpDstFile -Force
         }
+    }
+
+    It 'ModifyRunsOnAndShell updates runs-on and shell in all workflow jobs' {
+        $yaml = [Yaml]::new(@(
+            "jobs:",
+            "  CheckForUpdates:",
+            "    runs-on: [ windows-latest ]",
+            "    steps:",
+            "      - name: Read settings",
+            "        with:",
+            "          shell: powershell",
+            "  CreateRelease:",
+            "    runs-on: [ windows-latest ]",
+            "    steps:",
+            "      - name: Create release",
+            "        with:",
+            "          shell: powershell"
+        ))
+        $repoSettings = @{
+            "runs-on" = "self-hosted, custom-label"
+            "shell" = "pwsh"
+        }
+
+        ModifyRunsOnAndShell -yaml $yaml -repoSettings $repoSettings
+
+        ($yaml.Get('jobs:/CheckForUpdates:/runs-on').content -join '') | Should -Be 'runs-on: [ self-hosted, custom-label ]'
+        ($yaml.Get('jobs:/CheckForUpdates:/steps:/- name: Read settings/with:/shell:').content -join '') | Should -Be 'shell: pwsh'
+        ($yaml.Get('jobs:/CreateRelease:/runs-on').content -join '') | Should -Be 'runs-on: [ self-hosted, custom-label ]'
+        ($yaml.Get('jobs:/CreateRelease:/steps:/- name: Create release/with:/shell:').content -join '') | Should -Be 'shell: pwsh'
+    }
+
+    It 'ModifyRunsOnAndShell rejects powershell with ubuntu-latest' {
+        $yaml = [Yaml]::new(@(
+            "jobs:",
+            "  test:",
+            "    runs-on: [ windows-latest ]"
+        ))
+        $repoSettings = @{
+            "runs-on" = "ubuntu-latest"
+            "shell" = "powershell"
+        }
+
+        { ModifyRunsOnAndShell -yaml $yaml -repoSettings $repoSettings } | Should -Throw '*The shell cannot be set to powershell when runs-on is ubuntu-latest*'
+    }
+
+    It 'ModifyRunsOnAndShell rejects unsupported shells' {
+        $yaml = [Yaml]::new(@(
+            "jobs:",
+            "  test:",
+            "    runs-on: [ windows-latest ]"
+        ))
+        $repoSettings = @{
+            "runs-on" = "windows-latest"
+            "shell" = "bash"
+        }
+
+        { ModifyRunsOnAndShell -yaml $yaml -repoSettings $repoSettings } | Should -Throw '*The shell can only be set to powershell or pwsh*'
     }
 
     It 'GetModifiedSettingsContent returns correct content when destination file is not empty' {


### PR DESCRIPTION
# ❔What, Why & How

## Change

This PR moves the existing AL-Go system file update check out of the `CreateRelease` job and into a dedicated `CheckForUpdates` job.

The change applies to both the AppSource App and Per Tenant Extension release templates.

The update check does not need to block release creation. With a separate job, `CheckForUpdates` can run in parallel with `CreateRelease`, so release creation no longer has to wait for the check to complete.

The check itself remains reporting-only. Updates are still applied through the existing `Update AL-Go System Files` workflow.

## Additional test coverage

While working on this, I noticed that the existing `ModifyRunsOnAndShell` logic had no test coverage.

I added tests for the existing behavior, including workflows with multiple jobs and the validation of invalid runner/shell combinations.

## Open question

While looking at the update check, I also started wondering whether we need it in the `Create Release` workflow at all.

In many cases, `CI/CD` has already run shortly before creating a release and performed the same check. I am not sure the additional check during release creation provides much value.

Would it make sense to remove it from `Create Release` entirely? If so, I can adjust this PR accordingly.

### ✅ Checklist

- [x] Add tests (E2E, unit tests)
- [x] Update RELEASENOTES.md
- [x] Update documentation (e.g. for new settings or scenarios)
- [ ] Add telemetry