### PR TITLE
Fix incremental PR builds affected by baseline drift

### DIFF
--- a/Actions/CompileApps/Compile.ps1
+++ b/Actions/CompileApps/Compile.ps1
@@ -146,8 +146,9 @@ try {
     if ($baselineWorkflowSHA -and $baselineWorkflowRunId -ne '0' -and $settings.incrementalBuilds.mode -eq 'modifiedApps') {
         try {
             $modifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA)
-            OutputMessageAndArray -message "Modified files" -arrayOfStrings $modifiedFiles
-            $buildAll = Get-BuildAllApps -baseFolder $baseFolder -project $project -modifiedFiles $modifiedFiles
+            OutputMessageAndArray -message "Modified files (since baseline build)" -arrayOfStrings $modifiedFiles
+            $prModifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA -useMergeBase)
+            $buildAll = Get-BuildAllApps -baseFolder $baseFolder -project $project -modifiedFiles $prModifiedFiles
         }
         catch {
             OutputNotice -message "Failed to calculate modified files since $baselineWorkflowSHA, building all apps"

--- a/Actions/CompileApps/Compile.ps1
+++ b/Actions/CompileApps/Compile.ps1
@@ -145,8 +145,8 @@ try {
 
     if ($baselineWorkflowSHA -and $baselineWorkflowRunId -ne '0' -and $settings.incrementalBuilds.mode -eq 'modifiedApps') {
         try {
-            $modifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA)
-            OutputMessageAndArray -message "Modified files (since baseline build)" -arrayOfStrings $modifiedFiles
+            $baselineModifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA)
+            OutputMessageAndArray -message "Modified files (since baseline build)" -arrayOfStrings $baselineModifiedFiles
             $prModifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA -useMergeBase)
             $buildAll = Get-BuildAllApps -baseFolder $baseFolder -project $project -modifiedFiles $prModifiedFiles
         }
@@ -169,7 +169,7 @@ try {
                     -baseFolder $baseFolder `
                     -project $project `
                     -baselineWorkflowRunId $baselineWorkflowRunId `
-                    -modifiedFiles $modifiedFiles `
+                    -modifiedFiles $baselineModifiedFiles `
                     -buildArtifactFolder $buildArtifactFolder `
                     -buildMode $buildMode `
                     -projectPath $projectFolder

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
@@ -16,8 +16,9 @@ Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "DetermineProjectsToBuil
 
 $settings = $env:Settings | ConvertFrom-Json
 
+$isPullRequest = Test-IsPullRequest -ghEventName $ENV:GITHUB_EVENT_NAME
 $targetBranch = $env:GITHUB_REF_NAME
-if ($ENV:GITHUB_EVENT_NAME -eq 'pull_request') {
+if ($isPullRequest) {
     $targetBranch = $env:GITHUB_BASE_REF
 }
 
@@ -26,6 +27,7 @@ Write-Host "$($ENV:GITHUB_EVENT_NAME) on $targetBranch"
 $buildAllProjects, $publishSkippedProjects = Get-BuildAllProjectsBasedOnEventAndSettings -ghEventName $ENV:GITHUB_EVENT_NAME -settings $settings
 
 $modifiedFiles = @()
+$prModifiedFiles = @()
 $baselineWorkflowRunId = 0 #default to 0, which means no baseline workflow run ID is set
 $baselineWorkflowSHA = ''
 if(-not $buildAllProjects) {
@@ -40,8 +42,19 @@ if(-not $buildAllProjects) {
     else {
         Write-Host "::group::Get Modified Files"
         try {
+            # Files modified since the baseline build. Used to determine which apps must be (re)built versus reused from the baseline artifacts.
             $modifiedFiles = Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA
-            OutputMessageAndArray -message "Modified files" -arrayOfStrings $modifiedFiles
+            OutputMessageAndArray -message "Modified files (since baseline build)" -arrayOfStrings $modifiedFiles
+            # Files modified by the pull request itself (diffed against its merge-base). Used to decide whether a full build is
+            # required and whether the pull request modifies anything at all, so that unrelated commits merged to the target branch
+            # after the baseline build are not attributed to the pull request.
+            if ($isPullRequest) {
+                $prModifiedFiles = Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA -useMergeBase
+                OutputMessageAndArray -message "Modified files (pull request)" -arrayOfStrings $prModifiedFiles
+            }
+            else {
+                $prModifiedFiles = $modifiedFiles
+            }
         }
         catch {
             OutputWarning -message "Failed to calculate modified files since $baselineWorkflowSHA, the Error was $($_.Exception.Message). Building all projects"
@@ -53,7 +66,9 @@ if(-not $buildAllProjects) {
 
 if (-not $buildAllProjects) {
     Write-Host "::group::Determine Incremental Build"
-    $buildAllProjects = Get-BuildAllProjects -modifiedFiles $modifiedFiles -baseFolder $baseFolder
+    # Whether a full build is required is based on what the pull request itself changed ($prModifiedFiles), not on unrelated
+    # commits merged to the target branch after the baseline build.
+    $buildAllProjects = Get-BuildAllProjects -modifiedFiles $prModifiedFiles -baseFolder $baseFolder
     Write-Host "::endgroup::"
 }
 
@@ -61,7 +76,18 @@ if (-not $buildAllProjects) {
 # buildAllProjects is set to true if we are to build all projects
 # publishSkippedProjects is set to true if we are to publish artifacts for skipped projects (meaning we are still going through the build process for all projects, just not building)
 Write-Host "::group::Get Projects To Build"
-$allProjects, $modifiedProjects, $projectsToBuild, $projectDependencies, $buildOrder = Get-ProjectsToBuild -baseFolder $baseFolder -buildAllProjects ($buildAllProjects -or $publishSkippedProjects) -modifiedFiles $modifiedFiles -maxBuildDepth $maxBuildDepth
+$getProjectsToBuildParams = @{
+    baseFolder = $baseFolder
+    buildAllProjects = ($buildAllProjects -or $publishSkippedProjects)
+    modifiedFiles = $modifiedFiles
+    maxBuildDepth = $maxBuildDepth
+}
+# For pull requests, pass the pull request's own modified files so that a pull request that modifies no project is not built,
+# even if unrelated files changed on the target branch since the baseline build.
+if ($isPullRequest) {
+    $getProjectsToBuildParams['prModifiedFiles'] = $prModifiedFiles
+}
+$allProjects, $modifiedProjects, $projectsToBuild, $projectDependencies, $buildOrder = Get-ProjectsToBuild @getProjectsToBuildParams
 if ($buildAllProjects) {
     $skippedProjects = @()
 }

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.Action.ps1
@@ -26,7 +26,7 @@ if ($isPullRequest) {
 Write-Host "$($ENV:GITHUB_EVENT_NAME) on $targetBranch"
 $buildAllProjects, $publishSkippedProjects = Get-BuildAllProjectsBasedOnEventAndSettings -ghEventName $ENV:GITHUB_EVENT_NAME -settings $settings
 
-$modifiedFiles = @()
+$baselineModifiedFiles = @()
 $prModifiedFiles = @()
 $baselineWorkflowRunId = 0 #default to 0, which means no baseline workflow run ID is set
 $baselineWorkflowSHA = ''
@@ -43,8 +43,8 @@ if(-not $buildAllProjects) {
         Write-Host "::group::Get Modified Files"
         try {
             # Files modified since the baseline build. Used to determine which apps must be (re)built versus reused from the baseline artifacts.
-            $modifiedFiles = Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA
-            OutputMessageAndArray -message "Modified files (since baseline build)" -arrayOfStrings $modifiedFiles
+            $baselineModifiedFiles = Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA
+            OutputMessageAndArray -message "Modified files (since baseline build)" -arrayOfStrings $baselineModifiedFiles
             # Files modified by the pull request itself (diffed against its merge-base). Used to decide whether a full build is
             # required and whether the pull request modifies anything at all, so that unrelated commits merged to the target branch
             # after the baseline build are not attributed to the pull request.
@@ -53,7 +53,7 @@ if(-not $buildAllProjects) {
                 OutputMessageAndArray -message "Modified files (pull request)" -arrayOfStrings $prModifiedFiles
             }
             else {
-                $prModifiedFiles = $modifiedFiles
+                $prModifiedFiles = $baselineModifiedFiles
             }
         }
         catch {
@@ -79,7 +79,7 @@ Write-Host "::group::Get Projects To Build"
 $getProjectsToBuildParams = @{
     baseFolder = $baseFolder
     buildAllProjects = ($buildAllProjects -or $publishSkippedProjects)
-    modifiedFiles = $modifiedFiles
+    baselineModifiedFiles = $baselineModifiedFiles
     maxBuildDepth = $maxBuildDepth
 }
 # For pull requests, pass the pull request's own modified files so that a pull request that modifies no project is not built,

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -7,7 +7,9 @@
 function Get-ModifiedFiles {
     param(
         [Parameter(HelpMessage = "The baseline SHA", Mandatory = $true)]
-        [string] $baselineSHA
+        [string] $baselineSHA,
+        [Parameter(HelpMessage = "For pull requests, diff against the merge-base of the pull request instead of the baseline SHA, so only the files the pull request itself changed are returned", Mandatory = $false)]
+        [switch] $useMergeBase
     )
 
     Push-Location $ENV:GITHUB_WORKSPACE
@@ -17,7 +19,15 @@ function Get-ModifiedFiles {
             $headSHA = $ghEvent.pull_request.head.sha
             Write-Host "Using head SHA $headSHA from pull request"
             Invoke-CommandWithRetry -ScriptBlock { RunAndCheck git fetch origin $headSHA | Out-Host }
-            if ($baselineSHA) {
+            if ($useMergeBase) {
+                # Diff against the pull request's merge-base so that only what the pull request itself changed is returned.
+                # This avoids attributing commits merged to the target branch after the baseline build to the pull request.
+                $prBaseSHA = $ghEvent.pull_request.base.sha
+                Invoke-CommandWithRetry -ScriptBlock { RunAndCheck git fetch origin $prBaseSHA | Out-Host }
+                $baselineSHA = (RunAndCheck git merge-base $prBaseSHA $headSHA).Trim()
+                Write-Host "This is a pull request, using merge-base SHA $baselineSHA (base $prBaseSHA, head $headSHA)"
+            }
+            elseif ($baselineSHA) {
                 Write-Host "This is a pull request, but baseline SHA was specified to $baselineSHA"
             }
             else {
@@ -156,6 +166,8 @@ function Get-ProjectsToBuild {
         [bool] $buildAllProjects = $true,
         [Parameter(HelpMessage = "An array of changed files paths, used to filter the projects to build", Mandatory = $false)]
         [string[]] $modifiedFiles = @(),
+        [Parameter(HelpMessage = "An array of files changed by the pull request itself (diffed against its merge-base). When provided and the pull request modifies no project, nothing is built.", Mandatory = $false)]
+        [string[]] $prModifiedFiles = @(),
         [Parameter(HelpMessage = "The maximum depth to build the dependency tree", Mandatory = $false)]
         [int] $maxBuildDepth = 0
     )
@@ -187,6 +199,19 @@ function Get-ProjectsToBuild {
                                         Where-Object { ShouldBuildProject -baseFolder $baseFolder -project $_ -modifiedFiles $modifiedFilesFullPaths } |
                                         ForEach-Object { $_; if ($projectBuildInfo.AdditionalProjectsToBuild.Keys -contains $_) { $projectBuildInfo.AdditionalProjectsToBuild."$_" } } |
                                         Select-Object -Unique)
+
+                # $modifiedFiles is diffed against the baseline (last successful) build, which may include commits merged to the
+                # target branch after that build. For pull requests, $prModifiedFiles reflects only what the pull request itself
+                # changed (diffed against its merge-base). If the pull request does not modify any project, nothing needs to be built,
+                # even if unrelated files changed on the target branch since the baseline build.
+                if ($PSBoundParameters.ContainsKey('prModifiedFiles') -and $modifiedProjects) {
+                    $prModifiedFilesFullPaths = @($prModifiedFiles | ForEach-Object { return Join-Path $baseFolder $_ })
+                    $prModifiedProjects = @($projects | Where-Object { ShouldBuildProject -baseFolder $baseFolder -project $_ -modifiedFiles $prModifiedFilesFullPaths })
+                    if (-not $prModifiedProjects) {
+                        Write-Host "The pull request does not modify any project (based on the merge-base diff). Nothing to build."
+                        $modifiedProjects = @()
+                    }
+                }
             }
 
             if($buildAllProjects) {
@@ -237,6 +262,18 @@ function Get-ProjectsToBuild {
 
 <#
 .Synopsis
+    Determines whether a GitHub event is a pull request event.
+#>
+function Test-IsPullRequest {
+    Param(
+        [string] $ghEventName
+    )
+
+    return ($ghEventName -in @('pull_request', 'pull_request_target'))
+}
+
+<#
+.Synopsis
     Determines whether a full build is required and whether to publish artifacts from skipped projects based on the event and settings.
 .Outputs
     A boolean indicating whether a full build is required and a boolean indicating whether to publish artifacts from skipped projects.
@@ -257,7 +294,7 @@ function Get-BuildAllProjectsBasedOnEventAndSettings {
     )
     $buildAllProjects = $true
     $publishSkippedProjects = $true
-    if ($ghEventName -eq 'pull_request' -or $ghEventName -eq 'pull_request_target') {
+    if (Test-IsPullRequest -ghEventName $ghEventName) {
         # DEPRECATION: REMOVE AFTER October 1st 2025 --->
         if ($settings.PSObject.Properties.Name -eq 'alwaysBuildAllProjects' -and $settings.alwaysBuildAllProjects) {
             $buildAllProjects = $settings.alwaysBuildAllProjects

--- a/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
+++ b/Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1
@@ -164,8 +164,9 @@ function Get-ProjectsToBuild {
         $baseFolder,
         [Parameter(HelpMessage = "Whether a full build is required", Mandatory = $false)]
         [bool] $buildAllProjects = $true,
-        [Parameter(HelpMessage = "An array of changed files paths, used to filter the projects to build", Mandatory = $false)]
-        [string[]] $modifiedFiles = @(),
+        [Parameter(HelpMessage = "An array of files changed since the baseline build, used to filter the projects to build", Mandatory = $false)]
+        [Alias('modifiedFiles')]
+        [string[]] $baselineModifiedFiles = @(),
         [Parameter(HelpMessage = "An array of files changed by the pull request itself (diffed against its merge-base). When provided and the pull request modifies no project, nothing is built.", Mandatory = $false)]
         [string[]] $prModifiedFiles = @(),
         [Parameter(HelpMessage = "The maximum depth to build the dependency tree", Mandatory = $false)]
@@ -190,18 +191,18 @@ function Get-ProjectsToBuild {
             # Calculate the full projects order
             $projectBuildInfo = AnalyzeProjectDependencies -baseFolder $baseFolder -projects $projects
 
-            if ($modifiedFiles) {
-                Write-Host "Calculating modified projects based on the modified files"
+            if ($baselineModifiedFiles) {
+                Write-Host "Calculating modified projects based on files changed since the baseline build"
 
                 #Include the base folder in the modified files
-                $modifiedFilesFullPaths = @($modifiedFiles | ForEach-Object { return Join-Path $baseFolder $_ })
+                $baselineModifiedFilesFullPaths = @($baselineModifiedFiles | ForEach-Object { return Join-Path $baseFolder $_ })
                 $modifiedProjects = @($projects |
-                                        Where-Object { ShouldBuildProject -baseFolder $baseFolder -project $_ -modifiedFiles $modifiedFilesFullPaths } |
+                                        Where-Object { ShouldBuildProject -baseFolder $baseFolder -project $_ -modifiedFiles $baselineModifiedFilesFullPaths } |
                                         ForEach-Object { $_; if ($projectBuildInfo.AdditionalProjectsToBuild.Keys -contains $_) { $projectBuildInfo.AdditionalProjectsToBuild."$_" } } |
                                         Select-Object -Unique)
 
-                # $modifiedFiles is diffed against the baseline (last successful) build, which may include commits merged to the
-                # target branch after that build. For pull requests, $prModifiedFiles reflects only what the pull request itself
+                # $baselineModifiedFiles may include commits merged to the target branch after the baseline build.
+                # For pull requests, $prModifiedFiles reflects only what the pull request itself
                 # changed (diffed against its merge-base). If the pull request does not modify any project, nothing needs to be built,
                 # even if unrelated files changed on the target branch since the baseline build.
                 if ($PSBoundParameters.ContainsKey('prModifiedFiles') -and $modifiedProjects) {

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -150,8 +150,8 @@ try {
     if ((-not $settings.workspaceCompilation.enabled) -and $baselineWorkflowSHA -and $baselineWorkflowRunId -ne '0' -and $settings.incrementalBuilds.mode -eq 'modifiedApps') {
         # Incremental builds are enabled and we are only building modified apps
         try {
-            $modifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA)
-            OutputMessageAndArray -message "Modified files (since baseline build)" -arrayOfStrings $modifiedFiles
+            $baselineModifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA)
+            OutputMessageAndArray -message "Modified files (since baseline build)" -arrayOfStrings $baselineModifiedFiles
             $prModifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA -useMergeBase)
             $buildAll = Get-BuildAllApps -baseFolder $baseFolder -project $project -modifiedFiles $prModifiedFiles
         }
@@ -168,7 +168,7 @@ try {
                 -baseFolder $baseFolder `
                 -project $project `
                 -baselineWorkflowRunId $baselineWorkflowRunId `
-                -modifiedFiles $modifiedFiles `
+                -modifiedFiles $baselineModifiedFiles `
                 -buildArtifactFolder $buildArtifactFolder `
                 -buildMode $buildMode `
                 -projectPath $projectPath

--- a/Actions/RunPipeline/RunPipeline.ps1
+++ b/Actions/RunPipeline/RunPipeline.ps1
@@ -151,8 +151,9 @@ try {
         # Incremental builds are enabled and we are only building modified apps
         try {
             $modifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA)
-            OutputMessageAndArray -message "Modified files" -arrayOfStrings $modifiedFiles
-            $buildAll = Get-BuildAllApps -baseFolder $baseFolder -project $project -modifiedFiles $modifiedFiles
+            OutputMessageAndArray -message "Modified files (since baseline build)" -arrayOfStrings $modifiedFiles
+            $prModifiedFiles = @(Get-ModifiedFiles -baselineSHA $baselineWorkflowSHA -useMergeBase)
+            $buildAll = Get-BuildAllApps -baseFolder $baseFolder -project $project -modifiedFiles $prModifiedFiles
         }
         catch {
             OutputNotice -message "Failed to calculate modified files since $baselineWorkflowSHA, building all apps"

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,9 @@
+### Incremental builds on pull requests no longer over-build due to baseline drift
+
+When incremental builds are enabled, the set of modified files used to decide whether a full build is required (`fullBuildPatterns`) and whether any project/app needs building was diffed against the last successful build of the target branch. On a busy branch, commits merged after that baseline build were attributed to the pull request, so an unrelated change (for example under a `fullBuildPatterns` path) could escalate a pull request that changed no AL code into a full build.
+
+The decision about what a pull request changed is now evaluated against the pull request's merge-base (only what the pull request itself changed). If a pull request modifies neither a project nor a full-build pattern, nothing is built. Artifact reuse still uses the last successful build as the baseline, so dependencies that changed on the target branch since that build are still rebuilt rather than reused.
+
 ### Expanded AL-Go telemetry dashboard
 
 The starter Azure Data Explorer dashboard now includes dedicated views for workflow reliability, run exploration, test quality, workflow duration, runner efficiency, and AL-Go maintenance. It also provides repository, workflow, branch, and repository-type filtering, clearer empty states, and repository-level runtime supportability information.

--- a/Tests/DetermineProjectsToBuild.Test.ps1
+++ b/Tests/DetermineProjectsToBuild.Test.ps1
@@ -194,6 +194,48 @@ Describe "Get-ProjectsToBuild" {
         $buildOrder[0].buildDimensions[0].project | Should -BeExactly "Project1"
     }
 
+    It 'does not build any project when the pull request modifies no project, even if files changed on the target branch since the baseline build (merge-base gate)' {
+        # Setup project structure
+        $appJson = @{ id = '83fb8305-4079-415d-a25d-8132f0436fd1'; name = 'My app'; publisher = 'Contoso'; version = '1.0.0.0' }
+        New-Item -Path "$baseFolder/Project1/.AL-Go/settings.json" -type File -Force
+        New-Item -Path "$baseFolder/Project1/app/app.json" -Value (ConvertTo-Json $appJson) -type File -Force
+        New-Item -Path "$baseFolder/Project2/.AL-Go/settings.json" -type File -Force
+
+        $alGoSettings = @{ fullBuildPatterns = @(); projects = @(); powerPlatformSolutionFolder = ''; useProjectDependencies = $false }
+        $env:Settings = ConvertTo-Json $alGoSettings -Depth 99 -Compress
+
+        # The baseline diff attributes a change in Project1 to the run (e.g. a commit merged to the target branch after the baseline build)...
+        $modifiedFiles = @('Project1/.AL-Go/settings.json')
+        # ...but the pull request itself only changed a non-project file.
+        $prModifiedFiles = @('README.md')
+        $allProjects, $modifiedProjects, $projectsToBuild, $projectDependencies, $buildOrder = Get-ProjectsToBuild -baseFolder $baseFolder -modifiedFiles $modifiedFiles -prModifiedFiles $prModifiedFiles -buildAllProjects $false
+
+        $allProjects | Should -BeExactly @("Project1", "Project2")
+        $modifiedProjects | Should -BeExactly @()
+        $projectsToBuild | Should -BeExactly @()
+    }
+
+    It 'keeps the baseline-based projects to build when the pull request modifies at least one project (merge-base gate passes)' {
+        # Setup project structure
+        $appJson = @{ id = '83fb8305-4079-415d-a25d-8132f0436fd1'; name = 'My app'; publisher = 'Contoso'; version = '1.0.0.0' }
+        New-Item -Path "$baseFolder/Project1/.AL-Go/settings.json" -type File -Force
+        New-Item -Path "$baseFolder/Project1/app/app.json" -Value (ConvertTo-Json $appJson) -type File -Force
+        New-Item -Path "$baseFolder/Project2/.AL-Go/settings.json" -type File -Force
+
+        $alGoSettings = @{ fullBuildPatterns = @(); projects = @(); powerPlatformSolutionFolder = ''; useProjectDependencies = $false }
+        $env:Settings = ConvertTo-Json $alGoSettings -Depth 99 -Compress
+
+        # The baseline diff sees changes in both projects (Project2 changed on the target branch after the baseline build)...
+        $modifiedFiles = @('Project1/.AL-Go/settings.json', 'Project2/.AL-Go/settings.json')
+        # ...and the pull request itself modifies Project1, so the gate passes and the baseline-based set is kept
+        # (this ensures dependencies changed since the baseline build are still rebuilt).
+        $prModifiedFiles = @('Project1/.AL-Go/settings.json')
+        $allProjects, $modifiedProjects, $projectsToBuild, $projectDependencies, $buildOrder = Get-ProjectsToBuild -baseFolder $baseFolder -modifiedFiles $modifiedFiles -prModifiedFiles $prModifiedFiles -buildAllProjects $false
+
+        $modifiedProjects | Should -BeExactly @("Project1", "Project2")
+        $projectsToBuild | Should -BeExactly @("Project1", "Project2")
+    }
+
     It 'loads correct projects, based on the modified files: multiple modified files in Project1 and Project2' {
         # Setup project structure
         $appJson = @{ id = '83fb8305-4079-415d-a25d-8132f0436fd1'; name = 'My app'; publisher = 'Contoso'; version = '1.0.0.0' }
@@ -1168,6 +1210,28 @@ Describe "Get-ProjectsToBuild" {
 
     AfterEach {
         Remove-Item $baseFolder -Force -Recurse
+    }
+}
+
+Describe "Test-IsPullRequest" {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot "../Actions/DetermineProjectsToBuild/DetermineProjectsToBuild.psm1" -Resolve) -DisableNameChecking
+    }
+
+    It "returns true for <eventName>" -ForEach @(
+        @{ eventName = 'pull_request' }
+        @{ eventName = 'pull_request_target' }
+    ) {
+        Test-IsPullRequest -ghEventName $eventName | Should -BeTrue
+    }
+
+    It "returns false for <eventName>" -ForEach @(
+        @{ eventName = 'push' }
+        @{ eventName = 'schedule' }
+        @{ eventName = 'workflow_dispatch' }
+        @{ eventName = 'merge_group' }
+    ) {
+        Test-IsPullRequest -ghEventName $eventName | Should -BeFalse
     }
 }
 

--- a/Tests/DetermineProjectsToBuild.Test.ps1
+++ b/Tests/DetermineProjectsToBuild.Test.ps1
@@ -205,10 +205,10 @@ Describe "Get-ProjectsToBuild" {
         $env:Settings = ConvertTo-Json $alGoSettings -Depth 99 -Compress
 
         # The baseline diff attributes a change in Project1 to the run (e.g. a commit merged to the target branch after the baseline build)...
-        $modifiedFiles = @('Project1/.AL-Go/settings.json')
+        $baselineModifiedFiles = @('Project1/.AL-Go/settings.json')
         # ...but the pull request itself only changed a non-project file.
         $prModifiedFiles = @('README.md')
-        $allProjects, $modifiedProjects, $projectsToBuild, $projectDependencies, $buildOrder = Get-ProjectsToBuild -baseFolder $baseFolder -modifiedFiles $modifiedFiles -prModifiedFiles $prModifiedFiles -buildAllProjects $false
+        $allProjects, $modifiedProjects, $projectsToBuild, $projectDependencies, $buildOrder = Get-ProjectsToBuild -baseFolder $baseFolder -baselineModifiedFiles $baselineModifiedFiles -prModifiedFiles $prModifiedFiles -buildAllProjects $false
 
         $allProjects | Should -BeExactly @("Project1", "Project2")
         $modifiedProjects | Should -BeExactly @()
@@ -226,11 +226,11 @@ Describe "Get-ProjectsToBuild" {
         $env:Settings = ConvertTo-Json $alGoSettings -Depth 99 -Compress
 
         # The baseline diff sees changes in both projects (Project2 changed on the target branch after the baseline build)...
-        $modifiedFiles = @('Project1/.AL-Go/settings.json', 'Project2/.AL-Go/settings.json')
+        $baselineModifiedFiles = @('Project1/.AL-Go/settings.json', 'Project2/.AL-Go/settings.json')
         # ...and the pull request itself modifies Project1, so the gate passes and the baseline-based set is kept
         # (this ensures dependencies changed since the baseline build are still rebuilt).
         $prModifiedFiles = @('Project1/.AL-Go/settings.json')
-        $allProjects, $modifiedProjects, $projectsToBuild, $projectDependencies, $buildOrder = Get-ProjectsToBuild -baseFolder $baseFolder -modifiedFiles $modifiedFiles -prModifiedFiles $prModifiedFiles -buildAllProjects $false
+        $allProjects, $modifiedProjects, $projectsToBuild, $projectDependencies, $buildOrder = Get-ProjectsToBuild -baseFolder $baseFolder -baselineModifiedFiles $baselineModifiedFiles -prModifiedFiles $prModifiedFiles -buildAllProjects $false
 
         $modifiedProjects | Should -BeExactly @("Project1", "Project2")
         $projectsToBuild | Should -BeExactly @("Project1", "Project2")


### PR DESCRIPTION
### ❔What, Why & How

Incremental pull request builds currently use the last successful target-branch build for both change detection and artifact reuse. On busy branches, this attributes changes merged after that baseline to the pull request, potentially triggering `fullBuildPatterns` and building everything for an otherwise unrelated PR.

This separates those decisions:

- The pull request merge-base diff determines whether the PR modifies a project and whether `fullBuildPatterns` requires all projects or apps to be built.
- The successful workflow baseline diff continues to determine which artifacts can safely be reused, ensuring dependencies changed since the baseline are rebuilt.
- The app-level behavior is applied to both standard and workspace compilation paths.

A shared `Test-IsPullRequest` helper is used for PR event handling.

Related work item: [AB#647482](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/647482/)

Related to issue: N/A

### ✅ Checklist

- [x] Add tests (E2E, unit tests)
- [x] Update RELEASENOTES.md
- [ ] Update documentation (e.g. for new settings or scenarios) - N/A, no settings or user configuration changed
- [ ] Add telemetry - N/A, existing incremental-build telemetry remains applicable

<!-- Include more checklist entries, if needed -->